### PR TITLE
feat: spec 002 P1 (WS-A) — gap event type in the design ledger

### DIFF
--- a/knowledge/recall-mind.md
+++ b/knowledge/recall-mind.md
@@ -29,7 +29,22 @@ NON-DETERMINISTIC  recall/ — embeddings + vector index + ranking
   it comes back identical. Never treat the index as a second source of truth.
 - Learned knowledge flows back into the ledger **only** through
   `ui memory record insight --refs <ids>` — provenance is mandatory.
+- A gap in the knowledge core is filed, not fixed in place:
+  `ui memory record gap --data '{"text":"…","target":"<file>[#<section>]"}'`. A `gap` is the
+  raw material of the librarian loop — designer/curator/figma-hand never edit `knowledge/`
+  themselves; they record a gap and the librarian graduates it through a PR. `refs` is
+  optional (unlike `insight`), but pointing at the `taste_verdict`/`duel_result` that
+  exposed the gap is encouraged.
 - The `ui` binary never imports anything from `recall/` (a test enforces this).
+
+### Which channel: gap vs. GitHub issue
+
+A `gap` event is for when the **knowledge core** cannot express something — a rubric axis,
+a persona, a recipe, a stale benchmark. A **GitHub issue** is for when **code or a check** is
+missing — a linter blind spot, a CLI feature, a broken gate. A hybrid case (the knowledge is
+absent *and* a check should enforce it) is filed as a `gap`; the librarian then proposes the
+issue in the PR body. When in doubt, file the gap — a gap is cheap to record and the librarian
+routes it.
 
 ## Setup
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -50,7 +50,9 @@ record flags:
 
 Event types (v1): variant_generated, rendition_created, taste_verdict, user_pick,
   vibe_edit, manual_edit, token_change, component_registered, harvested, duel_result,
-  insight (an 'insight' event requires --refs for provenance).
+  insight (an 'insight' event requires --refs for provenance),
+  gap (a knowledge-core gap for the librarian to graduate; refs optional).
+  Example: ui memory record gap --data '{"text":"…","target":"taste-rubric.md#motion"}'
 
 Other flags:
   --now <iso>         compile/context/consolidate: decay + compiledAt clock (deterministic when fixed)

--- a/src/core/memory-events.ts
+++ b/src/core/memory-events.ts
@@ -28,6 +28,7 @@ export const EVENT_TYPES = [
   "harvested",
   "duel_result",
   "insight",
+  "gap",
 ] as const;
 export type EventType = (typeof EVENT_TYPES)[number];
 
