### PR TITLE
feat: five web craft lints (spec 003 P2)

### DIFF
--- a/knowledge/page-structures.md
+++ b/knowledge/page-structures.md
@@ -132,11 +132,15 @@ page *genuinely* needs nothing else, and reach for a deliberate archetype otherw
 
 **What the machine already catches (do not spend judgment re-inspecting these):**
 `taste-lint` owns `italic-display-heading`, `uppercase-tight-line-height`,
-`overshoot-easing`, `focus-ring-animates-in`, `z-index-inflation`, `ai-cliche-gradient`
-(large violet-band background gradient), and `tap-target-undersized` (interactive control
-under the 44px touch minimum); `validate-layout` owns `css-100vw-width` and
-`root-overflow-x-hidden`. If a tell is on that list, the linter has it — spend your
-attention on the tells that are not.
+`overshoot-easing`, `focus-ring-animates-in`, `z-index-inflation`, `z-index-off-ladder`
+(a `z-index` off any base-10 ladder step), `ai-cliche-gradient` (large violet-band background
+gradient), `mode-invisible-surface` (a low-alpha white surface on a light page, or black on a
+dark page — a boundary that passes contrast but shows nothing), `font-scale-sprawl` (more than
+7 hand-picked font sizes), and `tap-target-undersized` (interactive control under the 44px
+touch minimum); `validate-layout` owns `css-100vw-width`, `root-overflow-x-hidden`,
+`clickable-no-pointer` (a non-native clickable with no `cursor:pointer`), and
+`font-display-missing` (a font with no `font-display` → FOIT + swap-in shift). If a tell is on
+that list, the linter has it — spend your attention on the tells that are not.
 
 ## §6 When to read this file
 

--- a/knowledge/taste-rubric.md
+++ b/knowledge/taste-rubric.md
@@ -78,6 +78,10 @@ word inside a heading) read as generated, not designed. All-caps display keeps l
 **Anti-patterns:** five+ font sizes with no ratio relationship; headings and body at the
 same weight; uppercase paragraphs; default-tracked huge display text; pairing two fonts
 that occupy the same role; italic display headings; all-caps display with line-height below 1.0.
+*Machine floor:* `taste-lint`'s `font-scale-sprawl` counts the distinct hand-picked font
+sizes (arbitrary `text-[..px]` utilities and raw `font-size` literals — named Tailwind steps
+and `var(--…)` token sizes do not count) and warns past 7, errors past 10 — the signal that
+the scale was never derived from one ratio.
 
 ### Scoring 0–10
 
@@ -243,10 +247,16 @@ never designed.
 shadow and heavy border stacked on the same surface; glass over busy content that kills
 text contrast; elevation that doesn't correlate with actual stacking order; z-index 9999;
 a large background gradient in the indigo→magenta band (the machine-default "AI glow" —
-finance/enterprise surfaces read it as cheap). *Machine floor:* `taste-lint`'s
-`ai-cliche-gradient` (error) converts each gradient stop to OKLCH and flags a large-surface
-linear/radial/conic gradient dominated by stops in the ~270–330° hue band; recolor to the
-brand hue (or declare that hue as an in-doc brand token to exempt it).
+finance/enterprise surfaces read it as cheap); a low-alpha same-mode surface tint (a white
+hairline/fill on a light page, or the black inverse on a dark page) that passes text-contrast
+but draws no visible boundary. *Machine floor:* `taste-lint`'s `ai-cliche-gradient` (error)
+converts each gradient stop to OKLCH and flags a large-surface linear/radial/conic gradient
+dominated by stops in the ~270–330° hue band; `mode-invisible-surface` (error) reads the
+document mode from its root and flags a sub-15%-alpha white surface on a light page (or black
+on a dark page); `z-index-off-ladder` (warning) flags a `z-index` above single-digit local
+stacking that is not a base-10 ladder step, and `z-index-inflation` (error) flags the
+all-nines escalation. Recolor the gradient to the brand hue (or declare that hue as an in-doc
+brand token), give the invisible boundary a visible tint, and snap stacking to a named z-scale.
 
 ### Scoring 0–10
 

