### PR TITLE
feat: mobile machine floor — five responsive-web mobile lints (spec 003 P3)

### DIFF
--- a/knowledge/accessibility.md
+++ b/knowledge/accessibility.md
@@ -26,8 +26,13 @@ handoff. Neither, alone or together, is a conformance verdict.
 
 - **`ui a11y-lint <file.html>`** — structural / markup WCAG checks over the HTML AST:
   missing `alt` attribute, an icon-only control with no accessible name, missing `lang`,
-  a label-less input, a redirect-only stub, and similar *presence/absence* facts the source
-  states outright. Precision-first: a finding is a real defect, and a pass is **not** a
+  a label-less input, a redirect-only stub, a viewport meta that blocks zoom
+  (`viewport-zoom-blocked`, 1.4.4) **or is missing entirely on a responsive document**
+  (`viewport-meta-missing`, 1.4.10 Reflow — without it a mobile browser renders at a fake
+  ~980px desktop width, so the breakpoints never fire), and similar *presence/absence* facts
+  the source states outright. Precision-first: `viewport-meta-missing` fires only when the
+  markup shows mobile intent (a responsive breakpoint class or a width media query), so a
+  print/desktop-only page is never nagged. A finding is a real defect, and a pass is **not** a
   conformance claim.
 - **`ui ds a11y`** — token-pair contrast. It checks the **declared** `{role}` /
   `{role}-foreground` pairs at ≥ AA using color math, exactly because the paired *name*

--- a/knowledge/mode-constraints.md
+++ b/knowledge/mode-constraints.md
@@ -94,6 +94,26 @@ Target: a single mobile screen.
 - **States:** Any data view requires a skeleton loading state (`animate-pulse`) **and** an
   empty state. Errors require a retry button.
 
+**Machine floor (responsive-web mobile).** These reliability rules are enforced by
+`ui validate-layout` / `ui a11y-lint` on ANY HTML — the mobile mode above is where they bite
+hardest, but a responsive desktop page that reflows to a phone owes them too:
+
+- **Tap spacing (`tap-spacing-cramped`):** adjacent tappables in a flex/grid row or stack need
+  a gap of **at least 8 px** (`gap-2`). A `gap-0`/`gap-1` row of controls invites mis-taps —
+  fingers are wider than a cursor. WHY: sub-8px spacing is the top touch-reliability failure.
+- **Input font (`input-font-below-16`):** a text-entry `<input>`/`<textarea>`/`<select>` must
+  render at **16 px or larger**. WHY: iOS Safari auto-zooms the page when a focused control is
+  under 16 px and does not zoom back out — a `text-sm` field is the classic offender.
+- **Safe area (`edge-bar-no-safe-area`):** a `fixed`/`sticky` bar anchored to the **bottom**
+  viewport edge (a bottom tab bar, a sticky CTA) must pad the system inset with
+  `env(safe-area-inset-bottom)`. WHY: without it the bar sits under the home indicator on
+  modern phones, hiding its own controls. (A top-0 sticky header is not flagged — the top
+  inset only bites in standalone/PWA mode, which static markup cannot prove.)
+- **Viewport height (`dvh-over-100vh`):** a full-viewport container uses **`100dvh`**
+  (`h-dvh` / `min-h-dvh`), never `100vh` / `h-screen`. WHY: the mobile URL bar resizes the
+  visual viewport, so `100vh` clips content then jumps as the bar collapses; the dynamic unit
+  tracks the real viewport.
+
 ## Desktop
 
 Default for web pages — landing, portfolio, documentation, marketing, social.

--- a/src/core/a11y-checks.ts
+++ b/src/core/a11y-checks.ts
@@ -80,6 +80,29 @@ export function checkViewportZoom(html: string): A11yFinding[] {
   return out;
 }
 