@@ -44,6 +45,11 @@ const REQUIRED_DATA: Readonly<Record<EventType, readonly string[]>> = {
   harvested: ["source"],
   duel_result: ["benchmark", "traits"],
   insight: ["text"],
+  // A knowledge gap the librarian graduates: `text` describes the gap, `target`
+  // names where it belongs (`<file>[#<section>]`, e.g. `taste-rubric.md#motion`).
+  // `data.kind` is optional and unenforced (rubric-gap | persona-gap | recipe-gap |
+  // benchmark-stale | guardrail-lesson). Unlike `insight`, `gap` needs no refs.
+  gap: ["text", "target"],
 };
 
 export interface MemoryArtifact {

--- a/tests/cmd-memory.test.ts
+++ b/tests/cmd-memory.test.ts
@@ -78,6 +78,19 @@ describe("ui memory record + compile", () => {
     expect(JSON.parse(record(["frobnicate", "--data", "{}", "--json"]).out).error.code).toBe("BAD_EVENT_TYPE");
   });
 
+  it("records a gap event (no refs needed) → envelope { id, type: 'gap' }", () => {
+    const r = record(["gap", "--data", '{"text":"motion has no bounce guidance","target":"taste-rubric.md#motion"}', "--json"]);
+    expect(r.code, r.out).toBe(0);
+    const data = JSON.parse(r.out).data;
+    expect(data.id).toBe("e1");
+    expect(data.type).toBe("gap");
+    expect(data.eventCount).toBe(1);
+  });
+
+  it("rejects a gap missing target with BAD_EVENT", () => {
+    expect(JSON.parse(record(["gap", "--data", '{"text":"x"}', "--json"]).out).error.code).toBe("BAD_EVENT");
+  });
+
   it("compile on an empty project → NO_MEMORY", () => {
     const r = capture(["memory", "compile", "--dir", proj, "--json"]);
     expect(r.code).toBe(1);

--- a/tests/memory-events.test.ts
+++ b/tests/memory-events.test.ts
@@ -33,11 +33,25 @@ describe("memory-events — validateEvent", () => {
       component_registered: { name: "Card/Elevated" },
       harvested: { source: "https://example.com" },
       duel_result: { benchmark: "linear", traits: [] },
+      gap: { text: "motion axis has no bounce guidance", target: "taste-rubric.md#motion" },
     };
     for (const [type, data] of Object.entries(happy)) {
       expect(codeOf(() => validateEvent(type, data, undefined)), type).toBeNull();
     }
     expect(codeOf(() => validateEvent("insight", { text: "learned x" }, ["e1"]))).toBeNull();
+  });
+
+  it("records a gap event with text+target", () => {
+    expect(codeOf(() => validateEvent("gap", { text: "no bounce guidance", target: "taste-rubric.md#motion" }, undefined))).toBeNull();
+  });
+
+  it("rejects gap missing target with BAD_EVENT", () => {
+    expect(codeOf(() => validateEvent("gap", { text: "no bounce guidance" }, undefined))).toBe("BAD_EVENT");
+  });
+
+  it("gap does not require refs", () => {
+    expect(codeOf(() => validateEvent("gap", { text: "x", target: "personas" }, undefined))).toBeNull();
+    expect(codeOf(() => validateEvent("gap", { text: "x", target: "personas" }, []))).toBeNull();
   });
 
   it("rejects an unknown type with BAD_EVENT_TYPE", () => {
@@ -55,8 +69,9 @@ describe("memory-events — validateEvent", () => {
     expect(codeOf(() => validateEvent("insight", { text: "x" }, ["e1"]))).toBeNull();
   });
 
-  it("EVENT_TYPES has 11 members; isEventType/isMedium guard", () => {
-    expect(EVENT_TYPES.length).toBe(11);
+  it("EVENT_TYPES has 12 members; isEventType/isMedium guard", () => {
+    expect(EVENT_TYPES.length).toBe(12);
+    expect(isEventType("gap")).toBe(true);
     expect(isEventType("user_pick")).toBe(true);
     expect(isEventType("nope")).toBe(false);
     expect(isMedium("html")).toBe(true);


### PR DESCRIPTION
## Spec 002 — Studio librarian · Phase P1 (WS-A only)

Opens the **gap channel**: a `gap` event in the design ledger. designer/curator/figma-hand
never edit `knowledge/` themselves — they record a gap; the librarian (later phases) graduates
it through a PR.

### Changes
- **`src/core/memory-events.ts`** — `EVENT_TYPES` += `"gap"` (11→12, `v:1` unchanged);
  `REQUIRED_DATA.gap = ["text","target"]`. `data.kind` optional & unenforced
  (`rubric-gap | persona-gap | recipe-gap | benchmark-stale | guardrail-lesson`);
  `refs` **optional** for gap (unlike `insight`). `serializeEvent`/`nextEventId` untouched.
- **`src/commands/memory.ts`** — help text lists `gap` + a `--data` example.
- **`knowledge/recall-mind.md`** — gap channel note + WHY + **gap-vs-issue boundary**
  (decision #9): gap = knowledge core can't express something; GitHub issue = code/check
  missing; hybrid → file gap, librarian proposes the issue in its PR body.
- **tests** — core `validateEvent` (happy, missing-target→BAD_EVENT, no-refs-needed) +
  CLI `record gap` envelope `{id,type:"gap"}` and missing-target rejection.

### Verify
- 4 gates green: `typecheck` · `lint` · `build` · `test` (116 files, 1687 tests pass).
- Acceptance WS-A — real run on a tmp project (`EASE_DESIGN_HOME` tmp):
  `ui memory record gap` writes a valid event, `eventCount` grows, graph recompiles;
  missing `target` → `BAD_EVENT` exit 1.

### Executor decisions (plan marked "executor xác định")
1. **Docs file (A3)** = `knowledge/recall-mind.md` — no knowledge doc enumerates the event
   types; recall-mind.md is the ledger/memory knowledge doc and already owns a
   "boundary (do not cross it)" section, the natural home for the gap channel + its WHY.
   Content written in **English** to match the file (Art VIII: knowledge in English).
2. **Help text (A2)** lives in `src/commands/memory.ts` (`MEMORY_HELP`), **not**
   `memory-record-impl.ts` as plan.md §A2 states — mechanical deviation, adjusted to the
   real location.

Scope: WS-A only. WS-C/E/B/D are later phases.