--- a/src/core/layout-checks-craft.ts
+++ b/src/core/layout-checks-craft.ts
@@ -1,0 +1,108 @@
+/**
+ * Two web-craft layout checks that are functional affordance/loading bugs rather
+ * than taste-axis judgments, so they live on the layout linter (no rubric axis):
+ *
+ *   clickable-no-pointer (warning) — a non-native element made clickable
+ *     (`[onclick]` / `role="button"`) with no `cursor: pointer`, so the hand
+ *     affordance native buttons/links get for free is missing.
+ *   font-display-missing (warning) — an `@font-face` with no `font-display`, or a
+ *     Google-Fonts `<link>` with no `display=` param → FOIT (invisible text while
+ *     the font loads) plus a layout shift when it swaps in.
+ *
+ * Split into its own module (layout-checks.ts is already over the 200-line
+ * guideline). Reuses the CSS helpers from taste-checks-shared. Pure string/regex —
+ * no DOM, no deps.
+ */
+import type { LayoutFinding } from "./layout-lint.js";
+import { cssRegions, cssRules, lineOf } from "./taste-checks-shared.js";
+
+// ─── clickable-no-pointer ───────────────────────────────────────────────────────
+
+/** Native controls already carry a pointer cursor and are never flagged. */
+const NATIVE_CONTROL = /^(?:button|a|input|select|textarea|label|summary|option)$/i;
+
+/** Classes targeted by a CSS rule whose body sets `cursor: pointer`. */
+function pointerClasses(css: string): Set<string> {
+  const out = new Set<string>();
+  for (const { selector, body } of cssRules(css)) {
+    if (!/cursor\s*:\s*pointer/i.test(body)) continue;
+    for (const m of selector.matchAll(/\.([\w-]+)/g)) out.add((m[1] ?? "").toLowerCase());
+  }
+  return out;
+}
+
+/** The element's own class list (lower-cased) from its attribute string. */
+function classList(attrs: string): string[] {
+  const cm = /\bclass\s*=\s*["']([^"']*)["']/i.exec(attrs);
+  if (!cm) return [];
+  return (cm[1] ?? "").toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * clickable-no-pointer: a non-native element carrying a click handler or
+ * `role="button"` but no `cursor: pointer` (utility `cursor-pointer`, inline
+ * `cursor:pointer`, or a matching CSS rule on one of its classes). Precision-first:
+ * native controls are skipped (they get the cursor for free) and any provable
+ * pointer source exempts the element, so only genuinely bare clickables flag.
+ */
+export function checkClickableNoPointer(html: string): LayoutFinding[] {
+  const findings: LayoutFinding[] = [];
+  const ptrClasses = pointerClasses(cssRegions(html));
+  const tagRe = /<([a-zA-Z][\w-]*)\b([^>]*)>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(html)) !== null) {
+    const tag = m[1] ?? "";
+    const attrs = m[2] ?? "";
+    if (NATIVE_CONTROL.test(tag)) continue;
+    const clickable = /\bonclick\s*=/i.test(attrs) || /\brole\s*=\s*["']?button\b/i.test(attrs);
+    if (!clickable) continue;
+    if (/\bcursor-pointer\b/i.test(attrs)) continue;               // Tailwind utility
+    if (/cursor\s*:\s*pointer/i.test(attrs)) continue;             // inline style
+    if (classList(attrs).some((c) => ptrClasses.has(c))) continue; // CSS rule on a class
+    findings.push({
+      checkId: "clickable-no-pointer", severity: "warning",
+      message: `<${tag}> is made clickable (onclick / role=button) but has no cursor:pointer — non-native controls do not get the hand affordance for free; add cursor-pointer (or use a real <button>)`,
+      line: lineOf(html, m.index),
+    });
+  }
+  return findings;
+}
+
+// ─── font-display-missing ───────────────────────────────────────────────────────
+
+/**
+ * font-display-missing: an `@font-face` block with no `font-display` descriptor,
+ * or a Google-Fonts stylesheet `<link>` with no `display=` query param. Either
+ * leaves the browser in its default (block) behaviour — invisible text for up to
+ * 3s (FOIT) then a swap-in layout shift. `font-display: swap|optional|fallback`
+ * fixes it. Precision-first: an `@font-face` that already declares any
+ * `font-display` is respected (the author made a choice) and not flagged.
+ */
+export function checkFontDisplayMissing(html: string): LayoutFinding[] {
+  const findings: LayoutFinding[] = [];
+
+  // @font-face blocks (in <style> or inline CSS) lacking a font-display descriptor.
+  const css = cssRegions(html);
+  const faceRe = /@font-face\s*\{([^}]*)\}/gi;
+  let m: RegExpExecArray | null;
+  while ((m = faceRe.exec(css)) !== null) {
+    if (/font-display\s*:/i.test(m[1] ?? "")) continue;
+    findings.push({
+      checkId: "font-display-missing", severity: "warning",
+      message: `@font-face has no font-display descriptor — the browser defaults to block (FOIT: invisible text while the font loads, then a swap-in layout shift); add font-display: swap (or optional)`,
+    });
+  }
+
+  // Google-Fonts <link> stylesheets with no display= param.
+  const linkRe = /<link\b[^>]*\bhref\s*=\s*["']([^"']*fonts\.googleapis\.com[^"']*)["'][^>]*>/gi;
+  while ((m = linkRe.exec(html)) !== null) {
+    if (/[?&]display=/i.test(m[1] ?? "")) continue;
+    findings.push({
+      checkId: "font-display-missing", severity: "warning",
+      message: `Google-Fonts <link> has no display= param — the font renders with the default block behaviour (FOIT + swap-in shift); append &display=swap to the href`,
+      line: lineOf(html, m.index),
+    });
+  }
+
+  return findings;
+}

--- a/src/core/layout-lint.ts
+++ b/src/core/layout-lint.ts
@@ -1,7 +1,7 @@
 /**
  * Static HTML layout linter — pure string/regex heuristics, zero deps.
  *
- * Runs 13 checks against an HTML string and returns a structured result.
+ * Runs 15 checks against an HTML string and returns a structured result.
  * All checks are documented as heuristic approximations (no DOM parser, no
  * browser, no rendering). See layout-checks.ts for individual check logic.
  *
@@ -26,6 +26,7 @@ import {
 } from "./layout-checks.js";
 import { checkCss100vwWidth, checkRootOverflowXHidden } from "./layout-checks-viewport.js";
 import { checkAvoidableScreenshotCrop } from "./layout-checks-delivery.js";
+import { checkClickableNoPointer, checkFontDisplayMissing } from "./layout-checks-craft.js";
 import { isRedirectStub } from "./redirect-stub.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -73,6 +74,9 @@ const WARNING_CHECKS = [
   checkImgNoDimensions,
   checkEmptyFlexGrid,
   checkAvoidableScreenshotCrop,
+  // Web craft lints (spec 003 P2): functional affordance/loading bugs, not layout structure.
+  checkClickableNoPointer,
+  checkFontDisplayMissing,
 ] as const;
 
 // ─── Orchestrator ─────────────────────────────────────────────────────────────
@@ -86,10 +90,10 @@ function stripCommentsPreservingOffsets(html: string): string {
   return html.replace(/<!--[\s\S]*?-->/g, (match) => " ".repeat(match.length));
 }
 
-/** Run all 13 checks and return findings sorted errors-first, then warnings. */
+/** Run all 15 checks and return findings sorted errors-first, then warnings. */
 export function lintLayout(html: string): LayoutLintResult {
   // L4 dogfood: a redirect stub intentionally has no <html>/<body>, so every structural
-  // check below is noise on it — short-circuit before running any of the 12 checks.
+  // check below is noise on it — short-circuit before running any of the other checks.
   if (isRedirectStub(html)) {
     return { findings: [], errorCount: 0, warningCount: 0 };
   }

--- a/src/core/taste-checks-depth.ts
+++ b/src/core/taste-checks-depth.ts
@@ -35,3 +35,36 @@ export function checkZIndexInflation(html: string): TasteFinding[] {
   }
   return findings;
 }
