### PR TITLE
spec 003 P1 — tap-target-undersized + ai-cliche-gradient taste lints

### DIFF
--- a/knowledge/page-structures.md
+++ b/knowledge/page-structures.md
@@ -125,12 +125,18 @@ page *genuinely* needs nothing else, and reach for a deliberate archetype otherw
 - **Hero:** the core (headline + lede + primary CTA) must fit the 1280×800 fold. A hero
   never builds *fake* chrome to look substantial — no drawn browser bar, phone frame, or
   IDE window. Use a real screenshot or drop the chrome entirely.
+- **The AI-glow gradient:** a large indigo/violet/magenta background gradient (radial glow
+  behind the hero, `from-indigo-500 … to-purple-600` full-bleed) is the loudest
+  machine-default surface tell. Reach for it only when the brand *is* that hue; otherwise
+  recolor to the brand or drop the gradient for a flat/tinted surface.
 
 **What the machine already catches (do not spend judgment re-inspecting these):**
 `taste-lint` owns `italic-display-heading`, `uppercase-tight-line-height`,
-`overshoot-easing`, `focus-ring-animates-in`, `z-index-inflation`; `validate-layout` owns
-`css-100vw-width` and `root-overflow-x-hidden`. If a tell is on that list, the linter has
-it — spend your attention on the tells that are not.
+`overshoot-easing`, `focus-ring-animates-in`, `z-index-inflation`, `ai-cliche-gradient`
+(large violet-band background gradient), and `tap-target-undersized` (interactive control
+under the 44px touch minimum); `validate-layout` owns `css-100vw-width` and
+`root-overflow-x-hidden`. If a tell is on that list, the linter has it — spend your
+attention on the tells that are not.
 
 ## §6 When to read this file
 

--- a/knowledge/taste-rubric.md
+++ b/knowledge/taste-rubric.md
@@ -115,7 +115,10 @@ reads correctly. Spacing steps should progress on a recognizable scale (e.g. 4, 
 
 **Anti-patterns:** off-grid values (`13px`, `27px`); inconsistent gaps between sibling
 elements; padding that doesn't scale with element role; cramped touch targets (interactive
-hit area below ~44px on touch surfaces).
+hit area below ~44px on touch surfaces). *Machine floor:* `taste-lint`'s
+`tap-target-undersized` (warning) flags an interactive control with a fixed height below
+44px, a min-height floor below 44px with no compensating padding, or an icon-only control
+with too little padding — the WCAG 2.5.5 / HIG / Material touch minimum.
 
 ### Scoring 0–10
 
@@ -238,7 +241,12 @@ never designed.
 
 **Anti-patterns:** a unique shadow value on every element; pure-black harsh shadows;
 shadow and heavy border stacked on the same surface; glass over busy content that kills
-text contrast; elevation that doesn't correlate with actual stacking order; z-index 9999.
+text contrast; elevation that doesn't correlate with actual stacking order; z-index 9999;
+a large background gradient in the indigo→magenta band (the machine-default "AI glow" —
+finance/enterprise surfaces read it as cheap). *Machine floor:* `taste-lint`'s
+`ai-cliche-gradient` (error) converts each gradient stop to OKLCH and flags a large-surface
+linear/radial/conic gradient dominated by stops in the ~270–330° hue band; recolor to the
+brand hue (or declare that hue as an in-doc brand token to exempt it).
 
 ### Scoring 0–10
 

--- a/src/commands/taste-lint.ts
+++ b/src/commands/taste-lint.ts
@@ -6,8 +6,9 @@
  * binary floor under the model's self-scored critique gate — a variant that
  * trips an error here breaks a rubric rule the model cannot talk past.
  *
