### PR TITLE
spec 003 P4 — delivery-assets discipline (originals, not screenshot crops)

### DIFF
--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -32,6 +32,7 @@ directly** while designing UI — curated design taste that sets the quality flo
 | `design-agents.md` | **Soul-bound, task-scoped project agents** — what a design agent is, the role-first naming with a genealogy suffix (studio soul `name:` × project → `designer-jang-vsf-pcp`), the first three roles and their hard boundaries (designer never self-scores · curator never edits · figma-hand never simulates), runtime-read identity (agents read `ui ds context`, soul text is never baked), the opt-in roster (`ui agents init|list|check`), and the stale-drift check. Claude Code only for now. Read when generating or auditing a project's agent roster. |
 | `page-structures.md` | **Shape before dress — the page-composition layer between persona and code.** The macrostructure catalog (21 named page shapes — pick one shape, not six loose axes), the diversification rule + the variety↔conformance switch (resist the default-attractor), honest-copy rules (no fabricated evidence), the six-axis pre-emit self-critique, and the nav/footer/hero "AI tells" (with pointers to the `taste-lint`/`layout-lint` checkIds that catch the machine-detectable ones). Read when shaping a standalone landing / marketing / docs surface or a custom `ds preview` chrome — NOT for a single component. |
 | `prompt-modes.md` | The replicate / enhance / adapt strategy modifiers for reference-driven generation. |
