### PR TITLE
spec 004 P3: registry schema — scope + deprecated on ComponentRecord

### DIFF
--- a/schemas/component-registry.schema.json
+++ b/schemas/component-registry.schema.json
@@ -57,6 +57,16 @@
         "description": {
           "type": "string",
           "description": "Human-readable description of the component's purpose."
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["local", "global"],
+          "default": "local",
+          "description": "Reuse scope (spec 004): 'local' = owned by this project's DS; 'global' = a published/shared library component. Semantically required, but omitted here from the required list so pre-migration registries stay valid — a missing value is read as 'local'."
+        },
+        "deprecated": {
+          "type": "boolean",
+          "description": "Soft-deprecation flag (spec 004). Absent or false = active; true = deprecated (the audit reads this). Distinct from lifecycle 'status'."
         }
       },
       "required": ["name", "category", "markup", "tokensUsed"],

--- a/src/core/component-kit/index.ts
+++ b/src/core/component-kit/index.ts
@@ -67,4 +67,8 @@ export const COMPONENT_KIT: ComponentRecord[] = [
   textarea,
   toast,
   tooltip,
-].sort((a, b) => a.name.localeCompare(b.name));
+]
+  // Every shipped kit component is scoped "local" (spec 004 D3 default) — once installed it
+  // belongs to the project's own DS. Injected centrally so the 27 source files stay scope-free.
+  .map((c): ComponentRecord => ({ ...c, scope: c.scope ?? "local" }))
+  .sort((a, b) => a.name.localeCompare(b.name));

--- a/src/core/figma-ds-registry.ts
+++ b/src/core/figma-ds-registry.ts
@@ -153,6 +153,10 @@ export function buildRegistry(components: DsComponent[]): Registry {
       markup: "", // no HTML from a Figma scan; instances are authored on-canvas later
       tokensUsed: [],
       description: descParts.join(" · "),
+      // TODO(spec 004 P1/P4): map scope from the Figma publish-status / `remote` signal once
+      // the capture stream carries it. The current scan (DsComponent) exposes no publish
+      // signal, so default every scanned record to "local" (spec 004 D3 default).
+      scope: "local",
     };
     if (hasAxes) rec.variants = variantList(axes);
     if (status !== undefined) rec.status = status;

--- a/src/core/registry-store.ts
+++ b/src/core/registry-store.ts
@@ -19,6 +19,15 @@ import { readFileSync, writeFileSync } from "node:fs";
 export type ComponentState = "default" | "hover" | "active" | "focus" | "disabled";
 /** Lifecycle status (shadcn 🔵/🟢 convention): a `stable` component must honour its state contract. */
 export type ComponentStatus = "draft" | "beta" | "stable";