- * Exit code policy (mirrors validate-layout's D4): exit 1 iff any finding. All
- * taste findings are error-severity (definite rubric violations, not smells).
+ * Exit code policy (mirrors validate-layout's D4): exit 1 iff any error-severity
+ * finding. Most taste findings are errors (definite rubric violations); a few
+ * craft lints are warnings (smells that surface but never fail the build).
  * No subcommands — hasSubcommands: false.
  */
 import { readFileSync } from "node:fs";
@@ -29,7 +30,9 @@ Options:
   --json        Emit a JSON envelope instead of human-readable output
   -h, --help    Show this help
 
-Checks (the machine-verifiable subset of knowledge/taste-rubric.md; all error-severity):
+Checks (the machine-verifiable subset of knowledge/taste-rubric.md; error unless noted):
+  tap-target-undersized      Spacing        interactive control below the 44px touch target (warning)
+  ai-cliche-gradient         Depth/Surface  large indigo/violet/magenta "AI glow" background gradient
   tiny-body-text             Typography     font-size <= 13px (rubric: body never below 16px)
   italic-display-heading     Typography     italic heading/display type (a generated-UI tell)
   uppercase-tight-line-height Typography    all-caps text with line-height below 1.0
@@ -49,8 +52,8 @@ Subjective axis judgment (is the composition authored? the scale on one ratio?)
 stays with the model's critique. This command only catches unambiguous breaches.
 
 Exit codes:
-  0  No violations
-  1  One or more violations, or user/file error
+  0  No error-severity violations (warnings may still be reported)
+  1  One or more error-severity violations, or user/file error
 
 Error codes:
   BAD_ARG        Missing <file.html> argument or unexpected extra positionals
@@ -109,8 +112,9 @@ function loadTokenHexes(path: string): Set<string> | undefined {
 function formatReport(
   filePath: string,
   errorCount: number,
+  warningCount: number,
   axesAffected: string[],
-  findings: Array<{ checkId: string; axis: string; message: string; line?: number }>,
+  findings: Array<{ checkId: string; axis: string; severity: string; message: string; line?: number }>,
 ): string {
   const lines: string[] = [];
   lines.push(`taste-lint: ${filePath}`);
@@ -120,13 +124,15 @@ function formatReport(
   } else {
     for (const f of findings) {
       const loc = f.line !== undefined ? `:${f.line}` : "";
-      lines.push(`  [${f.axis}] ${f.checkId}${loc}: ${f.message}`);
+      lines.push(`  [${f.axis}] ${f.checkId} (${f.severity})${loc}: ${f.message}`);
     }
   }
 
   lines.push("");
   const axes = axesAffected.length > 0 ? ` (axes: ${axesAffected.join(", ")})` : "";
-  lines.push(`${errorCount} violation(s)${axes}`);
+  const total = errorCount + warningCount;
+  const split = total > 0 ? ` (${errorCount} error, ${warningCount} warning)` : "";
+  lines.push(`${total} violation(s)${split}${axes}`);
   return lines.join("\n") + "\n";
 }
 
@@ -173,22 +179,22 @@ export const tasteLintCommand = {
       typeof tokensFlag === "string" ? loadTokenHexes(tokensFlag) : undefined;
 
     // 4. Run the linter (pure transform).
-    const { findings, errorCount, axesAffected } = lintTaste(raw, { knownHexes });
+    const { findings, errorCount, warningCount, axesAffected } = lintTaste(raw, { knownHexes });
 
-    // 5. Exit 1 iff any violation (all findings are error-severity).
+    // 5. Exit 1 iff any error-severity violation; warnings never fail the build.
     const exitCode = errorCount > 0 ? 1 : 0;
 
     // 6. Shape output.
     if (useJson) {
       return okJsonWithExit(
         CMD,
-        { file: filePath, errorCount, axesAffected, findings },
+        { file: filePath, errorCount, warningCount, axesAffected, findings },
         exitCode,
       );
     }
     return {
       exitCode,
-      stdout: formatReport(filePath, errorCount, axesAffected, findings),
+      stdout: formatReport(filePath, errorCount, warningCount, axesAffected, findings),
     };
   },
 };

--- a/src/core/taste-checks-gradient.ts
+++ b/src/core/taste-checks-gradient.ts
@@ -1,0 +1,153 @@
+/**
+ * ai-cliche-gradient (Depth/Surface axis, ERROR) — the loudest machine-default
+ * "AI glow" tell: a large background linear/radial/conic gradient whose color
+ * stops sit in the indigo→magenta hue band (~270–330° OKLCH). Finance/enterprise
+ * surfaces read it as cheap, untrustworthy default taste.
+ *
+ * Detection reuses the project's OKLCH color math (color-convert.ts) — each hex/
+ * rgb stop is converted to an OKLCH hue and tested against the band. Named
+ * Tailwind gradient utilities (`from-indigo-500 … to-purple-600`) are classified
+ * by name since no hex is present. Only LARGE surfaces are flagged (hero, section,
+ * body, full-bleed / inset overlays) — small accents (buttons, chips, avatars) are
+ * left alone. When the document itself declares a brand/accent token in the same
+ * band, the gradient is treated as intentional and the whole check is skipped.
+ *
+ * Limitation: brand exemption reads only in-document custom properties — an
+ * external design-soul / DS file that declares a violet brand is not visible to a
+ * single-file static check, so a genuinely on-brand violet may still flag; recolor
+ * or declare the hue in-doc to exempt.
+ *
+ * Pure string/regex + color math — no DOM, no network.
+ */
+import type { TasteFinding } from "./taste-lint.js";
+import { hexToOKLCH } from "./color-convert.js";
+import { cssRules, cssRegions, lineOf } from "./taste-checks-shared.js";
+
+const CHECK_ID = "ai-cliche-gradient";
+const BAND_LO = 270;
+const BAND_HI = 330;
+const CHROMA_FLOOR = 0.06; // below this a color is effectively grey — its hue is meaningless
+const DOMINANCE = 0.6; // in-band / chromatic ratio needed to call the gradient a violet tell
+
+/** Named Tailwind palette hues that fall inside the AI-glow band. */
+const NAMED_IN_BAND = new Set(["indigo", "violet", "purple", "fuchsia"]);
+/** Named Tailwind palette hues that are chromatic but outside the band (so they dilute dominance). */
+const NAMED_OUT_BAND = new Set(["blue", "sky", "cyan", "teal", "green", "emerald", "lime", "yellow", "amber", "orange", "red", "rose", "pink"]);
+
+const LARGE_SURFACE = /hero|banner|jumbotron|masthead|splash|cover|backdrop|full-?bleed|section|\bbody\b|\bhtml\b|:root|\bmain\b|min-h-screen|h-screen|\[100vh|inset-0|w-full|\bpage\b|background/i;
+const SMALL_ELEMENT = /btn|button|badge|chip|pill|\btag\b|\bicon\b|avatar|\bdot\b|thumb|swatch|underline|divider|\bborder\b|\blink\b|logo|\bcard\b|rounded-full/i;
+
+/** Convert one gradient color stop (hex, #rgba, or rgb/rgba()) to an OKLCH hue+chroma; null if not a color. */
+function stopHue(raw: string): { h: number; c: number } | null {
+  const s = raw.trim().toLowerCase();
+  let hex: string | null = null;
+  const hexM = /^#([0-9a-f]{3,8})$/.exec(s);
+  if (hexM) {
+    const d = hexM[1] ?? "";
+    if (d.length === 3 || d.length === 6) hex = `#${d}`;
+    else if (d.length === 4) hex = `#${d.slice(0, 3)}`; // #rgba → drop alpha nibble
+    else if (d.length === 8) hex = `#${d.slice(0, 6)}`; // #rrggbbaa → drop alpha
+  } else {
+    const rgb = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(s);
+    if (rgb) {
+      const to2 = (n: string) => Math.max(0, Math.min(255, parseInt(n, 10))).toString(16).padStart(2, "0");
+      hex = `#${to2(rgb[1] ?? "0")}${to2(rgb[2] ?? "0")}${to2(rgb[3] ?? "0")}`;
+    }
+  }
+  if (hex === null) return null;
+  try {
+    const o = hexToOKLCH(hex);
+    return { h: o.h, c: o.c };
+  } catch {
+    return null; // ColorError on a malformed token — ignore it
+  }
+}
+
+/** Verdict for one gradient's combined stop set: is it dominantly in the AI-glow band? */
+function isViolet(chromatic: number, inBand: number): boolean {
+  return chromatic >= 1 && inBand >= 1 && inBand / chromatic >= DOMINANCE;
+}
+
+/** Extract every `linear|radial|conic-gradient(...)` payload from a text region (handles one nested paren level, e.g. rgba()). */
+function gradientPayloads(text: string): string[] {
+  const out: string[] = [];
+  const re = /(?:linear|radial|conic)-gradient\(((?:[^()]|\([^()]*\))*)\)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) out.push(m[1] ?? "");
+  return out;
+}
+
+/** Count chromatic and in-band stops across the hex/rgb colors inside a gradient payload. */
+function tallyPayload(payload: string): { chromatic: number; inBand: number } {
+  let chromatic = 0, inBand = 0;
+  const colorRe = /#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = colorRe.exec(payload)) !== null) {
+    const hue = stopHue(m[0]);
+    if (hue === null || hue.c < CHROMA_FLOOR) continue;
+    chromatic++;
+    if (hue.h >= BAND_LO && hue.h <= BAND_HI) inBand++;
+  }
+  return { chromatic, inBand };
+}
+
+/** Count named Tailwind gradient stops (from-/via-/to-<color>-<shade>) split into in-band vs out-of-band. */
+function tallyNamed(attrs: string): { chromatic: number; inBand: number } {
+  if (!/\bbg-gradient-to-[a-z]+/i.test(attrs)) return { chromatic: 0, inBand: 0 };
+  let chromatic = 0, inBand = 0;
+  const re = /\b(?:from|via|to)-([a-z]+)-\d{2,3}\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(attrs)) !== null) {
+    const name = (m[1] ?? "").toLowerCase();
+    if (NAMED_IN_BAND.has(name)) { chromatic++; inBand++; }
+    else if (NAMED_OUT_BAND.has(name)) chromatic++;
+  }
+  return { chromatic, inBand };
+}
+
+/** Does the document declare a brand/accent/soul token whose hue is in the AI-glow band? */
+function brandDeclaresBand(html: string): boolean {
+  const re = /--[\w-]*(?:primary|brand|accent|soul)[\w-]*\s*:\s*(#[0-9a-fA-F]{3,8}|rgba?\([^)]*\))/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    const hue = stopHue(m[1] ?? "");
+    if (hue && hue.c >= CHROMA_FLOOR && hue.h >= BAND_LO && hue.h <= BAND_HI) return true;
+  }
+  return false;
+}
+
+const MSG =
+  `large-surface gradient sits in the indigo–magenta "AI glow" hue band (~270–330°) (rubric Depth/Surface: gradient-on-material is a design choice, not a default) — the loudest machine-default tell; recolor to the brand hue or drop the gradient`;
+
+export function checkAiClicheGradient(html: string): TasteFinding[] {
+  if (brandDeclaresBand(html)) return []; // violet is the declared brand — intentional, exempt
+
+  const findings: TasteFinding[] = [];
+
+  // Source 1 — <style> rules: gradient in the body, large-surface read from the selector.
+  for (const { selector, body } of cssRules(cssRegions(html))) {
+    if (!LARGE_SURFACE.test(selector) || SMALL_ELEMENT.test(selector)) continue;
+    let chromatic = 0, inBand = 0;
+    for (const p of gradientPayloads(body)) { const t = tallyPayload(p); chromatic += t.chromatic; inBand += t.inBand; }
+    if (isViolet(chromatic, inBand)) {
+      findings.push({ checkId: CHECK_ID, axis: "Depth/Surface", severity: "error", message: MSG });
+    }
+  }
+
+  // Source 2 — element opening tags: inline-style gradients + Tailwind gradient utilities.
+  const tagRe = /<([a-zA-Z][\w-]*)\b([^>]*)>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(html)) !== null) {
+    const attrs = m[2] ?? "";
+    if (!LARGE_SURFACE.test(attrs) || SMALL_ELEMENT.test(attrs)) continue;
+    let chromatic = 0, inBand = 0;
+    for (const p of gradientPayloads(attrs)) { const t = tallyPayload(p); chromatic += t.chromatic; inBand += t.inBand; }
+    const named = tallyNamed(attrs);
+    chromatic += named.chromatic; inBand += named.inBand;
+    if (isViolet(chromatic, inBand)) {
+      findings.push({ checkId: CHECK_ID, axis: "Depth/Surface", severity: "error", message: MSG, line: lineOf(html, m.index) });
+    }
+  }
+
+  return findings;
+}