+
+// ─── Off-ladder z-index: a stacking value that is not a clean scale step ─────────
+
+/** Any `z-index` set to an integer (optionally negative). Group 1 = the signed value. */
+const Z_INDEX_VALUE = /z-index\s*:\s*(-?\d+)\b/gi;
+
+/**
+ * z-index-off-ladder: a `z-index` above single-digit local stacking that is not a
+ * base-10 ladder step (10 / 20 / 30 / … / 100 / 1000). Values 0–9 are left alone
+ * (legitimate local stacking within a component); the all-nines values are already
+ * an error via `checkZIndexInflation`, so they are excluded here to avoid a double
+ * report. A value like `z-index: 47` or `z-index: 250` is the tell that the scale
+ * was improvised rather than designed. Scoped to CSS regions; a warning (the page
+ * still renders). Pure string/regex.
+ */
+export function checkZIndexOffLadder(html: string): TasteFinding[] {
+  const findings: TasteFinding[] = [];
+  const css = cssRegions(html);
+  Z_INDEX_VALUE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = Z_INDEX_VALUE.exec(css)) !== null) {
+    const raw = m[1] ?? "0";
+    const mag = Math.abs(parseInt(raw, 10));
+    if (mag <= 9) continue;                     // single-digit local stacking is fine
+    if (mag % 10 === 0) continue;               // on the 10/20/…/100/1000 ladder
+    if (/^(?:9{3,}|2147483647)$/.test(String(mag))) continue; // all-nines → already an error
+    findings.push({
+      checkId: "z-index-off-ladder", axis: "Depth/Surface", severity: "warning",
+      message: `z-index: ${raw} is off any base-10 ladder (rubric Depth/Surface: "stacking order is a designed scale, not an arms race") — snap it to a named z-scale step (e.g. 10/20/30/40/50)`,
+    });
+  }
+  return findings;
+}

--- a/src/core/taste-checks-font-scale.ts
+++ b/src/core/taste-checks-font-scale.ts
@@ -1,0 +1,82 @@
+/**
+ * font-scale-sprawl (Typography axis, WARNING at > 7 / ERROR at > 10) — the
+ * machine floor under the rubric's scale rule ("pick one modular ratio and derive
+ * the scale from it; do not hand-pick unrelated sizes" — taste-rubric.md Axis 2).
+ *
+ * A designed type scale is a handful of steps on one ratio. A sprawl of many
+ * distinct hand-picked sizes reads as unauthored — vertical rhythm dies when
+ * every element sits on its own arbitrary size.
+ *
+ * What is counted: only ARBITRARY concrete font sizes — Tailwind arbitrary values
+ * (`text-[13px]` / `text-[1.1rem]`), raw CSS `font-size: 17px`, and inline
+ * `style="font-size:..."`. NOT counted: named Tailwind steps (`text-sm`/`text-lg`
+ * …) — those already ride a fixed ratio — and `font-size: var(--…)` token
+ * references, which by definition resolve to a design-system scale. A document
+ * that dresses type entirely from a token scale or the named ramp trips nothing.
+ *
+ * Thresholds: > 10 distinct arbitrary sizes → error (definite sprawl); > 7 →
+ * warning (drifting). One whole-document finding; no line number.
+ *
+ * Pure string/regex — no DOM, no deps.
+ */
+import type { TasteFinding } from "./taste-lint.js";
+import { cssRegions } from "./taste-checks-shared.js";
+
+const CHECK_ID = "font-scale-sprawl";
+const WARN_OVER = 7;
+const ERROR_OVER = 10;
+
+/** Normalize a numeric size + unit to px (2-dp) so equivalent sizes dedupe. Null if not a length. */
+function toPx(value: string, unit: string): number | null {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const u = unit.toLowerCase();
+  const px =
+    u === "px" ? n :
+    u === "rem" || u === "em" ? n * 16 : // em approximated at the 16px root — good enough to dedupe
+    u === "pt" ? n * (96 / 72) :
+    null;
+  return px === null ? null : Math.round(px * 100) / 100;
+}
+
+/** Collect distinct arbitrary font sizes (in px) declared anywhere in the document. */
+function distinctArbitrarySizes(html: string): Set<number> {
+  const sizes = new Set<number>();
+
+  // Tailwind arbitrary font-size utilities: text-[13px], text-[1.125rem] (skip named steps entirely).
+  const twRe = /\btext-\[(\d+(?:\.\d+)?)(px|rem|em|pt)\]/gi;
+  let m: RegExpExecArray | null;
+  while ((m = twRe.exec(html)) !== null) {
+    const px = toPx(m[1] ?? "", m[2] ?? "");
+    if (px !== null) sizes.add(px);
+  }
+
+  // Raw `font-size:` in <style> rules and inline styles. `var(--…)` values carry no
+  // literal length and are skipped (they resolve to a token scale by construction).
+  const css = cssRegions(html);
+  const fsRe = /font-size\s*:\s*(\d+(?:\.\d+)?)(px|rem|em|pt)\b/gi;
+  while ((m = fsRe.exec(css)) !== null) {
+    const px = toPx(m[1] ?? "", m[2] ?? "");
+    if (px !== null) sizes.add(px);
+  }
+
+  return sizes;
+}
+
+/**
+ * font-scale-sprawl: count the distinct arbitrary font sizes in the document.
+ * More than 10 is an error (the scale was never designed); more than 7 a warning
+ * (it is drifting off one ratio). Named Tailwind steps and token references never
+ * count — only hand-picked concrete sizes do.
+ */
+export function checkFontScaleSprawl(html: string): TasteFinding[] {
+  const count = distinctArbitrarySizes(html).size;
+  if (count <= WARN_OVER) return [];
+  const severity = count > ERROR_OVER ? "error" : "warning";
+  return [{
+    checkId: CHECK_ID,
+    axis: "Typography",
+    severity,
+    message: `${count} distinct hand-picked font sizes (rubric Typography: "pick one modular ratio and derive the scale from it; do not hand-pick unrelated sizes") — derive the scale from one ratio or map these onto the design-system type steps`,
+  }];
+}