+/**
+ * Reuse scope (spec 004 D3): `local` = owned by this project's DS; `global` = a
+ * published/shared library component reusable across projects (inferred from Figma
+ * publish-status / `remote` during reconcile). Semantically REQUIRED — every record
+ * carries a scope after load/validate. Optional here only so a pre-migration file
+ * (written before this field existed) parses; the load/validate boundary normalizes a
+ * missing value to `"local"`.
+ */
+export type ComponentScope = "local" | "global";
 
 export interface ComponentRecord {
   name: string;
@@ -29,6 +38,11 @@ export interface ComponentRecord {
   states?: ComponentState[];
   description?: string;
   status?: ComponentStatus;
+  /** Reuse scope; defaults to `"local"` when absent (migration). See {@link ComponentScope}. */
+  scope?: ComponentScope;
+  /** Soft-deprecation flag (spec 004). Absent = active; `true` = deprecated (audit reads this).
+   * A distinct field, NOT a `status` value — a component can be `stable` and `deprecated`. */
+  deprecated?: boolean;
 }
 
 export interface Registry {
@@ -58,8 +72,12 @@ const REGISTRY_ROOT_KEYS = new Set(["version", "components"]);
 /** Keys permitted on a component record (mirrors schema additionalProperties:false). */
 const COMPONENT_ALLOWED_KEYS = new Set([
   "name", "category", "markup", "tokensUsed", "variants", "states", "description", "status",
+  "scope", "deprecated",
 ]);
 const VALID_STATUSES = new Set<string>(["draft", "beta", "stable"]);
+const VALID_SCOPES = new Set<string>(["local", "global"]);
+/** Default reuse scope for records that predate the `scope` field (spec 004 migration). */
+const DEFAULT_SCOPE: ComponentScope = "local";
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
@@ -144,6 +162,16 @@ export function validateComponentRecord(rec: unknown): ComponentRecord {
     throw new RegistryError("BAD_ARG", `component.status must be one of: ${[...VALID_STATUSES].join(", ")}`);
   }
 
+  // Optional: scope (reuse scope) — absent is valid and migrates to the default below.
+  if (r["scope"] !== undefined && (typeof r["scope"] !== "string" || !VALID_SCOPES.has(r["scope"]))) {
+    throw new RegistryError("BAD_ARG", `component.scope must be one of: ${[...VALID_SCOPES].join(", ")}`);
+  }
+
+  // Optional: deprecated (soft-deprecation flag)
+  if (r["deprecated"] !== undefined && typeof r["deprecated"] !== "boolean") {
+    throw new RegistryError("BAD_ARG", "component.deprecated must be a boolean");
+  }
+
   // additionalProperties: false — reject keys outside the schema
   for (const key of Object.keys(r)) {
     if (!COMPONENT_ALLOWED_KEYS.has(key)) {
@@ -163,6 +191,9 @@ export function validateComponentRecord(rec: unknown): ComponentRecord {
     ...(r["states"] !== undefined && { states: r["states"] as ComponentState[] }),
     ...(r["description"] !== undefined && { description: r["description"] as string }),
     ...(r["status"] !== undefined && { status: r["status"] as ComponentStatus }),
+    // Migration: missing scope defaults to "local" so the returned record always carries one.
+    scope: (r["scope"] as ComponentScope | undefined) ?? DEFAULT_SCOPE,
+    ...(r["deprecated"] !== undefined && { deprecated: r["deprecated"] as boolean }),
   };
 }
 
@@ -224,7 +255,17 @@ export function loadRegistry(path: string): Registry {
     }
   }
 
-  return { version: obj["version"], components: obj["components"] as ComponentRecord[] };
+  // Migration (spec 004): records written before `scope` existed lack it — default to
+  // "local" on read so every in-memory record carries a scope. Deliberately scoped to this
+  // one field; loadRegistry does not otherwise per-record-validate (that would retroactively
+  // reject registries the old lenient loader accepted).
+  const components = (obj["components"] as ComponentRecord[]).map((c) =>
+    c !== null && typeof c === "object" && (c as ComponentRecord).scope === undefined
+      ? { ...(c as ComponentRecord), scope: DEFAULT_SCOPE }
+      : c,
+  );
+
+  return { version: obj["version"], components };
 }
 
 /**

--- a/tests/registry-store.test.ts
+++ b/tests/registry-store.test.ts
@@ -144,6 +144,57 @@ describe("validateComponentRecord", () => {
       }),
     );
   });
+
+  // ─── scope + deprecated (spec 004 D3) ────────────────────────────────────
+
+  it("accepts each valid scope and preserves it on the returned record", () => {
+    for (const scope of ["local", "global"] as const) {
+      const rec = validateComponentRecord(validRecord({ scope }));
+      expect(rec.scope).toBe(scope);
+    }
+  });
+
+  it("defaults a missing scope to 'local' (migration)", () => {
+    // validRecord() carries no scope — the returned record must still have one.
+    const rec = validateComponentRecord({
+      name: "Button/Primary",
+      category: "action",
+      markup: "<button>Click</button>",
+      tokensUsed: ["color.primary"],
+    });
+    expect(rec.scope).toBe("local");
+  });
+
+  it("throws BAD_ARG for an invalid scope value", () => {
+    expect(() => validateComponentRecord(validRecord({ scope: "team" as never }))).toThrow(
+      expect.objectContaining({
+        code: "BAD_ARG",
+        message: expect.stringMatching(/component\.scope must be one of/),
+      }),
+    );
+  });
+
+  it("accepts deprecated:true and preserves it; absent stays absent", () => {
+    const dep = validateComponentRecord(validRecord({ deprecated: true }));
+    expect(dep.deprecated).toBe(true);
+    const active = validateComponentRecord(validRecord());
+    expect(active.deprecated).toBeUndefined();
+  });
+
+  it("throws BAD_ARG when deprecated is not a boolean", () => {
+    expect(() => validateComponentRecord(validRecord({ deprecated: "yes" as never }))).toThrow(
+      expect.objectContaining({
+        code: "BAD_ARG",
+        message: expect.stringMatching(/component\.deprecated must be a boolean/),
+      }),
+    );
+  });
+
+  it("still rejects an unknown key now that scope/deprecated are allowed", () => {
+    expect(() =>
+      validateComponentRecord({ ...validRecord({ scope: "global", deprecated: true }), bogus: 1 }),
+    ).toThrow(expect.objectContaining({ code: "BAD_REGISTRY" }));
+  });
 });
 
 // ─── createEmptyRegistry ──────────────────────────────────────────────────────
@@ -201,6 +252,44 @@ describe("saveRegistry + loadRegistry", () => {
       "utf8",
     );
     expect(() => loadRegistry(path)).toThrow(expect.objectContaining({ code: "BAD_REGISTRY" }));
+  });
+
+  it("migrates a pre-scope registry file to scope 'local' on load (spec 004)", () => {
+    const path = registerTmp(tmpPath());
+    // Simulate a registry written before `scope` existed — the record has no scope key.
+    writeFileSync(
+      path,
+      JSON.stringify(
+        {
+          version: "0.1.0",
+          components: [
+            {
+              name: "Button/Primary",
+              category: "action",
+              markup: "<button>Click</button>",
+              tokensUsed: ["color.primary"],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const loaded = loadRegistry(path);
+    expect(loaded.components[0]?.scope).toBe("local");
+  });
+
+  it("round-trips scope + deprecated through disk", () => {
+    const path = registerTmp(tmpPath());
+    const reg: Registry = {
+      version: "0.1.0",
+      components: [validRecord({ scope: "global", deprecated: true })],
+    };
+    saveRegistry(path, reg);
+    const loaded = loadRegistry(path);
+    expect(loaded.components[0]?.scope).toBe("global");
+    expect(loaded.components[0]?.deprecated).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Spec 004 P3 — Registry schema (D3)

Gate for P4. Small, independent of P1/P2. Adds two fields to \`ComponentRecord\`:

- **\`scope: "local" | "global"\`** — default \`"local"\` (spec 004 D3). Semantically required; every record carries a scope after load/validate. TS-optional only so a pre-scope file parses — the load/validate boundary normalizes a missing value to \`local\`.
- **\`deprecated?: boolean\`** — soft-deprecation flag. Absent = active. A *distinct* field from lifecycle \`status\` (a component can be \`stable\` and \`deprecated\`); matches what the audit already reads.

### Changes
- \`registry-store.ts\`: types, validation (BAD_ARG on bad scope/deprecated), allowed-keys extended, migration default in **both** \`validateComponentRecord\` and \`loadRegistry\` (loader defaults scope only — no broader per-record validation, to avoid retroactively rejecting registries the old lenient loader accepted).
- \`component-registry.schema.json\`: \`scope\`/\`deprecated\` in properties; scope carries \`default: "local"\` and is intentionally **not** in \`required\` (keeps pre-migration files valid).
- \`figma-ds-registry.ts\`: scanned records default \`scope: "local"\` + TODO to map from Figma publish-status/\`remote\` in P1/P4 (no publish signal on \`DsComponent\` yet).
- \`component-kit/index.ts\`: the 27 shipped kit records get \`scope: "local"\` injected centrally (source files stay scope-free).

### Verification
- 4 gates green (typecheck / lint / build / test — 1810 passed) + \`ui knowledge check\` (0 findings) + \`design-os\` \`pytest -q\` (156 passed — audit reads \`deprecated\`, unbroken).
- New tests: scope/deprecated validate + round-trip, missing-scope→local (both validate and on-disk load), field still rejects unknown keys.
- **Dogfood:** loaded the real 718-component \`reference-ds/shadcn-standard\` registry (no scope on disk) → every record migrates to \`scope: local\`, \`deprecated\` absent.

### Not in scope (P4)
Capture, reconcile-apply, idle-commit; \`registerComponent\` keeps whatever scope the passed record carries (whole-record replace) — P4's reconcile rebuilds the record and preserves prior scope.