--- a/src/core/taste-checks-tap-target.ts
+++ b/src/core/taste-checks-tap-target.ts
@@ -1,0 +1,138 @@
+/**
+ * tap-target-undersized (Spacing axis, WARNING) — the deterministic floor under
+ * the rubric's touch-target rule ("touch targets under ~44px on a touch surface"
+ * / "cramped touch targets" — taste-rubric.md Axis 3, Spacing).
+ *
+ * Interactive controls (`<button> <a> <input>`, `[role=button]`, `[onclick]`)
+ * need a ≥44×44px hit area (WCAG 2.5.5 / Apple HIG / Material). This is a static
+ * heuristic: it only flags when the markup carries POSITIVE evidence of an
+ * undersized box — a fixed height below 44px, a min-height floor below 44px with
+ * no padding to reach it, or an icon-only control with too little padding and no
+ * height at all. A plain text link or a control whose size lives in an external
+ * stylesheet is never flagged (precision over recall — a warning that fires on a
+ * fine control is worse than a missed marginal one).
+ *
+ * Pure string/regex — no DOM, no deps.
+ */
+import type { TasteFinding } from "./taste-lint.js";
+import { lineOf } from "./taste-checks-shared.js";
+
+const MIN_TAP = 44; // px — the touch-target floor
+const CHECK_ID = "tap-target-undersized";
+
+/** An opening tag is interactive when it is a native control or carries a click/button role. */
+function isInteractive(tag: string, attrs: string): boolean {
+  const t = tag.toLowerCase();
+  if (t === "button" || t === "a" || t === "input") return true;
+  return /\brole\s*=\s*["']?button\b/i.test(attrs) || /\bonclick\s*=/i.test(attrs);
+}
+
+/** Largest px value among matches of `re` (group 1), scaling Tailwind scale units (×4). Null if none. */
+function pxFrom(attrs: string, re: RegExp, scale: boolean): number | null {
+  let best: number | null = null;
+  let m: RegExpExecArray | null;
+  re.lastIndex = 0;
+  while ((m = re.exec(attrs)) !== null) {
+    const n = parseFloat(m[1] ?? "0");
+    if (!Number.isFinite(n)) continue;
+    const px = scale ? n * 4 : n;
+    if (best === null || px < best) best = px; // smallest declared height governs the ceiling
+  }
+  return best;
+}
+
+/** Smallest fixed height (h-*, size-*, inline height) in px; null when none is declared. */
+function fixedHeightPx(attrs: string): number | null {
+  // Lookbehind `(?<!-)` keeps the `h-` inside `min-h-`/`max-h-` from reading as a fixed height.
+  const cands = [
+    pxFrom(attrs, /(?<!-)\bh-\[(\d+(?:\.\d+)?)px\]/g, false),
+    pxFrom(attrs, /(?<!-)\bh-(\d+(?:\.\d+)?)(?=[\s"'>]|$)/g, true),
+    pxFrom(attrs, /\bsize-\[(\d+(?:\.\d+)?)px\]/g, false),
+    pxFrom(attrs, /\bsize-(\d+(?:\.\d+)?)(?=[\s"'>]|$)/g, true),
+    pxFrom(attrs, /(?:^|[;"'\s])height\s*:\s*(\d+(?:\.\d+)?)px/gi, false),
+  ].filter((v): v is number => v !== null);
+  return cands.length > 0 ? Math.min(...cands) : null;
+}
+
+/** Smallest min-height floor (min-h-*, inline min-height) in px; null when none. */
+function minHeightPx(attrs: string): number | null {
+  const cands = [
+    pxFrom(attrs, /\bmin-h-\[(\d+(?:\.\d+)?)px\]/g, false),
+    pxFrom(attrs, /\bmin-h-(\d+(?:\.\d+)?)(?=[\s"'>]|$)/g, true),
+    pxFrom(attrs, /min-height\s*:\s*(\d+(?:\.\d+)?)px/gi, false),
+  ].filter((v): v is number => v !== null);
+  return cands.length > 0 ? Math.min(...cands) : null;
+}
+
+/** Largest single-side vertical padding (py-*, p-*, pt-*, pb-*, inline) in px; 0 when none. */
+function verticalPadPx(attrs: string): number {
+  const cands = [
+    pxFrom(attrs, /\b(?:py|p|pt|pb)-\[(\d+(?:\.\d+)?)px\]/g, false),
+    pxFrom(attrs, /\b(?:py|p|pt|pb)-(\d+(?:\.\d+)?)(?=[\s"'>]|$)/g, true),
+    pxFrom(attrs, /padding(?:-(?:top|bottom))?\s*:\s*(\d+(?:\.\d+)?)px/gi, false),
+  ].filter((v): v is number => v !== null);
+  // pxFrom returns the SMALLEST; for padding we want the LARGEST evidence of compensation.
+  return cands.length > 0 ? Math.max(...cands) : 0;
+}
+
+/** True when the element's inner HTML is an icon with no visible text label. */
+function isIconOnly(inner: string): boolean {
+  const hasIcon = /data-lucide|<svg\b|class="[^"]*\bicon\b|<i\b[^>]*\b(?:fa-|bi-|ti-|material-icons)/i.test(inner);
+  if (!hasIcon) return false;
+  const text = inner.replace(/<[^>]*>/g, "").replace(/&[a-z]+;/gi, "").trim();
+  return text.length === 0;
+}
+
+/**
+ * Flag an interactive control whose touch target is provably under 44px.
+ *  A. fixed height < 44px (a hard ceiling — padding cannot grow it);
+ *  B. min-height floor < 44px with no vertical padding to reach 44px;
+ *  C. icon-only control with ≤ 8px vertical padding and no height token at all.
+ */
+export function checkTapTargetUndersized(html: string): TasteFinding[] {
+  const findings: TasteFinding[] = [];
+  const seen = new Set<number>(); // dedup by source offset
+
+  // Scan 1 — opening interactive tags: prongs A & B (explicit size tokens).
+  const tagRe = /<([a-zA-Z][\w-]*)\b([^>]*)>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(html)) !== null) {
+    const tag = m[1] ?? "";
+    const attrs = m[2] ?? "";
+    if (!isInteractive(tag, attrs)) continue;
+    const fixed = fixedHeightPx(attrs);
+    const floor = minHeightPx(attrs);
+    const pad = verticalPadPx(attrs);
+    let msg: string | null = null;
+    if (fixed !== null && fixed < MIN_TAP) {
+      msg = `interactive control has a fixed height of ${fixed}px, below the ${MIN_TAP}px touch-target minimum (rubric Spacing: touch targets ≥ ~44px) — raise it to h-11 / min-h-[44px]`;
+    } else if (floor !== null && floor < MIN_TAP && pad === 0) {
+      msg = `interactive control sets min-height ${floor}px (< ${MIN_TAP}px) with no vertical padding to reach the ${MIN_TAP}px touch-target floor — raise the min-height or add padding`;
+    }
+    if (msg !== null) {
+      seen.add(m.index);
+      findings.push({ checkId: CHECK_ID, axis: "Spacing", severity: "warning", message: msg, line: lineOf(html, m.index) });
+    }
+  }
+
+  // Scan 2 — icon-only <button>/<a role=button>: prong C (no height token, tiny padding).
+  const elRe = /<(button|a)\b([^>]*)>([\s\S]*?)<\/\1>/gi;
+  while ((m = elRe.exec(html)) !== null) {
+    if (seen.has(m.index)) continue;
+    const tag = m[1] ?? "";
+    const attrs = m[2] ?? "";
+    const inner = m[3] ?? "";
+    if (tag.toLowerCase() === "a" && !/\brole\s*=\s*["']?button\b/i.test(attrs)) continue;
+    if (fixedHeightPx(attrs) !== null || minHeightPx(attrs) !== null) continue; // sized → scan 1's job
+    if (!isIconOnly(inner)) continue;
+    if (verticalPadPx(attrs) > 8) continue; // adequate padding around the icon
+    const pad = verticalPadPx(attrs);
+    findings.push({
+      checkId: CHECK_ID, axis: "Spacing", severity: "warning",
+      message: `icon-only control has no explicit height and only ${pad}px vertical padding — likely below the ${MIN_TAP}px touch-target floor; add min-h-[44px] or more padding`,
+      line: lineOf(html, m.index),
+    });
+  }
+
+  return findings;
+}

--- a/src/core/taste-lint.ts
+++ b/src/core/taste-lint.ts
@@ -10,14 +10,19 @@
  *   error   — a definite rubric-rule violation (exit 1). These are not smells;
  *             each is a rule the rubric states as an absolute ("body never below
  *             16px", "exactly one icon family", "never linear easing").
+ *   warning — a craft smell the rubric flags but does not treat as absolute; it
+ *             surfaces in the report but never fails the exit code (e.g. an
+ *             undersized touch target whose true size may live in external CSS).
  *
  * Coverage (axis → check):
  *   Typography    → tiny-body-text          (font-size ≤ 13px)
  *   Spacing       → off-grid-spacing        (Tailwind spacing not on 4px grid)
+ *   Spacing       → tap-target-undersized   (interactive control < 44px; warning)
  *   Iconography   → mixed-icon-families     (≥ 2 icon libraries)
  *   Typography    → italic-display-heading, uppercase-tight-line-height
  *   Depth/Surface → pure-black-shadow       (hard/opaque black shadow)
  *   Depth/Surface → z-index-inflation       (all-nines z-index)
+ *   Depth/Surface → ai-cliche-gradient      (indigo/violet/magenta AI-glow gradient)
  *   Motion        → linear-easing, transition-all, animation-no-reduced-motion,
  *                   keyframes-layout-props
  *   Motion        → overshoot-easing, focus-ring-animates-in
@@ -42,10 +47,18 @@ import {
 import { checkOvershootEasing, checkFocusRingAnimatesIn } from "./taste-checks-motion-state.js";
 import { checkItalicDisplayHeading, checkUppercaseTightLineHeight } from "./taste-checks-typography.js";
 import { checkZIndexInflation } from "./taste-checks-depth.js";
+import { checkTapTargetUndersized } from "./taste-checks-tap-target.js";
+import { checkAiClicheGradient } from "./taste-checks-gradient.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type TasteSeverity = "error";
+/**
+ * Most taste findings are `error` — a definite rubric-rule breach that exits 1.
+ * A `warning` is a craft smell the rubric flags but does not treat as absolute
+ * (e.g. an undersized touch target whose real size may live in external CSS); it
+ * surfaces in the report but never fails the exit code.
+ */
+export type TasteSeverity = "error" | "warning";
 
 /** A taste-rubric axis label (matches knowledge/taste-rubric.md exactly). */
 export type TasteAxis =
@@ -68,7 +81,10 @@ export interface TasteFinding {
 
 export interface TasteLintResult {
   findings: TasteFinding[];
+  /** Count of error-severity findings only — the exit code keys off this. */
   errorCount: number;
+  /** Count of warning-severity findings (craft smells; never fail the build). */
+  warningCount: number;
   /** Distinct rubric axes that have at least one violation. */
   axesAffected: TasteAxis[];
 }
@@ -117,6 +133,9 @@ export function lintTaste(html: string, opts: TasteLintOptions = {}): TasteLintR
     ...checkOvershootEasing(stripped),
     ...checkFocusRingAnimatesIn(stripped),
     ...checkRawHexWhenTokenExists(stripped, opts.knownHexes),
+    // Craft lints (spec 003 P1). ai-cliche-gradient is an error; tap-target is a warning.
+    ...checkAiClicheGradient(stripped),
+    ...checkTapTargetUndersized(stripped),
   ];
 
   // Sort by rubric axis order, then by line (undefined lines last).
@@ -130,5 +149,6 @@ export function lintTaste(html: string, opts: TasteLintOptions = {}): TasteLintR
     (a, b) => AXIS_ORDER[a] - AXIS_ORDER[b],
   );
 
-  return { findings, errorCount: findings.length, axesAffected };
+  const errorCount = findings.filter((f) => f.severity === "error").length;
+  return { findings, errorCount, warningCount: findings.length - errorCount, axesAffected };
 }

--- a/tests/taste-checks-craft.test.ts
+++ b/tests/taste-checks-craft.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The two spec-003 P1 craft lints:
+ *   tap-target-undersized (Spacing, warning) — taste-checks-tap-target.ts
+ *   ai-cliche-gradient    (Depth/Surface, error) — taste-checks-gradient.ts
+ * Each check gets fixtures that fire every prong plus passing negatives, then a
+ * final block drives them through lintTaste() to prove wiring, severity split,
+ * and that the warning never bumps errorCount.
+ */
+import { describe, expect, it } from "vitest";
+import { checkTapTargetUndersized } from "../src/core/taste-checks-tap-target.js";
+import { checkAiClicheGradient } from "../src/core/taste-checks-gradient.js";
+import { lintTaste } from "../src/core/taste-lint.js";
+
+// ─── tap-target-undersized (Spacing / warning) ──────────────────────────────────
+
+describe("tap-target-undersized", () => {
+  it("Prong A: flags a fixed Tailwind height below 44px (h-10 = 40px)", () => {
+    const f = checkTapTargetUndersized('<button class="w-10 h-10 rounded-full">x</button>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("tap-target-undersized");
+    expect(f[0]?.axis).toBe("Spacing");
+    expect(f[0]?.severity).toBe("warning");
+    expect(f[0]?.message).toContain("40px");
+  });
+
+  it("Prong A: flags an arbitrary-px fixed height (h-[36px]) and inline height", () => {
+    expect(checkTapTargetUndersized('<a href="#" class="h-[36px]">go</a>')).toHaveLength(1);
+    expect(checkTapTargetUndersized('<button style="height:32px">go</button>')).toHaveLength(1);
+  });
+
+  it("Prong B: flags a min-height floor below 44px with no vertical padding", () => {
+    const f = checkTapTargetUndersized('<button class="min-h-[32px]">Go</button>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.message).toContain("min-height 32px");
+  });
+
+  it("Prong C: flags an icon-only button with ≤8px padding and no height", () => {
+    expect(checkTapTargetUndersized('<button class="p-1"><svg></svg></button>')).toHaveLength(1);
+    expect(checkTapTargetUndersized('<button class="p-2" aria-label="menu"><i data-lucide="menu"></i></button>')).toHaveLength(1);
+  });
+
+  it("flags [role=button] and [onclick] carriers too", () => {
+    expect(checkTapTargetUndersized('<div role="button" class="h-8">x</div>')).toHaveLength(1);
+    expect(checkTapTargetUndersized('<div onclick="go()" class="h-[20px]">x</div>')).toHaveLength(1);
+  });
+
+  it("does NOT flag an adequately sized control (h-11 = 44px, px-4)", () => {
+    expect(checkTapTargetUndersized('<button class="h-11 px-4">Save</button>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a plain text link with no size utilities", () => {
+    expect(checkTapTargetUndersized('<a href="/about">About us</a>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a min-height floor that carries compensating padding", () => {
+    expect(checkTapTargetUndersized('<button class="min-h-[36px] py-3">Go</button>')).toHaveLength(0);
+  });
+
+  it("does NOT flag an icon button with enough padding (p-3 = 12px)", () => {
+    expect(checkTapTargetUndersized('<button class="p-3"><svg></svg></button>')).toHaveLength(0);
+  });
+
+  it("does NOT double-count a sized icon button (scan-1 wins, scan-2 skips)", () => {
+    expect(checkTapTargetUndersized('<button class="h-8 p-1"><svg></svg></button>')).toHaveLength(1);
+  });
+});
+
+// ─── ai-cliche-gradient (Depth/Surface / error) ─────────────────────────────────
+
+describe("ai-cliche-gradient", () => {
+  it("flags a large-surface hex gradient in the violet band (indigo→purple)", () => {
+    const f = checkAiClicheGradient('<section style="background:linear-gradient(135deg,#6366f1,#a855f7)">hi</section>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("ai-cliche-gradient");
+    expect(f[0]?.axis).toBe("Depth/Surface");
+    expect(f[0]?.severity).toBe("error");
+  });
+
+  it("flags an rgb() violet radial glow on a full-bleed inset overlay", () => {
+    const f = checkAiClicheGradient('<div class="absolute inset-0" style="background:radial-gradient(circle,rgba(123,66,246,0.3),transparent)"></div>');
+    expect(f).toHaveLength(1);
+  });
+
+  it("flags a named Tailwind gradient (from-indigo via-purple to-pink) on a large surface", () => {
+    expect(checkAiClicheGradient('<div class="min-h-screen bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500"></div>')).toHaveLength(1);
+  });
+
+  it("flags a <style>-rule gradient on a hero selector (no line number)", () => {
+    const f = checkAiClicheGradient('<style>.hero-bg{background:linear-gradient(#8b5cf6,#d946ef)}</style>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.line).toBeUndefined();
+  });
+
+  it("does NOT flag a violet gradient on a small accent (a button)", () => {
+    expect(checkAiClicheGradient('<button class="rounded-full" style="background:linear-gradient(#6366f1,#a855f7)">x</button>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a blue gradient (hue below the band)", () => {
+    expect(checkAiClicheGradient('<section style="background:linear-gradient(#3b82f6,#60a5fa)">x</section>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a warm/brand gradient (orange)", () => {
+    expect(checkAiClicheGradient('<section style="background:linear-gradient(#ff3e00,#ff8a3d)">x</section>')).toHaveLength(0);
+  });
+
+  it("exempts the whole doc when a brand token itself declares a violet hue", () => {
+    const html = '<style>:root{--color-primary:#8b5cf6}</style><section style="background:linear-gradient(#6366f1,#a855f7)">x</section>';
+    expect(checkAiClicheGradient(html)).toHaveLength(0);
+  });
+
+  it("does NOT flag a desaturated blue-grey glow (chroma below the floor)", () => {
+    expect(checkAiClicheGradient('<div class="absolute inset-0" style="background:radial-gradient(circle,rgba(60,70,90,0.35),transparent)"></div>')).toHaveLength(0);
+  });
+});
+
+// ─── lintTaste wiring — severity split ──────────────────────────────────────────
+
+describe("lintTaste — craft lints wired with correct severity", () => {
+  it("counts ai-cliche as an error and tap-target as a warning", () => {
+    const bad = [
+      '<section style="background:linear-gradient(135deg,#6366f1,#a855f7)">',
+      '<button class="h-10">x</button>',
+      "</section>",
+    ].join("\n");
+    const r = lintTaste(bad);
+    const ids = new Set(r.findings.map((f) => f.checkId));
+    expect(ids.has("ai-cliche-gradient")).toBe(true);
+    expect(ids.has("tap-target-undersized")).toBe(true);
+    expect(r.errorCount).toBeGreaterThanOrEqual(1); // ai-cliche
+    expect(r.warningCount).toBeGreaterThanOrEqual(1); // tap-target
+    expect(r.axesAffected).toContain("Depth/Surface");
+    expect(r.axesAffected).toContain("Spacing");
+  });
+
+  it("a warning-only document keeps errorCount 0 (exit stays green)", () => {
+    const r = lintTaste('<button class="h-9">x</button>');
+    expect(r.errorCount).toBe(0);
+    expect(r.warningCount).toBe(1);
+  });
+
+  it("clean DS-faithful markup trips neither craft lint", () => {
+    const clean = '<section class="hero"><button class="h-11 px-4">Save</button></section>';
+    const r = lintTaste(clean);
+    expect(r.errorCount).toBe(0);
+    expect(r.warningCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## What
Spec 003 P1 (proof phase): the two highest-signal craft lints, each a pure `checkXxx` + knowledge pairing (Art II) + tests + dogfood-fire.

**tap-target-undersized** (Spacing, **warning**) — `src/core/taste-checks-tap-target.ts`
Flags interactive controls (`button`/`a`/`input`/`[role=button]`/`[onclick]`) with:
- A. a fixed height < 44px (hard ceiling — padding can't grow it);
- B. a `min-height` floor < 44px with no compensating vertical padding;
- C. an icon-only control with ≤8px padding and no height token.

Precision-first: a plain text link or a control sized in external CSS is never flagged.

**ai-cliche-gradient** (Depth/Surface, **error**) — `src/core/taste-checks-gradient.ts`
Converts each gradient stop to OKLCH (reuses `color-convert.ts`) and flags a **large-surface** linear/radial/conic gradient dominated (≥60%) by chromatic stops in the ~270–330° hue band. Named Tailwind gradient utilities (`from-indigo-500 … to-purple-600`) classified by name. Exempt when an in-doc brand/accent/soul token itself declares that hue. Small accents (buttons, chips, avatars, `rounded-full`) never flagged.

`taste-lint` gains a **warning** severity tier (`warningCount`; exit code still keys off errors only).

## Knowledge pairing
- `taste-rubric.md` — Spacing (tap-target machine floor) + Depth/Surface (AI-glow gradient machine floor).
- `page-structures.md` — §5 chrome tells + the "what the machine already catches" list.

## Verify
- 4 gates green: `typecheck`, `lint`, `build`, `test` (1739 passed / 4 skipped, no regressions).
- `ui knowledge check` — 0 findings.
- Dogfood-fire on real rebuilds: `ai-cliche-gradient` fires on **hashicorp** (2 violet gradients: `#3a2d8f` full-bleed + a `<style>` rule), stays clean on **composio** (desaturated blue-grey glow, chroma below floor); `tap-target-undersized` fires on **cohere/ibm/expo/vercel** undersized controls (e.g. cohere `h-10` icon buttons = 40px).

## Notes
- Module home: split into two focused `taste-checks-*` modules (each < 200 lines) rather than one `taste-checks-craft.ts` — matches the existing per-concern taste-checks split.
- Brand exemption reads only in-document custom properties; an external design-soul file declaring a violet brand isn't visible to a single-file static check (documented limitation).
- No verbatim source text; only public-standard facts (WCAG 2.5.5, OKLCH band) shared.

Per spec: 1 phase = 1 PR, **human merge** — not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)