--- a/src/core/taste-checks-invisible-surface.ts
+++ b/src/core/taste-checks-invisible-surface.ts
@@ -1,0 +1,179 @@
+/**
+ * mode-invisible-surface (Depth/Surface axis, ERROR) — a boundary that passes
+ * text-contrast checks but is invisible in craft terms: a low-alpha WHITE border
+ * or fill on a light-mode document (white-on-white), or the dark inverse — a
+ * low-alpha BLACK border/fill on a dark-mode document (black-on-black).
+ *
+ * This is the classic copy-a-dark-recipe-onto-light bug: `border-white/10` is the
+ * correct hairline on a dark surface, but pasted onto a white page it separates
+ * nothing. A11y linters miss it (no text, no contrast pair); only craft catches it.
+ *
+ * Mode is read from the document root: the `dark` toggle class or a dark background
+ * utility / color on `<html>`/`<body>`/`:root` means dark mode; otherwise the
+ * browser default (light) governs. Precision over recall: on a MIXED-mode page (the
+ * common light-body-plus-dark-hero shape) a single global mode cannot prove which
+ * surface a tint sits on, so the check bails entirely rather than risk flagging a
+ * correct white hairline on a dark section. Text tints (`text-white/10`) are never
+ * flagged — only surfaces (background / border / ring / divide).
+ *
+ * Pure string/regex — no DOM, no deps.
+ */
+import type { TasteFinding } from "./taste-lint.js";
+import { cssRegions, lineOf } from "./taste-checks-shared.js";
+
+const CHECK_ID = "mode-invisible-surface";
+const ALPHA_FLOOR = 0.15; // below this a same-colour tint reads as no boundary at all
+
+type Mode = "light" | "dark";
+
+/**
+ * An UNPREFIXED (no `hover:`/`selection:`/`dark:`/`md:` variant) Tailwind bg
+ * utility naming a near-black surface. The `(?<!:)` guard is what keeps a
+ * `selection:bg-black/10` or `dark:bg-slate-900` from reading as the page's own
+ * background. `bg-[#rrggbb]` arbitrary values are handled separately (luminance).
+ */
+const DARK_BG_UTIL = /(?<![:\w-])bg-(?:black|(?:slate|gray|grey|zinc|neutral|stone)-(?:800|900|950))\b/i;
+/** The dark-mode toggle class as a WHOLE class token (`class="… dark …"`) — not `dark:`, not `*-dark`. */
+const DARK_CLASS = /\bclass\s*=\s*["'][^"']*(?<![\w-])dark(?![\w-:])[^"']*["']/i;
+/** An UNPREFIXED near-white Tailwind bg utility (light-surface signal). */
+const LIGHT_BG_UTIL = /(?<![:\w-])bg-(?:white|(?:slate|gray|grey|zinc|neutral|stone)-(?:50|100))\b/i;
+
+/** sRGB relative luminance (0–1) of a 3/6-digit hex; null if unparseable. */
+function hexLuminance(hex: string): number | null {
+  const d = hex.replace(/^#/, "");
+  const full = d.length === 3 ? d.split("").map((c) => c + c).join("") : d;
+  if (full.length !== 6 || /[^0-9a-f]/i.test(full)) return null;
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16) / 255);
+  return 0.2126 * (r ?? 0) + 0.7152 * (g ?? 0) + 0.0722 * (b ?? 0);
+}
+
+/**
+ * Decide the document colour mode from its ROOT only (`<html>`/`<body>` tag + the
+ * `html|body|:root` CSS rules). Dark when the root carries the `dark` toggle class
+ * or a near-black background; light otherwise (the browser default). Only the root
+ * is inspected so a dark card on a light page never flips the whole document.
+ * Custom-property declarations (`--color-base-dark: …`) are never read as the
+ * background — only real `background`/`background-color` properties are.
+ */
+function rootText(html: string): string {
+  const roots: string[] = [];
+  const tagRe = /<(?:html|body)\b([^>]*)>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(html)) !== null) roots.push(m[0] ?? "");
+  const css = cssRegions(html);
+  const rootRule = /(?:^|[\s,{])(?:html|body|:root)\b[^{]*\{([^}]*)\}/gi;
+  while ((m = rootRule.exec(css)) !== null) roots.push(m[1] ?? "");
+  return roots.join(" ");
+}
+
+/** Luminance of a real `background`/`background-color` hex in the given text; null when none/opaque-unknown. */
+function bgLuminance(text: string): number | null {
+  const bgHex = /(?:^|[;{"'\s])background(?:-color)?\s*:\s*(#[0-9a-fA-F]{3,6})\b/i.exec(text);
+  return bgHex ? hexLuminance(bgHex[1] ?? "") : null;
+}
+
+function detectMode(html: string): Mode {
+  const root = rootText(html);
+  if (DARK_CLASS.test(root) || DARK_BG_UTIL.test(root)) return "dark";
+  const lum = bgLuminance(root);
+  if (lum !== null && lum < 0.25) return "dark";
+  return "light";
+}
+
+/** True when the document uses a near-black surface anywhere (dark section / card / hero). */
+function hasDarkSurface(html: string): boolean {
+  if (DARK_BG_UTIL.test(html) || DARK_CLASS.test(html)) return true;
+  const arb = /(?<![:\w-])bg-\[(#[0-9a-fA-F]{3,6})\]/gi;
+  let m: RegExpExecArray | null;
+  while ((m = arb.exec(html)) !== null) {
+    const lum = hexLuminance(m[1] ?? "");
+    if (lum !== null && lum < 0.25) return true;
+  }
+  const cssLum = bgLuminance(cssRegions(html));
+  return cssLum !== null && cssLum < 0.25;
+}
+
+/** True when the document uses a near-white surface as an explicit section fill (light signal). */
+function hasLightSurface(html: string): boolean {
+  if (LIGHT_BG_UTIL.test(html)) return true;
+  const arb = /(?<![:\w-])bg-\[(#[0-9a-fA-F]{3,6})\]/gi;
+  let m: RegExpExecArray | null;
+  while ((m = arb.exec(html)) !== null) {
+    const lum = hexLuminance(m[1] ?? "");
+    if (lum !== null && lum > 0.85) return true;
+  }
+  return false;
+}
+
+/** Alpha (0–1) of a CSS colour token — rgba()/hsla()/#rrggbbaa — or null when opaque/unknown. */
+function cssAlpha(token: string): number | null {
+  const fn = /(?:rgba?|hsla?)\(([^)]*)\)/i.exec(token);
+  if (fn) {
+    const parts = (fn[1] ?? "").split(/[,/]/).map((p) => p.trim()).filter(Boolean);
+    if (parts.length >= 4) { const a = parseFloat(parts[3] ?? ""); return Number.isFinite(a) ? a : null; }
+    return null; // no alpha channel → opaque
+  }
+  const hex8 = /^#([0-9a-fA-F]{8})$/.exec(token);
+  if (hex8) return parseInt((hex8[1] ?? "").slice(6, 8), 16) / 255;
+  return null;
+}
+
+/** Does a colour token name pure white / pure black (ignoring its alpha)? */
+function isPureWhite(token: string): boolean {
+  return /\bwhite\b|#fff(?:f{0,5})\b|rgba?\(\s*255\s*,\s*255\s*,\s*255|hsla?\(\s*0\s*,\s*0%\s*,\s*100%/i.test(token);
+}
+function isPureBlack(token: string): boolean {
+  return /\bblack\b|#000(?:0{0,5})\b|rgba?\(\s*0\s*,\s*0\s*,\s*0|hsla?\(\s*0\s*,\s*0%\s*,\s*0%/i.test(token);
+}
+
+/** Surface-tint CSS props (never `color:` — text tint is not a boundary). */
+const SURFACE_PROP = /(?:background(?:-color)?|border(?:-[a-z]+)?-color|border(?:-[a-z]+)?|box-shadow|outline(?:-color)?)\s*:\s*([^;}]+)/gi;
+
+export function checkModeInvisibleSurface(html: string): TasteFinding[] {
+  const mode = detectMode(html);
+
+  // Precision guard for mixed-mode pages (a common shape: light body, dark hero/section).
+  // A single global mode cannot tell whether a given tint sits on a same-mode or an
+  // opposite-mode surface, so when the page carries BOTH modes we cannot prove the
+  // boundary is invisible — bail rather than risk a false positive. A white hairline is
+  // correct on a dark section; a black one is correct on a light section.
+  if (mode === "light" && hasDarkSurface(html)) return [];
+  if (mode === "dark" && hasLightSurface(html)) return [];
+
+  const findings: TasteFinding[] = [];
+  const wantWhite = mode === "light"; // light page → white tint vanishes; dark page → black tint vanishes
+  const pxLabel = wantWhite ? "white" : "black";
+
+  // Source 1 — Tailwind opacity utilities on surface prefixes: bg/border/ring/divide-<color>/<N>.
+  const utilRe = /\b(bg|border|ring|divide)-(white|black)\/(\d{1,3})\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = utilRe.exec(html)) !== null) {
+    const color = (m[2] ?? "").toLowerCase();
+    const alpha = parseInt(m[3] ?? "100", 10) / 100;
+    if (alpha >= ALPHA_FLOOR) continue;
+    if ((wantWhite && color !== "white") || (!wantWhite && color !== "black")) continue;
+    findings.push({
+      checkId: CHECK_ID, axis: "Depth/Surface", severity: "error",
+      message: `${m[1]}-${color}/${m[3]} is a ~${Math.round(alpha * 100)}% ${pxLabel} surface on a ${mode}-mode document — it passes text-contrast but the boundary is invisible; use a visible ${wantWhite ? "border/shadow tinted toward the background" : "light hairline"} instead`,
+      line: lineOf(html, m.index),
+    });
+  }
+
+  // Source 2 — literal low-alpha white/black on a surface prop (CSS rules + inline styles).
+  const css = cssRegions(html);
+  SURFACE_PROP.lastIndex = 0;
+  while ((m = SURFACE_PROP.exec(css)) !== null) {
+    const decl = m[1] ?? "";
+    const tok = /(?:rgba?|hsla?)\([^)]*\)|#[0-9a-fA-F]{8}\b/.exec(decl)?.[0];
+    if (!tok) continue;
+    const alpha = cssAlpha(tok);
+    if (alpha === null || alpha >= ALPHA_FLOOR) continue;
+    if (wantWhite ? !isPureWhite(tok) : !isPureBlack(tok)) continue;
+    findings.push({
+      checkId: CHECK_ID, axis: "Depth/Surface", severity: "error",
+      message: `a ~${Math.round(alpha * 100)}% ${pxLabel} surface tint on a ${mode}-mode document — it passes text-contrast but the boundary is invisible; raise the alpha or tint toward the background instead`,
+    });
+  }
+
+  return findings;
+}

--- a/src/core/taste-lint.ts
+++ b/src/core/taste-lint.ts
@@ -16,12 +16,15 @@
  *
  * Coverage (axis → check):
  *   Typography    → tiny-body-text          (font-size ≤ 13px)
+ *   Typography    → font-scale-sprawl       (> 7 hand-picked font sizes; error > 10)
  *   Spacing       → off-grid-spacing        (Tailwind spacing not on 4px grid)
  *   Spacing       → tap-target-undersized   (interactive control < 44px; warning)
  *   Iconography   → mixed-icon-families     (≥ 2 icon libraries)
  *   Typography    → italic-display-heading, uppercase-tight-line-height
  *   Depth/Surface → pure-black-shadow       (hard/opaque black shadow)
  *   Depth/Surface → z-index-inflation       (all-nines z-index)
+ *   Depth/Surface → z-index-off-ladder      (z-index off a base-10 scale; warning)
+ *   Depth/Surface → mode-invisible-surface  (low-alpha same-mode surface tint; error)
  *   Depth/Surface → ai-cliche-gradient      (indigo/violet/magenta AI-glow gradient)
  *   Motion        → linear-easing, transition-all, animation-no-reduced-motion,
  *                   keyframes-layout-props
@@ -46,9 +49,11 @@ import {
 // 200-line guideline, so we import these directly rather than via that barrel).
 import { checkOvershootEasing, checkFocusRingAnimatesIn } from "./taste-checks-motion-state.js";
 import { checkItalicDisplayHeading, checkUppercaseTightLineHeight } from "./taste-checks-typography.js";
-import { checkZIndexInflation } from "./taste-checks-depth.js";
+import { checkZIndexInflation, checkZIndexOffLadder } from "./taste-checks-depth.js";
 import { checkTapTargetUndersized } from "./taste-checks-tap-target.js";
 import { checkAiClicheGradient } from "./taste-checks-gradient.js";
+import { checkFontScaleSprawl } from "./taste-checks-font-scale.js";
+import { checkModeInvisibleSurface } from "./taste-checks-invisible-surface.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -127,6 +132,7 @@ export function lintTaste(html: string, opts: TasteLintOptions = {}): TasteLintR
     ...checkMixedIconFamilies(stripped),
     ...checkPureBlackShadow(stripped),
     ...checkZIndexInflation(stripped),
+    ...checkZIndexOffLadder(stripped),
     ...checkLinearOrAllTransition(stripped),
     ...checkAnimationNoReducedMotion(stripped),
     ...checkKeyframesLayoutProps(stripped),
@@ -136,6 +142,10 @@ export function lintTaste(html: string, opts: TasteLintOptions = {}): TasteLintR
     // Craft lints (spec 003 P1). ai-cliche-gradient is an error; tap-target is a warning.
     ...checkAiClicheGradient(stripped),
     ...checkTapTargetUndersized(stripped),
+    // Web craft lints (spec 003 P2). font-scale-sprawl & z-index-off-ladder are warnings
+    // (font-scale escalates to error past 10 sizes); mode-invisible-surface is an error.
+    ...checkFontScaleSprawl(stripped),
+    ...checkModeInvisibleSurface(stripped),
   ];
 
   // Sort by rubric axis order, then by line (undefined lines last).

--- a/tests/layout-checks-craft.test.ts
+++ b/tests/layout-checks-craft.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The two spec-003 P2 layout-lint craft checks:
+ *   clickable-no-pointer  (warning) — layout-checks-craft.ts
+ *   font-display-missing  (warning) — layout-checks-craft.ts
+ * Fixtures fire each prong plus passing negatives, then a wiring block drives them
+ * through lintLayout() to prove registration (both are warnings — exit stays green).
+ */
+import { describe, expect, it } from "vitest";
+import { checkClickableNoPointer, checkFontDisplayMissing } from "../src/core/layout-checks-craft.js";
+import { lintLayout } from "../src/core/layout-lint.js";
+
+// ─── clickable-no-pointer (warning) ─────────────────────────────────────────────
+
+describe("clickable-no-pointer", () => {
+  it("flags a <div onclick> with no cursor:pointer", () => {
+    const f = checkClickableNoPointer('<div onclick="go()">Menu</div>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("clickable-no-pointer");
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("flags a role=button carrier that lacks cursor:pointer", () => {
+    expect(checkClickableNoPointer('<span role="button">Toggle</span>')).toHaveLength(1);
+  });
+
+  it("does NOT flag when cursor-pointer utility is present", () => {
+    expect(checkClickableNoPointer('<div onclick="go()" class="cursor-pointer">Menu</div>')).toHaveLength(0);
+  });
+
+  it("does NOT flag when inline cursor:pointer is present", () => {
+    expect(checkClickableNoPointer('<div role="button" style="cursor:pointer">Menu</div>')).toHaveLength(0);
+  });
+
+  it("does NOT flag when a CSS rule sets cursor:pointer on the element's class", () => {
+    const html = '<style>.card{cursor:pointer}</style><div class="card" onclick="go()">Menu</div>';
+    expect(checkClickableNoPointer(html)).toHaveLength(0);
+  });
+
+  it("does NOT flag native controls (they get the cursor for free)", () => {
+    expect(checkClickableNoPointer('<button onclick="go()">Save</button>')).toHaveLength(0);
+    expect(checkClickableNoPointer('<a href="#" onclick="go()">Link</a>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a non-clickable div", () => {
+    expect(checkClickableNoPointer('<div class="panel">content</div>')).toHaveLength(0);
+  });
+});
+
+// ─── font-display-missing (warning) ─────────────────────────────────────────────
+
+describe("font-display-missing", () => {
+  it("flags an @font-face block with no font-display descriptor", () => {
+    const f = checkFontDisplayMissing('<style>@font-face{font-family:Acme;src:url(a.woff2)}</style>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("font-display-missing");
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("flags a Google-Fonts <link> with no display= param", () => {
+    const f = checkFontDisplayMissing('<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter">');
+    expect(f).toHaveLength(1);
+  });
+
+  it("does NOT flag an @font-face that declares font-display", () => {
+    expect(checkFontDisplayMissing('<style>@font-face{font-family:Acme;font-display:swap;src:url(a.woff2)}</style>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a Google-Fonts link carrying &display=swap", () => {
+    expect(checkFontDisplayMissing('<link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">')).toHaveLength(0);
+  });
+
+  it("does NOT flag a non-Google stylesheet link", () => {
+    expect(checkFontDisplayMissing('<link rel="stylesheet" href="/css/app.css">')).toHaveLength(0);
+  });
+});
+
+// ─── lintLayout wiring — both warnings, exit stays green ─────────────────────────
+
+describe("lintLayout — P2 craft lints wired as warnings", () => {
+  it("registers both and neither bumps errorCount", () => {
+    const html = [
+      "<!doctype html><html><body>",
+      '<div onclick="go()">Menu</div>',
+      "<style>@font-face{font-family:Acme;src:url(a.woff2)}</style>",
+      "</body></html>",
+    ].join("\n");
+    const r = lintLayout(html);
+    const ids = new Set(r.findings.map((f) => f.checkId));
+    expect(ids.has("clickable-no-pointer")).toBe(true);
+    expect(ids.has("font-display-missing")).toBe(true);
+    expect(r.errorCount).toBe(0);
+    expect(r.warningCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/taste-checks-web-craft.test.ts
+++ b/tests/taste-checks-web-craft.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The three spec-003 P2 taste-lint craft checks:
+ *   font-scale-sprawl      (Typography, warning>7 / error>10) — taste-checks-font-scale.ts
+ *   mode-invisible-surface (Depth/Surface, error)            — taste-checks-invisible-surface.ts
+ *   z-index-off-ladder     (Depth/Surface, warning)          — taste-checks-depth.ts
+ * Fixtures fire every prong plus passing negatives, then a wiring block drives
+ * them through lintTaste() to prove registration and the severity split.
+ */
+import { describe, expect, it } from "vitest";
+import { checkFontScaleSprawl } from "../src/core/taste-checks-font-scale.js";
+import { checkModeInvisibleSurface } from "../src/core/taste-checks-invisible-surface.js";
+import { checkZIndexOffLadder } from "../src/core/taste-checks-depth.js";
+import { lintTaste } from "../src/core/taste-lint.js";
+
+// ─── font-scale-sprawl (Typography / warning→error) ─────────────────────────────
+
+/** Build markup with `n` distinct arbitrary Tailwind font sizes (13px, 14px, …). */
+function nSizes(n: number): string {
+  return Array.from({ length: n }, (_, i) => `<p class="text-[${13 + i}px]">x</p>`).join("\n");
+}
+
+describe("font-scale-sprawl", () => {
+  it("warns at 8 distinct arbitrary sizes (> 7)", () => {
+    const f = checkFontScaleSprawl(nSizes(8));
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("font-scale-sprawl");
+    expect(f[0]?.axis).toBe("Typography");
+    expect(f[0]?.severity).toBe("warning");
+    expect(f[0]?.message).toContain("8 distinct");
+  });
+
+  it("errors at 11 distinct arbitrary sizes (> 10)", () => {
+    const f = checkFontScaleSprawl(nSizes(11));
+    expect(f).toHaveLength(1);
+    expect(f[0]?.severity).toBe("error");
+  });
+
+  it("counts raw CSS font-size and dedupes equivalent units (16px == 1rem)", () => {
+    const css = "<style>.a{font-size:16px}.b{font-size:1rem}</style>"; // one distinct size
+    expect(checkFontScaleSprawl(css + nSizes(7))).toHaveLength(0); // 7 tw + 1 css = 8 → but 16px dup? 13..19 + 16 dup → 7
+  });
+
+  it("does NOT count named Tailwind steps or var() token sizes", () => {
+    const html = '<p class="text-xs">a</p><p class="text-sm">b</p><p class="text-lg">c</p>' +
+      '<p class="text-xl">d</p><p class="text-2xl">e</p><p class="text-3xl">f</p>' +
+      '<p class="text-4xl">g</p><p class="text-5xl">h</p>' +
+      "<style>.x{font-size:var(--step-1)}.y{font-size:var(--step-2)}</style>";
+    expect(checkFontScaleSprawl(html)).toHaveLength(0);
+  });
+
+  it("does NOT flag a tight scale of 7 sizes", () => {
+    expect(checkFontScaleSprawl(nSizes(7))).toHaveLength(0);
+  });
+});
+
+// ─── mode-invisible-surface (Depth/Surface / error) ─────────────────────────────
+
+describe("mode-invisible-surface", () => {
+  it("flags border-white/10 on a light-mode document", () => {
+    const f = checkModeInvisibleSurface('<body class="bg-white"><div class="border border-white/10">x</div></body>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("mode-invisible-surface");
+    expect(f[0]?.axis).toBe("Depth/Surface");
+    expect(f[0]?.severity).toBe("error");
+    expect(f[0]?.message).toContain("light-mode");
+  });
+
+  it("flags bg-white/5 on a light (default) document", () => {
+    expect(checkModeInvisibleSurface('<div class="bg-white/5">x</div>')).toHaveLength(1);
+  });
+
+  it("flags a literal rgba(255,255,255,0.08) background on a light document", () => {
+    const f = checkModeInvisibleSurface('<div style="background:rgba(255,255,255,0.08)">x</div>');
+    expect(f).toHaveLength(1);
+  });
+
+  it("flags the dark inverse — border-black/10 on a dark-mode document", () => {
+    const f = checkModeInvisibleSurface('<body class="dark bg-slate-950"><div class="border-black/10">x</div></body>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.message).toContain("dark-mode");
+  });
+
+  it("does NOT flag border-white/10 on a DARK document (it is the correct hairline there)", () => {
+    expect(checkModeInvisibleSurface('<body class="dark bg-black"><div class="border-white/10">x</div></body>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a visible-alpha tint (border-white/20 ≥ 0.15)", () => {
+    expect(checkModeInvisibleSurface('<body class="bg-white"><div class="border-white/20">x</div></body>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a low-alpha WHITE text tint (text is not a surface boundary)", () => {
+    expect(checkModeInvisibleSurface('<div class="text-white/10">x</div>')).toHaveLength(0);
+  });
+});
+
+// ─── z-index-off-ladder (Depth/Surface / warning) ───────────────────────────────
+
+describe("z-index-off-ladder", () => {
+  it("flags an off-ladder value (z-index: 47)", () => {
+    const f = checkZIndexOffLadder("<style>.m{z-index:47}</style>");
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("z-index-off-ladder");
+    expect(f[0]?.axis).toBe("Depth/Surface");
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("flags 275 but NOT 100 / 1000 (base-10 ladder steps pass)", () => {
+    expect(checkZIndexOffLadder("<style>.a{z-index:275}</style>")).toHaveLength(1);
+    expect(checkZIndexOffLadder("<style>.a{z-index:100}.b{z-index:1000}</style>")).toHaveLength(0);
+  });
+
+  it("does NOT flag single-digit local stacking (z-index 1–9)", () => {
+    expect(checkZIndexOffLadder("<style>.a{z-index:1}.b{z-index:9}</style>")).toHaveLength(0);
+  });
+
+  it("does NOT flag a clean 10/20/30/40/50 ladder", () => {
+    expect(checkZIndexOffLadder("<style>.a{z-index:10}.b{z-index:20}.c{z-index:50}</style>")).toHaveLength(0);
+  });
+
+  it("does NOT double-report all-nines (that is z-index-inflation's error)", () => {
+    expect(checkZIndexOffLadder("<style>.a{z-index:9999}</style>")).toHaveLength(0);
+  });
+});
+
+// ─── lintTaste wiring — registration + severity split ───────────────────────────
+
+describe("lintTaste — P2 web-craft lints wired", () => {
+  it("registers all three and keeps the severity split (invisible-surface error, off-ladder warning)", () => {
+    const html = [
+      '<body class="bg-white">',
+      '<div class="border-white/10">x</div>',
+      "<style>.m{z-index:47}</style>",
+      nSizes(8),
+      "</body>",
+    ].join("\n");
+    const r = lintTaste(html);
+    const ids = new Set(r.findings.map((f) => f.checkId));
+    expect(ids.has("mode-invisible-surface")).toBe(true);
+    expect(ids.has("z-index-off-ladder")).toBe(true);
+    expect(ids.has("font-scale-sprawl")).toBe(true);
+    expect(r.errorCount).toBeGreaterThanOrEqual(1); // mode-invisible-surface
+    expect(r.warningCount).toBeGreaterThanOrEqual(2); // off-ladder + font-scale
+  });
+
+  it("clean DS-faithful markup trips none of the three", () => {
+    const clean = '<body class="bg-white"><div class="border border-slate-200"><p class="text-sm">Hi</p></div></body>';
+    const r = lintTaste(clean);
+    const ids = new Set(r.findings.map((f) => f.checkId));
+    expect(ids.has("mode-invisible-surface")).toBe(false);
+    expect(ids.has("z-index-off-ladder")).toBe(false);
+    expect(ids.has("font-scale-sprawl")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Spec 003 P2 — remaining web craft lints

Five deterministic lints distilled from the plan (§P2). Each is a pure per-concern
module (<200 lines), registered in its linter, paired with a knowledge line, and
tested with fixtures firing every prong plus passing negatives.

| Lint | Linter | Severity | Signal |
|------|--------|----------|--------|
| `font-scale-sprawl` | taste-lint (Typography) | warn >7 / error >10 | distinct hand-picked font sizes; named steps + `var()` tokens excluded |
| `mode-invisible-surface` | taste-lint (Depth/Surface) | error | sub-15%-alpha white surface on a light page (black on dark); bails on mixed-mode |
| `z-index-off-ladder` | taste-lint (Depth/Surface) | warning | `z-index` above single-digit stacking, off any base-10 ladder step |
| `clickable-no-pointer` | validate-layout | warning | non-native clickable with no `cursor:pointer` |
| `font-display-missing` | validate-layout | warning | `@font-face` / Google-Fonts `<link>` with no `font-display` / `display=` → FOIT |

`unbounded-measure` is intentionally deferred (D3-gated, awaiting owner).

### Precision note — mode-invisible-surface
Dogfood surfaced that the lab marketing rebuilds are **mixed-mode** (light body,
dark hero/section) and use `border-white/10` correctly on their dark sections. A
single global mode cannot prove which surface a given tint sits on, so the check
now **bails on any page carrying both modes** rather than risk a false positive —
it fires only on unambiguously single-mode pages. Two detection bugs were fixed in
the process (`\bdark\b` matching the `--color-base-dark` token name; `bg-black`
matching a `selection:bg-black/10` variant).

### Verification
- 4 gates green (typecheck, lint, build, `npm test` — 1777 pass / 4 skip, +32 P2 tests) and `ui knowledge check` — 0 findings.
- Dogfood over 13 lab rebuilds: `font-scale-sprawl` fires on 7 (composio 13 sizes → error), `font-display-missing` on 11; `mode-invisible-surface`, `z-index-off-ladder`, `clickable-no-pointer` correctly stay silent on this disciplined/mixed-mode corpus (unit tests prove each fires).