+| `delivery-assets.md` | **Resolve reproduced images to originals, never screenshot crops** — the best→last-resort resolution ladder (inline-SVG logo → harvested site-served raster → sprite slice → screenshot-crop LAST RESORT, art-only), the machine floor (the deterministic `avoidable-screenshot-crop` lint in `ui validate-layout` + the host-model resolution workflow that fills `real/` and emits `ASSET-MAP.json` provenance), and the failure modes (crop-includes-text · screenshot-as-hero · missing-DPR · provenance-loss). Read when rebuilding / cloning / design-from-URL off a probed source with a mirror + asset harvest — NOT for a from-scratch generative design. |
 | `ux-psychology.md` | UX laws (Hick's, Fitts', Miller's, …), Gestalt perception, cognitive biases, emotional design, trust building, cognitive-load management, ethical persuasion — with per-law application rules and a final audit checklist. Read selectively: only the law(s) a brief triggers. |
 | `benchmarks/*.dna.json` | SOURCE-grade measured DNA (type ramps, surfaces, shadows, gaps) of 8 ship-grade products — Arc, Figma, Framer, Linear, Notion, Raycast, Stripe, Vercel. Calibration data for the excellence-tier reference duel; see `benchmarks/README.md`. |
 | `figma-craft/workflow-experience.md` | The **interaction + cost brain** above the Figma verbs — the intent router (intent/drop → job → verb, incl. the multi-URL/image reference-drop row), the uniform job lifecycle (REFERENCE→SCOPE→PLAN→BUILD→SEE→ITERATE→LAND), reference intake (subagent-isolated DNA extract → cache in `<project>/references/` → deterministic synth), the "eyes" feedback contract, trust/clone-safety, progressive disclosure, and the zero-token-`ui`-binary cost contract. Read FIRST when routing a plain-language Figma job; every `/ui:*` Figma verb follows it. |
@@ -68,6 +69,11 @@ enforces.
 
 **Generate from a reference (image or existing design)** — `prompt-modes.md` to pick
 replicate / enhance / adapt, then the generate flow above
+
+**Rebuilding / cloning from a source** (design-from-URL, clone-adapt off a probed site) —
+`delivery-assets.md`: resolve every reproduced image to the original the source serves
+(inline-SVG → harvested raster → sprite slice → crop last resort), enforced by the
+`avoidable-screenshot-crop` lint
 
 **Make a color decision** — `color-science.md`
 

--- a/knowledge/delivery-assets.md
+++ b/knowledge/delivery-assets.md
@@ -1,0 +1,99 @@
+# Delivery Assets — resolve to originals, never screenshot crops
+
+## Purpose
+
+When a delivery reproduces a real surface — a rebuild, a clone-adapt, a design→code
+from a live site — its images MUST be the originals the source actually serves, not
+rectangles cropped out of a page capture.
+
+## Mental Model
+
+A page capture is a photograph of glass; the assets behind it are the glass. Cropping the
+photograph hands you a blurry, fixed-DPI, wrong-background rectangle. The source already
+serves the real files — sharp vectors and high-DPR rasters — and after a probe mirror +
+asset harvest they are almost always already sitting in your working tree. The job is not
+to *make* an asset from a screenshot; it is to *resolve* to the original that already
+exists.
+
+## When to Use / When NOT
+
+- **USE** for any rebuild / clone-adapt / design-from-URL where a probe mirror and an
+  asset harvest exist — there is a real source whose files you can resolve to.
+- **Do NOT** apply to a from-scratch generative design. With no source, there is no
+  original to resolve; there you generate or commission, and this ladder does not apply.
+
+## The resolution ladder (best → last resort)
+
+Resolve every reproduced image to the highest rung it can reach. State both sides so the
+rung is unambiguous.
+
+1. **Inline SVG logo / icon.** ALLOWED — extract the `<svg …>` verbatim from the mirror
+   HTML. Perfect vector, theme-able, infinite DPI; this is where partner wordmarks and
+   product logos live. Rasterizing a vector logo is NOT ALLOWED — WHY: it throws away the
+   resolution independence the source already gave you, and the wordmark goes soft on any
+   Hi-DPI screen.
+2. **Harvested raster the site serves.** ALLOWED — the CDN images already in the asset
+   harvest (product-UI windows, photos, illustrations as PNG/WebP/AVIF). Use them at full
+   resolution. Downscaling-then-upscaling or re-encoding a served raster is NOT ALLOWED —
+   WHY: a re-encode compounds compression artifacts the original never had, and a full-res
+   window always beats any crop of that same window.
+3. **Sprite / spritesheet slice.** ALLOWED — when the source ships a sprite, slice the real
+   sprite sheet. Screenshotting one icon out of a rendered sprite is NOT ALLOWED — WHY: the
+   slice is pixel-exact and theme-stable; a screenshot bakes in the page background behind
+   the icon's transparency.
+4. **Screenshot crop — LAST RESORT ONLY.** ALLOWED *only* when the asset is a live
+   DOM/canvas/WebGL composition the site never serves as a file (some hero illustrations,
+   animated canvases). When you must crop, crop ARTWORK ONLY, and record it as a debt in
+   `ASSET-MAP.json`. Cropping a region that contains baked-in headline or CTA text is NOT
+   ALLOWED — WHY: the page re-renders that same text as live HTML on top of the crop, so
+   the words double-render, misalign, and blur (see failure mode `crop-includes-text`).
+
+Repeat at the point of use: a crop is the LAST rung, never the first reach. If a same-role
+original is within reach, using the crop is the "noob" tell this file exists to kill.
+
+## Machine floor
+
+Two halves — one deterministic and shipped in the binary, one a host-model workflow.
+
+- **Enforced (deterministic).** `ui validate-layout` runs `avoidable-screenshot-crop`
+  (warning): an `<img src>` under a `crops/` path when the same document also references a
+  same-role original under a `real/` path (matched by normalized stem — `crops/hero-1560x1248.png`
+  and `real/hero.webp` both reduce to `hero`). It fires ONLY when both are demonstrably on
+  hand in the one document, so it never nags a lone crop whose original the linter cannot
+  see. This is the fence; the ladder above is the reason it exists.
+- **Resolution workflow (host-model, not a `ui` subcommand).** From a probe mirror + asset
+  harvest, resolve originals into `assets/real/`:
+  1. Copy every site-served raster into `real/`, named by its pixel dimension (a
+     `1560×1248` window beats any crop of it — the dimension in the name makes "use the
+     largest variant" a glance, not a guess).
+  2. Extract every labelled inline `<svg>` (by `aria-label` / `<title>`) as a real vector
+     under `real/`, so partner wordmarks and product logos survive as vectors.
+  3. Emit `ASSET-MAP.json` beside the delivery recording each real asset's origin URL. WHY
+     this is not a `ui` command: correct type-sniffing and dimension-reading across
+     PNG/JPEG/WebP/AVIF plus file copy is I/O orchestration over harvested bytes, not a
+     pure in-memory transform — it stays a reference script + this workflow rather than
+     bloating the deterministic binary with an image-codec surface. The *enforcement* half
+     (the lint) is what ships deterministic; the *resolution* half is guidance the host
+     model (or a small script) runs.
+
+Provenance is delivered, not just resolved: harvested originals are proprietary to their
+source and are for internal study/calibration only — never redistributed — and every real
+asset carries its origin URL in `ASSET-MAP.json` so a later reader can re-verify it.
+
+## Failure Modes
+
+- **crop-includes-text** → double text on the page: an HTML heading renders over a crop
+  that already contains that same headline, so the words overlap, misalign, and blur.
+  Observable: two copies of one string in the rendered hero. Cure — crop art-only, or drop
+  the crop for a CSS gradient when the "asset" was only a background wash.
+- **screenshot-as-hero** → a blurry, fixed-DPI, wrong-theme window shipped as the hero
+  while a sharp full-resolution original sat unused in the harvest. Observable: the hero
+  image is visibly softer than the live crisp UI beside it. Cure — this ladder, rung 2.
+- **missing-DPR** → a 1× crop shipped where the source serves a 2× file, so the image is
+  soft on every Hi-DPI screen. Observable: the asset looks sharp at 100% zoom on a 1×
+  display and soft on a Retina one. Cure — prefer the largest harvested variant (rung 2),
+  which is why `real/` names carry the pixel dimension.
+- **provenance-loss** → a real asset shipped with no record of where it came from, so no
+  reader can re-verify it or honor its redistribution terms. Observable: an image in the
+  delivery has no row in `ASSET-MAP.json`. Cure — emit `ASSET-MAP.json` (file ↔ source URL)
+  as part of resolution, never after.

--- a/src/commands/validate-layout.ts
+++ b/src/commands/validate-layout.ts
@@ -1,7 +1,7 @@
 /**
  * `ui validate-layout` command — static HTML structural/overflow linter.
  *
- * Runs 12 heuristic checks against an HTML file and reports findings.
+ * Runs 13 heuristic checks against an HTML file and reports findings.
  * Read-only: never writes to disk.
  *
  * Exit code policy (D4): exit 1 iff any error-severity finding; warnings → 0.
@@ -37,6 +37,7 @@ Checks (heuristic — may false-positive on unusual markup):
   empty-flex-grid           warning flex/grid container with no child tags
   css-100vw-width           warning width:100vw in a <style> rule (scrollbar gutter → overflow)
   root-overflow-x-hidden    warning overflow-x:hidden on html/body/:root (breaks position:sticky)
+  avoidable-screenshot-crop warning <img> is a crops/ screenshot when a same-role real/ original exists
 
 Exit codes:
   0  No error-severity findings (warnings are allowed)

--- a/src/core/layout-checks-delivery.ts
+++ b/src/core/layout-checks-delivery.ts
@@ -1,0 +1,89 @@
+/**
+ * Delivery-asset discipline check for the static HTML layout linter.
+ *
+ * avoidable-screenshot-crop (warning): an `<img src>` that points at a
+ * screenshot-crop path (`.../crops/...`) when the same document ALSO references
+ * a same-role original under a real-asset path (`.../real/...`). Cropping a page
+ * capture where the source's own file is already in reach is the "noob" tell the
+ * knowledge/delivery-assets.md ladder exists to prevent.
+ *
+ * Pure string/regex heuristic — no DOM parser, no filesystem. The linter proves
+ * "a same-role real asset exists" ONLY from the HTML itself: the crop and the
+ * real asset must share a normalized stem within the one document. This keeps
+ * the check deterministic and precision-first — it fires only when the author
+ * has demonstrably both on hand, never on a lone crop whose original the linter
+ * cannot see.
+ */
+import type { LayoutFinding } from "./layout-lint.js";
+
+/** Return 1-based line number for a match at byte offset `idx`. */
+function lineOf(html: string, idx: number): number {
+  return html.slice(0, idx).split("\n").length;
+}
+
+/**
+ * Normalize an image src to a role stem: last path segment, minus query/hash,
+ * minus extension, minus a trailing `-1234x567`/`_1234x567` dimension token and
+ * a trailing `@2x`/`-2x` DPR token, lowercased. So `crops/hero-1560x1248.png`
+ * and `real/hero.webp` both reduce to `hero` — a same-role match.
+ */
+function roleStem(src: string): string {
+  const last = (src.split(/[?#]/)[0] ?? "").split("/").pop() ?? "";
+  return last
+    .replace(/\.[a-z0-9]+$/i, "")        // extension
+    .replace(/[-_]\d{2,}x\d{2,}$/i, "")  // dimension token
+    .replace(/[-_@](?:[23])x$/i, "")     // DPR token
+    .toLowerCase();
+}
+
+/** True when a src sits under a path segment named `dir` (e.g. `crops`, `real`). */
+function underDir(src: string, dir: string): boolean {
+  return new RegExp(`(^|/)${dir}/`, "i").test(src.split(/[?#]/)[0] ?? "");
+}
+
+interface ImgRef {
+  src: string;
+  index: number;
+}
+
+/** Collect every `<img>`'s src attribute with its byte offset. */
+function collectImgSrcs(html: string): ImgRef[] {
+  const out: ImgRef[] = [];
+  const imgRe = /<img\b([^>]*)>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = imgRe.exec(html)) !== null) {
+    const srcM = (m[1] ?? "").match(/\bsrc\s*=\s*["']([^"']+)["']/i);
+    if (srcM?.[1]) out.push({ src: srcM[1], index: m.index });
+  }
+  return out;
+}
+
+/**
+ * avoidable-screenshot-crop: a crop-path `<img>` whose role stem also appears
+ * under a real-asset path in the same document.
+ */
+export function checkAvoidableScreenshotCrop(html: string): LayoutFinding[] {
+  const imgs = collectImgSrcs(html);
+  if (imgs.length < 2) return []; // need a crop AND a real reference to be sure
+
+  // Stems that the document serves from a real-asset path.
+  const realStems = new Set<string>();
+  for (const img of imgs) {
+    if (underDir(img.src, "real")) realStems.add(roleStem(img.src));
+  }
+  if (realStems.size === 0) return [];
+
+  const findings: LayoutFinding[] = [];
+  for (const img of imgs) {
+    if (!underDir(img.src, "crops")) continue;
+    const stem = roleStem(img.src);
+    if (stem === "" || !realStems.has(stem)) continue;
+    findings.push({
+      checkId: "avoidable-screenshot-crop",
+      severity: "warning",
+      message: `<img src="${img.src}"> is a screenshot crop, but a same-role original exists under real/ — use the original (see knowledge/delivery-assets.md)`,
+      line: lineOf(html, img.index),
+    });
+  }
+  return findings;
+}

--- a/src/core/layout-lint.ts
+++ b/src/core/layout-lint.ts
@@ -1,7 +1,7 @@
 /**
  * Static HTML layout linter — pure string/regex heuristics, zero deps.
  *
- * Runs 12 checks against an HTML string and returns a structured result.
+ * Runs 13 checks against an HTML string and returns a structured result.
  * All checks are documented as heuristic approximations (no DOM parser, no
  * browser, no rendering). See layout-checks.ts for individual check logic.
  *
@@ -25,6 +25,7 @@ import {
   checkEmptyFlexGrid,
 } from "./layout-checks.js";
 import { checkCss100vwWidth, checkRootOverflowXHidden } from "./layout-checks-viewport.js";
+import { checkAvoidableScreenshotCrop } from "./layout-checks-delivery.js";
 import { isRedirectStub } from "./redirect-stub.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -71,6 +72,7 @@ const WARNING_CHECKS = [
   checkAbsoluteWithoutRelative,
   checkImgNoDimensions,
   checkEmptyFlexGrid,
+  checkAvoidableScreenshotCrop,
 ] as const;
 
 // ─── Orchestrator ─────────────────────────────────────────────────────────────
@@ -84,7 +86,7 @@ function stripCommentsPreservingOffsets(html: string): string {
   return html.replace(/<!--[\s\S]*?-->/g, (match) => " ".repeat(match.length));
 }
 
-/** Run all 12 checks and return findings sorted errors-first, then warnings. */
+/** Run all 13 checks and return findings sorted errors-first, then warnings. */
 export function lintLayout(html: string): LayoutLintResult {
   // L4 dogfood: a redirect stub intentionally has no <html>/<body>, so every structural
   // check below is noise on it — short-circuit before running any of the 12 checks.

--- a/tests/layout-lint.test.ts
+++ b/tests/layout-lint.test.ts
@@ -272,6 +272,74 @@ describe("lintLayout — root-overflow-x-hidden", () => {
   });
 });
 
+// ─── Delivery-asset discipline (P4) ───────────────────────────────────────────
+
+describe("lintLayout — avoidable-screenshot-crop", () => {
+  it("flags a crops/ img when a same-role real/ original is referenced", () => {
+    const html = [
+      "<!doctype html><html><body>",
+      '<img src="assets/crops/hero.png" width="800" height="600">',
+      '<img src="assets/real/hero.webp" width="1560" height="1248">',
+      "</body></html>",
+    ].join("\n");
+    const { findings } = lintLayout(html);
+    const f = findings.find((x) => x.checkId === "avoidable-screenshot-crop");
+    expect(f).toBeDefined();
+    expect(f?.severity).toBe("warning");
+    expect(f?.line).toBeDefined();
+  });
+
+  it("matches across dimension/extension differences (crops/hero-1560x1248.png ↔ real/hero.webp)", () => {
+    const html = [
+      "<!doctype html><html><body>",
+      '<img src="/assets/real/hero.webp" width="1560" height="1248">',
+      '<img src="/assets/crops/hero-1560x1248.png" width="800" height="600">',
+      "</body></html>",
+    ].join("");
+    const { findings } = lintLayout(html);
+    expect(findings.some((x) => x.checkId === "avoidable-screenshot-crop")).toBe(true);
+  });
+
+  it("does NOT flag a lone crops/ img with no real/ counterpart (precision-first)", () => {
+    const html = '<!doctype html><html><body><img src="assets/crops/hero.png" width="8" height="6"></body></html>';
+    const { findings } = lintLayout(html);
+    expect(findings.some((x) => x.checkId === "avoidable-screenshot-crop")).toBe(false);
+  });
+
+  it("does NOT flag when the crop's stem differs from every real/ stem", () => {
+    const html = [
+      "<!doctype html><html><body>",
+      '<img src="assets/real/logo.svg" width="120" height="40">',
+      '<img src="assets/crops/hero.png" width="800" height="600">',
+      "</body></html>",
+    ].join("");
+    const { findings } = lintLayout(html);
+    expect(findings.some((x) => x.checkId === "avoidable-screenshot-crop")).toBe(false);
+  });
+
+  it("does NOT flag two real/ images (no crop present)", () => {
+    const html = [
+      "<!doctype html><html><body>",
+      '<img src="assets/real/a.png" width="100" height="100">',
+      '<img src="assets/real/b.png" width="100" height="100">',
+      "</body></html>",
+    ].join("");
+    const { findings } = lintLayout(html);
+    expect(findings.some((x) => x.checkId === "avoidable-screenshot-crop")).toBe(false);
+  });
+
+  it("does NOT flag a commented-out crops/ img", () => {
+    const html = [
+      "<!doctype html><html><body>",
+      '<img src="assets/real/hero.webp" width="1560" height="1248">',
+      '<!-- <img src="assets/crops/hero.png"> -->',
+      "</body></html>",
+    ].join("");
+    const { findings } = lintLayout(html);
+    expect(findings.some((x) => x.checkId === "avoidable-screenshot-crop")).toBe(false);
+  });
+});
+
 // ─── Comment stripping ────────────────────────────────────────────────────────
 
 describe("lintLayout — HTML comments do not trigger findings", () => {


### PR DESCRIPTION
## Spec 003 · Phase P4 — delivery-assets discipline ("get originals, not screenshots like a noob")

Three parts, per `specs/003-quality-upgrade/plan.md §P4`.

### 1. `knowledge/delivery-assets.md` (new)
Authored to `knowledge/authoring-standard.md`: Purpose → Mental model → When-to-Use/NOT →
the **resolution ladder** (inline-SVG logo → harvested site-served raster → sprite slice →
screenshot-crop LAST RESORT, art-only), the **machine floor**, and mandatory **Failure
modes** (crop-includes-text · screenshot-as-hero · missing-DPR · provenance-loss), each
observable + WHY-with-mechanism. Rewritten to the frame, not copied from the draft; no
hardcoded survey counts.

### 2. `avoidable-screenshot-crop` lint (warning)
New pure module `src/core/layout-checks-delivery.ts`, registered in `layout-lint.ts`
WARNING_CHECKS + documented in `ui validate-layout` help. Fires when an `<img src>` under a
`crops/` path shares a normalized stem (dimension/DPR/extension-stripped) with a `real/`
image referenced **in the same document** — precision-first: never nags a lone crop whose
original the linter cannot see. Pure string/regex, no DOM, no filesystem.

### 3. Resolver — shipped as workflow guidance, NOT a `ui` subcommand
Decision recorded in the knowledge file's Machine-floor section: type-sniffing +
dimension-reading + file copy across PNG/JPEG/WebP/AVIF is I/O orchestration over harvested
bytes, not a pure in-memory transform — bundling an image-codec surface into the
deterministic binary is the wrong trade. The **enforcement** half (the lint) is what ships
deterministic; the **resolution** half is a host-model workflow.

### Knowledge index
`knowledge/README.md`: new `## The files` row + a "Rebuilding / cloning from a source"
route. `ui knowledge check` → 0 findings.

### Verify
- `npm run typecheck` · `npm run lint` · `npm run build` · `npm test` — all pass.
- `node dist/cli.js knowledge check` → 0 findings.
- Dogfood: `ui validate-layout` on a rebuild fixture fires the warning end-to-end (exit 0,
  correct line), and does not fire on a lone crop or a stem mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)