+// ── 1.4.10 Reflow: a mobile-responsive doc must declare a viewport meta ──
+/** Mobile-intent signals: a responsive breakpoint prefix or a width-based media query. */
+const MOBILE_INTENT = /\b(?:sm|md|lg|xl|2xl):[a-z[]/i;
+const WIDTH_MEDIA = /@media[^{]*\(\s*(?:max|min)-width/i;
+
+/**
+ * checkViewportMetaPresent — the companion to checkViewportZoom (which flags a meta
+ * that BLOCKS zoom). This flags a meta that is entirely MISSING on a document that
+ * is clearly built to be responsive. Without `<meta name="viewport"
+ * content="width=device-width…">`, mobile browsers render at a fake ~980px desktop
+ * width and downscale, so the responsive breakpoints never fire. Precision-first:
+ * only fires when the markup shows mobile intent (a responsive breakpoint class or a
+ * width media query), so a print/email/desktop-only page is never nagged.
+ */
+export function checkViewportMetaPresent(html: string): A11yFinding[] {
+  if (isRedirectStub(html)) return [];
+  if (/<meta\b[^>]*name\s*=\s*("|')?viewport\1?/i.test(html)) return [];
+  if (!MOBILE_INTENT.test(html) && !WIDTH_MEDIA.test(html)) return [];
+  return [{ checkId: "viewport-meta-missing", severity: "warning", sc: "1.4.10",
+    message: "a responsive document has no <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"> — mobile browsers render it at a fake ~980px desktop width and downscale, so the breakpoints never fire",
+    line: 1 }];
+}
+
 // ── 4.1.2 / 2.4.4 Icon/emoji controls need an accessible name ──
 const ICON_GLYPHS = "×✕✓✔▶◀▲▼☰≡⋮⋯…→←↑↓«»‹›⌄⌃✚＋−✖☆★♥♡⚙🔍";
 // eslint-disable-next-line no-misleading-character-class

--- a/src/core/a11y-lint.ts
+++ b/src/core/a11y-lint.ts
@@ -4,7 +4,8 @@
  *
  * Scope is deliberately narrow: only WCAG criteria decidable from static markup with
  * near-zero false positives (alt presence, page language, title, positive tabindex,
- * viewport zoom, unnamed icon/emoji controls, heading hierarchy). Everything requiring
+ * viewport zoom, missing viewport meta on a responsive doc, unnamed icon/emoji
+ * controls, heading hierarchy). Everything requiring
  * a rendered DOM (real contrast, focus visibility, focus ORDER meaning) is Tier 2
  * (a browser workspace); everything requiring judgment (alt *quality*) is human.
  *
@@ -13,7 +14,7 @@
  */
 import {
   checkImgAlt, checkHtmlLang, checkDocumentTitle, checkPositiveTabindex,
-  checkViewportZoom, checkIconControlUnnamed, checkHeadingHierarchy,
+  checkViewportZoom, checkViewportMetaPresent, checkIconControlUnnamed, checkHeadingHierarchy,
 } from "./a11y-checks.js";
 
 export type A11ySeverity = "error" | "warning";
@@ -39,6 +40,7 @@ const CHECKS = [
   checkDocumentTitle,
   checkPositiveTabindex,
   checkViewportZoom,
+  checkViewportMetaPresent,
   checkIconControlUnnamed,
   checkHeadingHierarchy,
 ];

--- a/src/core/layout-checks-mobile.ts
+++ b/src/core/layout-checks-mobile.ts
@@ -1,0 +1,165 @@
+/**
+ * Mobile machine floor (spec 003 P3) — three responsive-web mobile-reliability
+ * checks a static parser can decide with high precision:
+ *
+ *   tap-spacing-cramped   (warning) — an interactive flex/grid container whose
+ *     gap resolves under 8px, so adjacent tappables sit too close (mis-tap).
+ *   input-font-below-16   (warning) — a text-entry <input>/<textarea>/<select>
+ *     with a font-size under 16px → iOS Safari zooms the page on focus.
+ *   edge-bar-no-safe-area (warning) — a fixed/sticky bar anchored to the BOTTOM
+ *     viewport edge with no env(safe-area-inset-*) → it collides with the home
+ *     indicator on modern phones. (Top-0 headers are intentionally not flagged —
+ *     see BOTTOM_ANCHOR; the top inset only bites in undetectable standalone/PWA.)
+ *
+ * Registered as warnings in layout-lint.ts (the document still renders). Pure
+ * string/regex — no DOM, no deps. Precision-first: each fires only on POSITIVE
+ * markup evidence; ambiguous cases are left un-flagged. M1 (touch-target size)
+ * ships separately as tap-target-undersized (taste-checks-tap-target.ts) — one
+ * home per rule; this module does not duplicate it.
+ */
+import type { LayoutFinding } from "./layout-lint.js";
+import { cssRegions, cssRules, lineOf } from "./taste-checks-shared.js";
+
+// ─── shared ─────────────────────────────────────────────────────────────────────
+
+/** The lower-cased class list value of an opening tag's attribute string. */
+function classAttr(attrs: string): string {
+  const m = /\bclass\s*=\s*["']([^"']*)["']/i.exec(attrs);
+  return (m?.[1] ?? "").toLowerCase();
+}
+
+/** Count distinct interactive controls in an inner-HTML slice (each element once). */
+function countInteractiveControls(inner: string): number {
+  let n = 0;
+  for (const m of inner.matchAll(/<([a-zA-Z][\w-]*)\b([^>]*)>/g)) {
+    const tag = (m[1] ?? "").toLowerCase();
+    if (tag === "button" || tag === "a" || tag === "input" || tag === "select" || tag === "textarea") n++;
+    else if (/\brole\s*=\s*["']?button\b/i.test(m[2] ?? "")) n++;
+  }
+  return n;
+}
+
+// ─── tap-spacing-cramped ──────────────────────────────────────────────────────────
+
+/** A flex or grid container (matches `flex`, `flex-col`, `grid`, `grid-cols-*`, inline). */
+const FLEX_OR_GRID = /\b(?:inline-)?(?:flex|grid)\b/i;
+/** A gap utility / inline gap resolving under 8px: gap-0, gap-0.5 (2px), gap-1 (4px), gap-[0-7px], gap:0|1-7px. */
+const SMALL_GAP =
+  /\bgap(?:-[xy])?-(?:0(?:\.5)?|1)\b|\bgap(?:-[xy])?-\[[0-7](?:\.\d+)?px\]|(?:^|[;"'\s])gap\s*:\s*(?:0|[1-7](?:\.\d+)?px)\b/i;
+
+/**
+ * tap-spacing-cramped: an interactive flex/grid container laying out two or more
+ * tappable controls with a gap under the 8px touch-spacing floor. Only fires when
+ * BOTH a flex/grid class and an explicit small-gap token are present AND the
+ * container holds ≥2 interactive controls — a container with no declared gap is
+ * never flagged (it may space via padding/margin). Inner HTML is captured to the
+ * first matching close tag (under-captures on nesting → misses, never over-flags).
+ */
+export function checkTapSpacingCramped(html: string): LayoutFinding[] {
+  const findings: LayoutFinding[] = [];
+  const lower = html.toLowerCase();
+  const re = /<(div|nav|ul|ol|header|footer|section|form|menu)\b([^>]*)>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    const attrs = m[2] ?? "";
+    if (!FLEX_OR_GRID.test(classAttr(attrs))) continue;
+    if (!SMALL_GAP.test(attrs)) continue;
+    const tag = (m[1] ?? "").toLowerCase();
+    const closeIdx = lower.indexOf(`</${tag}>`, re.lastIndex);
+    const inner = closeIdx === -1 ? html.slice(re.lastIndex) : html.slice(re.lastIndex, closeIdx);
+    if (countInteractiveControls(inner) < 2) continue;
+    findings.push({
+      checkId: "tap-spacing-cramped", severity: "warning",
+      message: `interactive <${tag}> lays out ≥2 controls with a gap under the 8px touch-spacing floor — adjacent tappables this close invite mis-taps; raise to gap-2 (8px) or more`,
+      line: lineOf(html, m.index),
+    });
+  }
+  return findings;
+}
+
+// ─── input-font-below-16 ────────────────────────────────────────────────────────
+
+/** Input types that take no text focus, so iOS never zooms them. */
+const NON_TEXT_INPUT = /\btype\s*=\s*["']?(?:checkbox|radio|hidden|range|color|submit|button|reset|file|image)\b/i;
+/** A sub-16px font: text-xs (12) / text-sm (14) always, or an explicit px value. */
+const SUB16_FONT = /\btext-(?:xs|sm)\b|\btext-\[(\d+(?:\.\d+)?)px\]|font-size\s*:\s*(\d+(?:\.\d+)?)px/i;
+
+/**
+ * input-font-below-16: a text-entry `<input>` / `<textarea>` / `<select>` whose
+ * font-size is under 16px. iOS Safari auto-zooms the viewport when a focused
+ * control's text is below 16px, then does not zoom back out — a jarring mobile
+ * defect. `text-xs`/`text-sm` always flag; an arbitrary/inline px size flags only
+ * when the number is < 16. Non-text input types (checkbox, submit, …) are skipped.
+ */
+export function checkInputFontBelow16(html: string): LayoutFinding[] {
+  const findings: LayoutFinding[] = [];
+  for (const m of html.matchAll(/<(input|textarea|select)\b([^>]*)>/gi)) {
+    const tag = (m[1] ?? "").toLowerCase();
+    const attrs = m[2] ?? "";
+    if (tag === "input" && NON_TEXT_INPUT.test(attrs)) continue;
+    const sm = SUB16_FONT.exec(attrs);
+    if (sm === null) continue;
+    const px = sm[1] ?? sm[2];
+    if (px !== undefined && parseFloat(px) >= 16) continue;
+    findings.push({
+      checkId: "input-font-below-16", severity: "warning",
+      message: `<${tag}> uses a font-size below 16px — iOS Safari zooms the page (and stays zoomed) when a control under 16px gains focus; set text-base (16px) or larger on form controls`,
+      line: lineOf(html, m.index),
+    });
+  }
+  return findings;
+}
+
+// ─── edge-bar-no-safe-area ──────────────────────────────────────────────────────
+
+const POSITIONED = /\b(?:fixed|sticky)\b|position\s*:\s*(?:fixed|sticky)/i;
+/**
+ * Anchored to the BOTTOM viewport edge: bottom-0 utility, or inline bottom:0.
+ * Precision decision (dogfood): the top edge is deliberately excluded — a sticky
+ * top-0 header is near-universal and, in normal browser chrome, sits below the
+ * status-bar/notch area (the top inset only bites in standalone/PWA, undetectable
+ * statically). The bottom home-indicator collision is the real, high-signal bug,
+ * so only the bottom edge (and bottom-bar names) flags.
+ */
+const BOTTOM_ANCHOR = /\bbottom-0\b|(?:^|[;"'\s])bottom\s*:\s*0\b/i;
+/** A bar whose name marks it as bottom chrome. */
+const BAR_HINT = /\b(?:tab-?bar|bottom-?nav|bottom-?bar|cta-?bar)\b/i;
+/** The element itself pads for the safe area (inline env(), or a pb-/pt-safe utility). */
+const ELEMENT_SAFE = /env\(\s*safe-area-inset|\bp[btxy]?-safe\b|\bp[btxy]?-\[env\(/i;
+
+/** Classes whose CSS rule pads for the safe area (env(safe-area-inset)/safe-area). */
+function safeAreaClasses(css: string): Set<string> {
+  const out = new Set<string>();
+  for (const { selector, body } of cssRules(css)) {
+    if (!/env\(\s*safe-area-inset|safe-area/i.test(body)) continue;
+    for (const c of selector.matchAll(/\.([\w-]+)/g)) out.add((c[1] ?? "").toLowerCase());
+  }
+  return out;
+}
+
+/**
+ * edge-bar-no-safe-area: a `fixed`/`sticky` element anchored to the bottom viewport
+ * edge (bottom-0), or a named bottom bar (tab-bar/bottom-nav/cta-bar), that never
+ * applies `env(safe-area-inset-*)`. On home-indicator phones such a bar overlaps the
+ * system inset. Exempt when the element pads for the safe area itself or via a CSS
+ * rule on one of its classes (precision-first — the author handled it).
+ */
+export function checkEdgeBarNoSafeArea(html: string): LayoutFinding[] {
+  const findings: LayoutFinding[] = [];
+  const safeClasses = safeAreaClasses(cssRegions(html));
+  for (const m of html.matchAll(/<([a-zA-Z][\w-]*)\b([^>]*)>/g)) {
+    const tag = (m[1] ?? "").toLowerCase();
+    const attrs = m[2] ?? "";
+    if (!POSITIONED.test(attrs)) continue;
+    const cls = classAttr(attrs);
+    if (!BOTTOM_ANCHOR.test(attrs) && !BAR_HINT.test(cls)) continue;
+    if (ELEMENT_SAFE.test(attrs)) continue;
+    if (cls.split(/\s+/).some((c) => safeClasses.has(c))) continue;
+    findings.push({
+      checkId: "edge-bar-no-safe-area", severity: "warning",
+      message: `<${tag}> is a fixed/sticky bar at the bottom viewport edge with no env(safe-area-inset-*) — it overlaps the home indicator on modern phones; add padding-bottom: env(safe-area-inset-bottom)`,
+      line: lineOf(html, m.index),
+    });
+  }
+  return findings;
+}

--- a/src/core/layout-checks-viewport.ts
+++ b/src/core/layout-checks-viewport.ts
@@ -1,8 +1,9 @@
 /**
- * Viewport/overflow layout checks — the two horizontal-overflow
+ * Viewport/overflow layout checks — the horizontal-overflow and viewport-height
  * tells the existing layout checks do not cover: a `100vw` width inside a
- * `<style>` rule (the scrollbar-gutter overflow trap) and `overflow-x: hidden` on
- * a root element (which silently breaks `position: sticky` descendants).
+ * `<style>` rule (the scrollbar-gutter overflow trap), `overflow-x: hidden` on
+ * a root element (which silently breaks `position: sticky` descendants), and a
+ * `100vh` / `h-screen` full-viewport height (the mobile URL-chrome jump — M6).
  *
  * Split into its own module (layout-checks.ts is already over the 200-line
  * guideline). Both are `warning`-severity: the document still renders. Reuses the
@@ -10,7 +11,7 @@
  * imports nothing back). Pure string/regex — no DOM, no deps.
  */
 import type { LayoutFinding } from "./layout-lint.js";
-import { cssRegions, cssRules } from "./taste-checks-shared.js";
+import { cssRegions, cssRules, lineOf } from "./taste-checks-shared.js";
 
 // ─── width: 100vw (scrollbar-gutter overflow) ───────────────────────────────────
 
@@ -62,6 +63,46 @@ export function checkRootOverflowXHidden(html: string): LayoutFinding[] {
     let message = `overflow-x: hidden on ${selector} — hidden breaks position:sticky descendants; use overflow-x: clip (same clipping, sticky survives)`;
     if (usesSticky) message += ` (this page USES sticky — it is broken right now)`;
     findings.push({ checkId: "root-overflow-x-hidden", severity: "warning", message });
+  }
+  return findings;
+}
+
+// ─── height: 100vh / h-screen (mobile URL-chrome jump — spec 003 M6) ─────────────
+
+/** A `height`/`min-height`/`max-height` declaration whose value uses 100vh. */
+const HEIGHT_100VH = /(?:^|[{;])\s*(?:min-|max-)?height\s*:\s*[^;}]*\b100vh\b/gi;
+/** The Tailwind full-viewport-height utilities: h-screen / min-h-screen / max-h-screen. */
+const SCREEN_UTIL = /\b(?:min-|max-)?h-screen\b/gi;
+
+/**
+ * dvh-over-100vh: a full-viewport height fixed to `100vh` — either a CSS
+ * `height:100vh` declaration or a Tailwind `h-screen` / `min-h-screen` utility.
+ * On mobile the URL bar shows and hides, changing the visual viewport: `100vh` is
+ * sized to the LARGER (URL-bar-hidden) state, so content is clipped while the bar
+ * is visible and the layout jumps as it collapses. The dynamic-viewport unit
+ * `100dvh` (Tailwind `h-dvh` / `min-h-dvh`) tracks the real viewport and removes
+ * the jump. CSS matches carry no line (cssRegions is offset-free); utility matches
+ * carry a line. Precision-first: only the exact full-viewport value flags — a
+ * `min-h-[80vh]` hero is untouched.
+ */
+export function checkDvhOver100vh(html: string): LayoutFinding[] {
+  const findings: LayoutFinding[] = [];
+  const css = cssRegions(html);
+  HEIGHT_100VH.lastIndex = 0;
+  while (HEIGHT_100VH.exec(css) !== null) {
+    findings.push({
+      checkId: "dvh-over-100vh", severity: "warning",
+      message: `height uses 100vh — on mobile the URL bar resizes the viewport, so 100vh clips content then jumps as the bar collapses; use 100dvh (dynamic viewport height)`,
+    });
+  }
+  SCREEN_UTIL.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SCREEN_UTIL.exec(html)) !== null) {
+    findings.push({
+      checkId: "dvh-over-100vh", severity: "warning",
+      message: `${m[0]} is 100vh — on mobile the URL bar resizes the viewport, so it clips content then jumps as the bar collapses; use the dynamic-viewport utility (h-dvh / min-h-dvh)`,
+      line: lineOf(html, m.index),
+    });
   }
   return findings;
 }

--- a/src/core/layout-lint.ts
+++ b/src/core/layout-lint.ts
@@ -1,7 +1,7 @@
 /**
  * Static HTML layout linter — pure string/regex heuristics, zero deps.
  *
- * Runs 15 checks against an HTML string and returns a structured result.
+ * Runs every registered check against an HTML string and returns a structured result.
  * All checks are documented as heuristic approximations (no DOM parser, no
  * browser, no rendering). See layout-checks.ts for individual check logic.
  *
@@ -24,9 +24,14 @@ import {
   checkImgNoDimensions,
   checkEmptyFlexGrid,
 } from "./layout-checks.js";
-import { checkCss100vwWidth, checkRootOverflowXHidden } from "./layout-checks-viewport.js";
+import { checkCss100vwWidth, checkRootOverflowXHidden, checkDvhOver100vh } from "./layout-checks-viewport.js";
 import { checkAvoidableScreenshotCrop } from "./layout-checks-delivery.js";
 import { checkClickableNoPointer, checkFontDisplayMissing } from "./layout-checks-craft.js";
+import {
+  checkTapSpacingCramped,
+  checkInputFontBelow16,
+  checkEdgeBarNoSafeArea,
+} from "./layout-checks-mobile.js";
 import { isRedirectStub } from "./redirect-stub.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -69,6 +74,7 @@ const WARNING_CHECKS = [
   checkViewportUnitOnBody,
   checkCss100vwWidth,
   checkRootOverflowXHidden,
+  checkDvhOver100vh,
   checkNestedScrollContainer,
   checkAbsoluteWithoutRelative,
   checkImgNoDimensions,
@@ -77,6 +83,10 @@ const WARNING_CHECKS = [
   // Web craft lints (spec 003 P2): functional affordance/loading bugs, not layout structure.
   checkClickableNoPointer,
   checkFontDisplayMissing,
+  // Mobile machine floor (spec 003 P3): responsive-web mobile-reliability warnings.
+  checkTapSpacingCramped,
+  checkInputFontBelow16,
+  checkEdgeBarNoSafeArea,
 ] as const;
 
 // ─── Orchestrator ─────────────────────────────────────────────────────────────
@@ -90,7 +100,7 @@ function stripCommentsPreservingOffsets(html: string): string {
   return html.replace(/<!--[\s\S]*?-->/g, (match) => " ".repeat(match.length));
 }
 
-/** Run all 15 checks and return findings sorted errors-first, then warnings. */
+/** Run every registered check and return findings sorted errors-first, then warnings. */
 export function lintLayout(html: string): LayoutLintResult {
   // L4 dogfood: a redirect stub intentionally has no <html>/<body>, so every structural
   // check below is noise on it — short-circuit before running any of the other checks.

--- a/tests/a11y-lint.test.ts
+++ b/tests/a11y-lint.test.ts
@@ -5,7 +5,7 @@ import { writeFileSync, mkdtempSync } from "node:fs";
 import { lintA11y } from "../src/core/a11y-lint.js";
 import {
   checkImgAlt, checkHtmlLang, checkDocumentTitle, checkPositiveTabindex,
-  checkViewportZoom, checkIconControlUnnamed, checkHeadingHierarchy,
+  checkViewportZoom, checkViewportMetaPresent, checkIconControlUnnamed, checkHeadingHierarchy,
   isRedirectStub,
 } from "../src/core/a11y-checks.js";
 import { run } from "../src/cli.js";
@@ -37,6 +37,18 @@ describe("a11y-checks — per rule", () => {
     expect(checkViewportZoom('<meta name="viewport" content="width=device-width, user-scalable=no">')).toHaveLength(1);
     expect(checkViewportZoom('<meta name="viewport" content="width=device-width, maximum-scale=1">')).toHaveLength(1);
     expect(checkViewportZoom('<meta name="viewport" content="width=device-width, initial-scale=1">')).toHaveLength(0);
+  });
+  it("viewport-meta-missing fires on a responsive doc with no viewport meta (M3)", () => {
+    // Responsive-intent signal (a breakpoint class) but no viewport meta → fires.
+    expect(ids(checkViewportMetaPresent('<html><body><div class="md:flex">x</div></body></html>'))).toContain("viewport-meta-missing");
+    // A width-based media query is also mobile intent.
+    expect(checkViewportMetaPresent("<style>@media (max-width:640px){.a{display:none}}</style>")).toHaveLength(1);
+    // Present viewport meta → never fires (checkViewportZoom owns the bad-content case).
+    expect(checkViewportMetaPresent('<meta name="viewport" content="width=device-width, initial-scale=1"><div class="md:flex"></div>')).toHaveLength(0);
+    // No mobile intent → not nagged (precision-first: print/desktop-only page).
+    expect(checkViewportMetaPresent("<html><body><h1>Static doc</h1></body></html>")).toHaveLength(0);
+    // A redirect stub is exempt.
+    expect(checkViewportMetaPresent('<!doctype html><meta http-equiv="refresh" content="0; url=x.html">')).toHaveLength(0);
   });
   it("icon-control-unnamed catches emoji/glyph and icon-only controls, exempts named ones", () => {
     expect(checkIconControlUnnamed("<button>☰</button>")).toHaveLength(1); // emoji-as-control (the dogfood)

--- a/tests/layout-checks-mobile.test.ts
+++ b/tests/layout-checks-mobile.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The spec-003 P3 mobile machine floor:
+ *   tap-spacing-cramped    (warning) — layout-checks-mobile.ts   (M2)
+ *   input-font-below-16    (warning) — layout-checks-mobile.ts   (M4)
+ *   edge-bar-no-safe-area  (warning) — layout-checks-mobile.ts   (M5)
+ *   dvh-over-100vh         (warning) — layout-checks-viewport.ts (M6)
+ * Fixtures fire each prong plus passing negatives, then a wiring block drives them
+ * through lintLayout() to prove registration (all warnings — exit stays green).
+ * M1 (tap-target-undersized) lives in taste-checks-tap-target.ts — not retested here.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  checkTapSpacingCramped,
+  checkInputFontBelow16,
+  checkEdgeBarNoSafeArea,
+} from "../src/core/layout-checks-mobile.js";
+import { checkDvhOver100vh } from "../src/core/layout-checks-viewport.js";
+import { lintLayout } from "../src/core/layout-lint.js";
+
+// ─── M2 tap-spacing-cramped (warning) ────────────────────────────────────────────
+
+describe("tap-spacing-cramped", () => {
+  it("flags a flex row of 2+ controls with gap-1 (<8px)", () => {
+    const f = checkTapSpacingCramped('<div class="flex gap-1"><button>A</button><button>B</button></div>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("tap-spacing-cramped");
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("flags gap-0 and inline gap:4px too", () => {
+    expect(checkTapSpacingCramped('<nav class="grid gap-0"><a href="#">1</a><a href="#">2</a></nav>')).toHaveLength(1);
+    expect(checkTapSpacingCramped('<div class="flex" style="gap:4px"><button>1</button><button>2</button></div>')).toHaveLength(1);
+  });
+
+  it("does NOT flag gap-2 (8px, on the floor)", () => {
+    expect(checkTapSpacingCramped('<div class="flex gap-2"><button>A</button><button>B</button></div>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a small gap with only ONE control", () => {
+    expect(checkTapSpacingCramped('<div class="flex gap-1"><button>A</button><span>label</span></div>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a flex container with no declared gap", () => {
+    expect(checkTapSpacingCramped('<div class="flex"><button>A</button><button>B</button></div>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a non-flex/grid container", () => {
+    expect(checkTapSpacingCramped('<div class="gap-1"><button>A</button><button>B</button></div>')).toHaveLength(0);
+  });
+
+  it("does NOT confuse gap-10 (40px) for gap-1", () => {
+    expect(checkTapSpacingCramped('<div class="flex gap-10"><button>A</button><button>B</button></div>')).toHaveLength(0);
+  });
+});
+
+// ─── M4 input-font-below-16 (warning) ────────────────────────────────────────────
+
+describe("input-font-below-16", () => {
+  it("flags text-sm on an <input>", () => {
+    const f = checkInputFontBelow16('<input type="text" class="text-sm">');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("input-font-below-16");
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("flags text-xs, an arbitrary sub-16px size, and a <textarea>/<select>", () => {
+    expect(checkInputFontBelow16('<input class="text-xs">')).toHaveLength(1);
+    expect(checkInputFontBelow16('<input class="text-[14px]">')).toHaveLength(1);
+    expect(checkInputFontBelow16('<textarea style="font-size:13px"></textarea>')).toHaveLength(1);
+    expect(checkInputFontBelow16('<select class="text-sm"></select>')).toHaveLength(1);
+  });
+
+  it("does NOT flag text-base (16px) or a ≥16px arbitrary size", () => {
+    expect(checkInputFontBelow16('<input class="text-base">')).toHaveLength(0);
+    expect(checkInputFontBelow16('<input class="text-[16px]">')).toHaveLength(0);
+    expect(checkInputFontBelow16('<input class="text-[18px]">')).toHaveLength(0);
+  });
+
+  it("does NOT flag a non-text input (checkbox/submit) even with text-sm", () => {
+    expect(checkInputFontBelow16('<input type="checkbox" class="text-sm">')).toHaveLength(0);
+    expect(checkInputFontBelow16('<input type="submit" class="text-xs">')).toHaveLength(0);
+  });
+
+  it("does NOT flag an input with no declared font-size", () => {
+    expect(checkInputFontBelow16('<input type="text" class="rounded border">')).toHaveLength(0);
+  });
+});
+
+// ─── M5 edge-bar-no-safe-area (warning) ──────────────────────────────────────────
+
+describe("edge-bar-no-safe-area", () => {
+  it("flags a fixed bottom-0 bar with no safe-area padding", () => {
+    const f = checkEdgeBarNoSafeArea('<nav class="fixed bottom-0 inset-x-0"><a href="#">Home</a></nav>');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("edge-bar-no-safe-area");
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("flags a named bottom tab-bar", () => {
+    expect(checkEdgeBarNoSafeArea('<div class="fixed tab-bar">x</div>')).toHaveLength(1);
+  });
+
+  it("does NOT flag a sticky top-0 header (precision: top inset only bites in standalone/PWA)", () => {
+    expect(checkEdgeBarNoSafeArea('<header class="sticky top-0">x</header>')).toHaveLength(0);
+  });
+
+  it("does NOT flag when the element pads for the safe area itself", () => {
+    expect(checkEdgeBarNoSafeArea('<nav class="fixed bottom-0" style="padding-bottom:env(safe-area-inset-bottom)">x</nav>')).toHaveLength(0);
+    expect(checkEdgeBarNoSafeArea('<nav class="fixed bottom-0 pb-safe">x</nav>')).toHaveLength(0);
+  });
+
+  it("does NOT flag when a CSS rule on the element's class handles the safe area", () => {
+    const html = '<style>.tabbar{padding-bottom:env(safe-area-inset-bottom)}</style><nav class="fixed bottom-0 tabbar">x</nav>';
+    expect(checkEdgeBarNoSafeArea(html)).toHaveLength(0);
+  });
+
+  it("does NOT flag a fixed element that is not at a viewport edge", () => {
+    expect(checkEdgeBarNoSafeArea('<div class="fixed right-4 bottom-8">tooltip</div>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a non-positioned bar", () => {
+    expect(checkEdgeBarNoSafeArea('<nav class="flex bottom-0">x</nav>')).toHaveLength(0);
+  });
+});
+
+// ─── M6 dvh-over-100vh (warning) ─────────────────────────────────────────────────
+
+describe("dvh-over-100vh", () => {
+  it("flags a CSS height:100vh declaration", () => {
+    const f = checkDvhOver100vh("<style>.hero{min-height:100vh}</style>");
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("dvh-over-100vh");
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("flags h-screen / min-h-screen utilities", () => {
+    expect(checkDvhOver100vh('<div class="h-screen"></div>')).toHaveLength(1);
+    expect(checkDvhOver100vh('<section class="min-h-screen"></section>')).toHaveLength(1);
+  });
+
+  it("does NOT flag the dynamic-viewport equivalents", () => {
+    expect(checkDvhOver100vh("<style>.hero{min-height:100dvh}</style>")).toHaveLength(0);
+    expect(checkDvhOver100vh('<div class="min-h-dvh"></div>')).toHaveLength(0);
+  });
+
+  it("does NOT flag a non-full-viewport height (80vh)", () => {
+    expect(checkDvhOver100vh('<div class="min-h-[80vh]"></div>')).toHaveLength(0);
+    expect(checkDvhOver100vh("<style>.a{height:80vh}</style>")).toHaveLength(0);
+  });
+});
+
+// ─── lintLayout wiring — all warnings, exit stays green ───────────────────────────
+
+describe("lintLayout — P3 mobile floor wired as warnings", () => {
+  it("registers all four and none bumps errorCount", () => {
+    const html = [
+      "<!doctype html><html><body>",
+      '<div class="flex gap-1"><button>A</button><button>B</button></div>',
+      '<input type="text" class="text-sm">',
+      '<nav class="fixed bottom-0 inset-x-0"><a href="#">Home</a></nav>',
+      '<section class="min-h-screen">hero</section>',
+      "</body></html>",
+    ].join("\n");
+    const r = lintLayout(html);
+    const found = new Set(r.findings.map((f) => f.checkId));
+    for (const id of ["tap-spacing-cramped", "input-font-below-16", "edge-bar-no-safe-area", "dvh-over-100vh"]) {
+      expect(found.has(id)).toBe(true);
+    }
+    expect(r.errorCount).toBe(0);
+    expect(r.warningCount).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## Spec 003 P3 — Mobile machine floor (D1 = responsive-web only)

Ships M2–M6 as static warnings in the web pipeline. M1 (tap-target-undersized) already lives in `taste-checks-tap-target.ts` (P1) — one home per rule, not duplicated.

| ID | checkId | Home | Fires on |
|----|---------|------|----------|
| M2 | `tap-spacing-cramped` | `layout-checks-mobile.ts` (new) | interactive flex/grid, ≥2 controls, gap <8px |
| M3 | `viewport-meta-missing` | `a11y-checks.ts` | responsive doc (breakpoint/media-query) with no viewport meta |
| M4 | `input-font-below-16` | `layout-checks-mobile.ts` | text-entry input/textarea/select <16px → iOS zoom |
| M5 | `edge-bar-no-safe-area` | `layout-checks-mobile.ts` | fixed/sticky **bottom** bar without `env(safe-area-inset-*)` |
| M6 | `dvh-over-100vh` | `layout-checks-viewport.ts` (extend) | `100vh` / `h-screen` full-viewport height |

All warnings (document still renders) — registered in `layout-lint.ts` WARNING_CHECKS / `a11y-lint.ts` CHECKS. Pure string/regex, precision-first.

### Knowledge pairing (Art II — emitter + linter)
- `knowledge/mode-constraints.md` → new **Machine floor (responsive-web mobile)** subsection (tap-spacing, input-font, safe-area, dvh with checkIds + WHY).
- `knowledge/accessibility.md` → tier-1 static list extended with `viewport-meta-missing` (1.4.10 Reflow).

### Gates
- 4 BARE gates green: typecheck, lint, build, `npm test` (1802 passed / 4 skipped).
- `ui knowledge check` green for P3 (P3 touches no persona/index files).

### Dogfood (real lab rebuilds — not modified)
- `viewport-meta-missing` → cohere rebuild (responsive, 0 viewport meta) — real bug.
- `tap-spacing-cramped` → elevenlabs rebuild.
- `dvh-over-100vh` → airbnb/apple/clickhouse/elevenlabs/linear demos.
- **M5 precision calibration:** first pass flagged top-0 sticky `<header>`s on ~every site (near-universal noise). Narrowed to the **bottom** edge — the home-indicator collision is the genuine high-signal bug; top inset only bites in undetectable standalone/PWA. After narrowing, edge-bar fires zero on the desktop-clone lab (correct: no bottom mobile bars there).

> ⚠️ Deviation from plan literal: plan §P3 listed "bottom-0/top-0" for M5; precision-first (repeated mandate) overrode the top-0 half. Recorded in code + knowledge.