### PR TITLE
spec 004 P1 — Figma live-sync capture (read-only)

### DIFF
--- a/figma-agent/cli/src/transport/broker-daemon.ts
+++ b/figma-agent/cli/src/transport/broker-daemon.ts
@@ -18,6 +18,8 @@ import { isPidAlive, readAdvertisement, selfBuildMtime, writeAdvertisement } fro
 import { isChunkMsg, isEventMsg, isReplyMsg, isRequestMsg, parseWireMsg, rawToString } from './protocol-helpers.ts';
 import { PluginRegistry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
+import { appendChangeFrames, changeLogPath } from './change-log.ts';
+import type { ComponentChange } from '../../../shared/figma-changes.ts';
 
 const LOG_FILE = '/tmp/figma-agent-broker.log';
 
@@ -87,6 +89,24 @@ function sendReplyErr(ws: WebSocket, id: string, code: ErrorCode, message: strin
   } catch { /* client already gone */ }
 }
 
+/**
+ * Extract a DOC_CHANGE batch's fields and append every frame to the change log.
+ * Best-effort: malformed data or an fs error is swallowed (logged) — capture must
+ * never break the relay. `ts` is stamped here (broker append time), near-real-time.
+ */
+function appendDocChange(changesPath: string, data: Record<string, unknown>): void {
+  try {
+    const changes = Array.isArray(data.changes) ? (data.changes as ComponentChange[]) : [];
+    if (changes.length === 0) return;
+    const page = typeof data.page === 'string' ? data.page : '';
+    const fileKey = typeof data.fileKey === 'string' ? data.fileKey : null;
+    const written = appendChangeFrames(changesPath, changes, { page, fileKey }, Date.now());
+    if (written > 0) log(`DOC_CHANGE: appended ${written} change frame(s) → ${changesPath}`);
+  } catch (err) {
+    log(`DOC_CHANGE append failed: ${(err as Error).message}`);
+  }
+}
+
 export async function runBrokerDaemon(): Promise<void> {
   // Refuse to double-start when a live same-or-newer broker already advertises.
   const existing = readAdvertisement();
@@ -118,6 +138,11 @@ export async function runBrokerDaemon(): Promise<void> {
   };
   writeAdvertisement(port, startedAt);
   log(`broker listening on 127.0.0.1:${port}${wss6 ? ' + [::1]:' + port : ''}`);
+
+  // Live-sync change log (spec 004 P1): resolved once from the broker's cwd (or
+  // FIGMA_AGENT_CHANGES_DIR). Each DOC_CHANGE batch is appended here; reconcile
+  // (P2/P4) walks it. Path fixed for the daemon's life — cwd never changes.
+  const changesPath = changeLogPath();
 
   const shutdown = (code: number, reason: string): never => {
     log(`shutdown (${reason})`);
@@ -257,6 +282,12 @@ export async function runBrokerDaemon(): Promise<void> {
         }
       } else if (msg.type === 'FILE_INFO') {
         if (isPlugin) { st.registry.updateScene(ws, msg.data); broadcastToClients(text); } // page change → refresh scene + fan out
+      } else if (msg.type === 'DOC_CHANGE') {
+        // Live-sync capture: append the plugin's coalesced batch to the change log.
+        // Broker-side append (not CLI) because the broker is the long-lived process —
+        // it catches edits even when no CLI command is running. Best-effort: a log
+        // write failure must never disrupt the relay.
+        if (isPlugin) appendDocChange(changesPath, msg.data);
       } else if (isPlugin) {
         broadcastToClients(text); // other plugin events fan out to CLI clients
       }

--- a/figma-agent/cli/src/transport/change-log.ts
+++ b/figma-agent/cli/src/transport/change-log.ts
@@ -1,0 +1,87 @@
+// Figma live-sync change log — fs layer for the broker (spec 004 P1, Tier 2).
+// Append-only JSONL, one ChangeFrame per line; cursor = line count. Mirrors the
+// design-memory ledger pattern (src/core/memory-store.ts: appendFileSync +
+// line-count cursor) so reconcile (P2/P4) can walk `--since <cursor>` deterministically.
+//
+// The broker is a GLOBAL long-lived daemon with no project binding, so the log
+// path is resolved from its spawn cwd (or an env override). Each frame carries
+// `fileKey`, so a future multi-project reconcile can still partition one shared log.
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import {
+  buildChangeFrame,
+  type ChangeBatchMeta,
+  type ChangeFrame,
+  type ComponentChange,
+} from '../../../shared/figma-changes.ts';
+
+export const CHANGE_LOG_FILENAME = 'figma.changes.jsonl';
+
+/**
+ * Directory holding the change log. `FIGMA_AGENT_CHANGES_DIR` overrides (tests MUST
+ * set it to a tmp dir); default is `<cwd>/design` — the broker inherits the spawning
+ * CLI's cwd, which is normally the project root.
+ */
+export function changeLogDir(): string {
+  const env = process.env['FIGMA_AGENT_CHANGES_DIR'];
+  if (env !== undefined && env.length > 0) return resolve(env);
+  return join(process.cwd(), 'design');
+}
+
+/** Absolute path to `design/figma.changes.jsonl`. */
+export function changeLogPath(): string {
+  return join(changeLogDir(), CHANGE_LOG_FILENAME);
+}
+
+/** Count non-blank lines (→ next reconcile cursor). 0 when the log is absent. */
+export function changeLogLineCount(path: string): number {
+  if (!existsSync(path)) return 0;
+  return readFileSync(path, 'utf8').split('\n').filter((l) => l.trim().length > 0).length;
+}
+
+/**
+ * Append one ChangeFrame line, creating the design/ dir if needed. Kept separate
+ * from the batch helper so a caller can stream frames without re-resolving paths.
+ */
+export function appendChangeFrame(path: string, frame: ChangeFrame): void {
+  mkdirSync(resolveDir(path), { recursive: true });
+  appendFileSync(path, JSON.stringify(frame) + '\n', 'utf8');
+}
+
+/**
+ * Stamp + append every coalesced ComponentChange from one DOC_CHANGE batch.
+ * Skips malformed entries (untrusted wire input) — a bad change never aborts the
+ * batch. Returns the number of frames actually written.
+ */
+export function appendChangeFrames(
+  path: string,
+  changes: readonly ComponentChange[],
+  meta: ChangeBatchMeta,
+  ts: number,
+): number {
+  let written = 0;
+  for (const change of changes) {
+    if (!isValidChange(change)) continue;
+    appendChangeFrame(path, buildChangeFrame(change, meta, ts));
+    written++;
+  }
+  return written;
+}
+
+/** Parent dir of a file path (avoids importing dirname just for one call). */
+function resolveDir(filePath: string): string {
+  const idx = filePath.lastIndexOf('/');
+  return idx <= 0 ? filePath : filePath.slice(0, idx);
+}
+
+/** Structural guard: a wire ComponentChange must at least carry an op + node id. */
+function isValidChange(c: unknown): c is ComponentChange {
+  if (c === null || typeof c !== 'object') return false;
+  const v = c as Record<string, unknown>;
+  return (
+    (v.op === 'created' || v.op === 'updated' || v.op === 'deleted') &&
+    typeof v.nodeId === 'string' &&
+    v.nodeId.length > 0
+  );
+}

--- a/figma-agent/plugin/code.js
+++ b/figma-agent/plugin/code.js
@@ -1,5 +1,45 @@
 "use strict";
 (() => {
+  // shared/figma-changes.ts
+  function mapChangeType(type) {
+    switch (type) {
+      case "CREATE":
+        return "created";
+      case "DELETE":
+        return "deleted";
+      case "PROPERTY_CHANGE":
+        return "updated";
+      default:
+        return null;
+    }
+  }
+  var OP_RANK = { deleted: 3, created: 2, updated: 1 };
+  function coalesceChanges(raw) {
+    const byId = /* @__PURE__ */ new Map();
+    const propSets = /* @__PURE__ */ new Map();
+    for (const c of raw) {
+      const props = propSets.get(c.nodeId) ?? /* @__PURE__ */ new Set();
+      for (const p of c.changedProps) props.add(p);
+      propSets.set(c.nodeId, props);
+      const prev = byId.get(c.nodeId);
+      if (!prev) {
+        byId.set(c.nodeId, { ...c, changedProps: [] });
+        continue;
+      }
+      prev.op = OP_RANK[c.op] > OP_RANK[prev.op] ? c.op : prev.op;
+      if (prev.nodeName === null && c.nodeName !== null) prev.nodeName = c.nodeName;
+      if (!prev.nodeType && c.nodeType) prev.nodeType = c.nodeType;
+      if (c.origin === "REMOTE") prev.origin = "REMOTE";
+    }
+    const out = [];
+    for (const [id, c] of byId) {
+      c.changedProps = [...propSets.get(id) ?? /* @__PURE__ */ new Set()].sort();
+      out.push(c);
+    }
+    out.sort((a, b) => a.nodeId < b.nodeId ? -1 : a.nodeId > b.nodeId ? 1 : 0);
+    return out;
+  }
+
   // plugin/src/main/font-match.ts
   var GENERIC_FAMILIES = /* @__PURE__ */ new Set([
     "serif",
@@ -1607,6 +1647,50 @@
   }
   announceFileInfo();
   figma.on("currentpagechange", announceFileInfo);
+  function resolveComponentIdentity(node) {
+    if ("removed" in node && node.removed) {
+      if (node.type === "COMPONENT" || node.type === "COMPONENT_SET") {
+        return { id: node.id, name: null, type: node.type };
+      }
+      return null;
+    }
+    let n = node;
+    while (n) {
+      if (n.type === "COMPONENT_SET") return { id: n.id, name: n.name, type: n.type };
+      if (n.type === "COMPONENT") {
+        if (n.parent && n.parent.type === "COMPONENT_SET") {
+          return { id: n.parent.id, name: n.parent.name, type: n.parent.type };
+        }
+        return { id: n.id, name: n.name, type: n.type };
+      }
+      n = n.parent;
+    }
+    return null;
+  }
+  function onDocumentChange(event) {
+    const raw = [];
+    for (const dc of event.documentChanges) {
+      const op = mapChangeType(dc.type);
+      if (op === null) continue;
+      const identity = resolveComponentIdentity(dc.node);
+      if (!identity) continue;
+      raw.push({
+        op,
+        nodeId: identity.id,
+        nodeName: identity.name,
+        nodeType: identity.type,
+        changedProps: dc.type === "PROPERTY_CHANGE" ? [...dc.properties] : [],
+        origin: dc.origin
+      });
+    }
+    const changes = coalesceChanges(raw);
+    if (changes.length === 0) return;
+    figma.ui.postMessage({
+      type: "DOC_CHANGE",
+      data: { changes, page: figma.currentPage.name, fileKey: figma.fileKey ?? null }
+    });
+  }
+  figma.loadAllPagesAsync().then(() => figma.on("documentchange", onDocumentChange)).catch((err) => figma.notify(`live-sync capture disabled: ${err instanceof Error ? err.message : String(err)}`));
   figma.ui.onmessage = async (msg) => {
     const chrome = msg;
     if (chrome && chrome.type === "PANEL_RESIZE") {

--- a/figma-agent/plugin/src/main/main.ts
+++ b/figma-agent/plugin/src/main/main.ts
@@ -8,6 +8,10 @@
 import type { CommandName, ErrorCode } from '../../../shared/protocol';
 import type { FigmaExportPayload } from '../../../shared/figma-payload-types';
 import {
+  coalesceChanges, mapChangeType,
+  type ChangeOrigin, type ComponentChange,
+} from '../../../shared/figma-changes';
+import {
   createColorStyles, createTextStyles, createEffectStyles,
   resetImportWarnings, getImportWarnings, withCode,
 } from './executor-styles';
@@ -36,6 +40,82 @@ function announceFileInfo(): void {
 }
 announceFileInfo();
 figma.on('currentpagechange', announceFileInfo);
+
+// ─── Live-sync capture (spec 004 P1) ────────────────────────────────
+// Watch whole-document edits, coalesce to the component level, and post the batch
+// as DOC_CHANGE; the relay forwards it to the broker, which appends it to
+// design/figma.changes.jsonl. Capture ONLY — no reconcile, no registry write here.
+//
+// The `dynamic-page` manifest requires loadAllPagesAsync() BEFORE subscribing to
+// `documentchange`, or the event fires for the current page only. We pay that cost
+// once at boot (RAM measured in the P1 dogfood) so edits on any page are captured.
+
+/** Component identity as recorded in a change (id + best-effort name + node type). */
+interface ComponentIdentity {
+  id: string;
+  name: string | null;
+  type: string;
+}
+
+/**
+ * Resolve a changed node to its canonical component container: the enclosing
+ * COMPONENT_SET if the node is a variant, else the nearest COMPONENT/COMPONENT_SET.
+ * Returns null when the change is not under any component (the volume filter —
+ * ordinary frame/text edits are ignored). Deletes arrive as a RemovedNode with only
+ * id + type (no name, no parent), so a deleted DESCENDANT of a component cannot be
+ * resolved upward — we capture only whole-component deletions. Documented P1 limit.
+ */
+function resolveComponentIdentity(node: SceneNode | RemovedNode): ComponentIdentity | null {
+  if ('removed' in node && node.removed) {
+    // RemovedNode: id + type only. Record it only if it WAS itself a component.
+    if (node.type === 'COMPONENT' || node.type === 'COMPONENT_SET') {
+      return { id: node.id, name: null, type: node.type };
+    }
+    return null;
+  }
+  let n: BaseNode | null = node;
+  while (n) {
+    if (n.type === 'COMPONENT_SET') return { id: n.id, name: n.name, type: n.type };
+    if (n.type === 'COMPONENT') {
+      // A variant's canonical unit is its enclosing set (matches the registry).
+      if (n.parent && n.parent.type === 'COMPONENT_SET') {
+        return { id: n.parent.id, name: n.parent.name, type: n.parent.type };
+      }
+      return { id: n.id, name: n.name, type: n.type };
+    }
+    n = n.parent;
+  }
+  return null;
+}
+
+function onDocumentChange(event: DocumentChangeEvent): void {
+  const raw: ComponentChange[] = [];
+  for (const dc of event.documentChanges) {
+    const op = mapChangeType(dc.type);
+    if (op === null) continue; // STYLE_* — components only in P1
+    const identity = resolveComponentIdentity((dc as { node: SceneNode | RemovedNode }).node);
+    if (!identity) continue; // change not under any component — filtered out
+    raw.push({
+      op,
+      nodeId: identity.id,
+      nodeName: identity.name,
+      nodeType: identity.type,
+      changedProps: dc.type === 'PROPERTY_CHANGE' ? [...dc.properties] : [],
+      origin: dc.origin as ChangeOrigin,
+    });
+  }
+  const changes = coalesceChanges(raw);
+  if (changes.length === 0) return;
+  figma.ui.postMessage({
+    type: 'DOC_CHANGE',
+    data: { changes, page: figma.currentPage.name, fileKey: figma.fileKey ?? null },
+  });
+}
+
+// Subscribe only after all pages are loaded (dynamic-page requirement).
+figma.loadAllPagesAsync()
+  .then(() => figma.on('documentchange', onDocumentChange))
+  .catch((err) => figma.notify(`live-sync capture disabled: ${err instanceof Error ? err.message : String(err)}`));
 
 type Params = Record<string, unknown>;
 

--- a/figma-agent/plugin/src/ui/ui-relay.ts
+++ b/figma-agent/plugin/src/ui/ui-relay.ts
@@ -201,6 +201,13 @@ window.addEventListener('message', (ev: MessageEvent) => {
     return;
   }
 
+  // Live-sync capture (spec 004 P1): main's coalesced documentchange batch →
+  // straight over the wire so the broker can append it to the change log.
+  if (pm.type === 'DOC_CHANGE') {
+    wsSend({ type: 'DOC_CHANGE', data: (pm.data as Record<string, unknown>) ?? {} });
+    return;
+  }
+
   // Command reply from main → back over the wire
   if (typeof pm.requestId === 'string') {
     const reply: ReplyMsg = pm.ok

--- a/figma-agent/plugin/ui.html
+++ b/figma-agent/plugin/ui.html
@@ -2381,6 +2381,10 @@ code {
       wsSend({ type: "FILE_INFO", data: fileInfo });
       return;
     }
+    if (pm.type === "DOC_CHANGE") {
+      wsSend({ type: "DOC_CHANGE", data: pm.data ?? {} });
+      return;
+    }
     if (typeof pm.requestId === "string") {
       const reply = pm.ok ? { id: pm.requestId, ok: true, result: pm.result } : {
         id: pm.requestId,

--- a/figma-agent/shared/figma-changes.ts
+++ b/figma-agent/shared/figma-changes.ts
@@ -1,0 +1,138 @@
+// Figma live-sync change contract (spec 004 P1) — shared by plugin (capture) and
+// cli/broker (append). Pure: no fs, no figma API, no network. Both bundles import
+// this relatively; esbuild inlines it per bundle (same pattern as protocol.ts).
+//
+// Data flow: plugin `documentchange` handler resolves each raw change to its
+// enclosing component and coalesces to one ComponentChange per component (Tier 1),
+// posts DOC_CHANGE over the wire; the broker stamps each ComponentChange into a
+// ChangeFrame and appends it to `design/figma.changes.jsonl` (Tier 2). Reconcile
+// (P2/P4) walks that log — so ChangeFrame is the ON-DISK CONTRACT those phases read.
+
+/** Bump when ChangeFrame's shape changes; reconcile refuses a mismatched `v`. */
+export const CHANGE_LOG_SCHEMA_VERSION = 1;
+
+/** Component-level operation, coalesced from Figma's finer DocumentChange types. */
+export type ChangeOp = 'created' | 'updated' | 'deleted';
+
+/** Where a change came from (Figma `DocumentChange.origin`). */
+export type ChangeOrigin = 'LOCAL' | 'REMOTE';
+
+/** Best-effort scope hint derived from origin — NON-authoritative (reconcile decides). */
+export type ScopeHint = 'local' | 'global';
+
+/**
+ * One component's coalesced change, as the plugin posts it (DOC_CHANGE.data.changes[]).
+ * `nodeName` is null when unknowable — a DELETE gives Figma a `RemovedNode` that
+ * carries only id + type (no name).
+ */
+export interface ComponentChange {
+  op: ChangeOp;
+  nodeId: string;
+  nodeName: string | null;
+  nodeType: string; // COMPONENT | COMPONENT_SET (or the raw type on an unresolved delete)
+  changedProps: string[]; // property names for `updated`; empty for created/deleted
+  origin: ChangeOrigin;
+}
+
+/**
+ * One line of `design/figma.changes.jsonl`. The broker stamps `v`/`ts`/`scopeHint`
+ * plus the per-batch `page`/`fileKey` onto each ComponentChange. THIS is the shape
+ * reconcile (P2/P4) parses — treat as an append-only, versioned contract.
+ */
+export interface ChangeFrame {
+  v: number; // CHANGE_LOG_SCHEMA_VERSION
+  ts: number; // epoch ms, stamped at append
+  op: ChangeOp;
+  nodeId: string;
+  nodeName: string | null;
+  nodeType: string;
+  changedProps: string[];
+  origin: ChangeOrigin;
+  scopeHint: ScopeHint; // origin === 'REMOTE' → 'global', else 'local' (a hint, not a decision)
+  page: string; // figma.currentPage.name at capture
+  fileKey: string | null; // figma.fileKey (undefined on some free-tier contexts → null)
+}
+
+/** Per-batch metadata (same for every change in one documentchange event). */
+export interface ChangeBatchMeta {
+  page: string;
+  fileKey: string | null;
+}
+
+/**
+ * Map a Figma `DocumentChange.type` to a component-level op. Returns null for the
+ * STYLE_* variants — P1 captures component nodes only (styles/tokens are out of scope).
+ */
+export function mapChangeType(type: string): ChangeOp | null {
+  switch (type) {
+    case 'CREATE': return 'created';
+    case 'DELETE': return 'deleted';
+    case 'PROPERTY_CHANGE': return 'updated';
+    default: return null; // STYLE_CREATE / STYLE_DELETE / STYLE_PROPERTY_CHANGE — ignored in P1
+  }
+}
+
+/** REMOTE-origin changes come from another user / a published library → global hint. */
+export function deriveScopeHint(origin: ChangeOrigin): ScopeHint {
+  return origin === 'REMOTE' ? 'global' : 'local';
+}
+
+// Op precedence when several raw changes hit the same component in one batch:
+// a deletion supersedes everything; a creation supersedes a mere update.
+const OP_RANK: Record<ChangeOp, number> = { deleted: 3, created: 2, updated: 1 };
+
+/**
+ * Coalesce raw per-node component changes to ONE ComponentChange per component id.
+ * Deterministic: output sorted by nodeId; changedProps unioned + sorted; the
+ * highest-ranked op wins; origin is REMOTE if any contributing change is remote;
+ * nodeName is the first non-null seen. Pure — no figma calls, so unit-testable.
+ * Idempotent on already-coalesced input (ids are unique → each maps to itself).
+ */
+export function coalesceChanges(raw: ComponentChange[]): ComponentChange[] {
+  const byId = new Map<string, ComponentChange>();
+  const propSets = new Map<string, Set<string>>();
+  for (const c of raw) {
+    const props = propSets.get(c.nodeId) ?? new Set<string>();
+    for (const p of c.changedProps) props.add(p);
+    propSets.set(c.nodeId, props);
+
+    const prev = byId.get(c.nodeId);
+    if (!prev) {
+      byId.set(c.nodeId, { ...c, changedProps: [] });
+      continue;
+    }
+    prev.op = OP_RANK[c.op] > OP_RANK[prev.op] ? c.op : prev.op;
+    if (prev.nodeName === null && c.nodeName !== null) prev.nodeName = c.nodeName;
+    if (!prev.nodeType && c.nodeType) prev.nodeType = c.nodeType;
+    if (c.origin === 'REMOTE') prev.origin = 'REMOTE';
+  }
+  const out: ComponentChange[] = [];
+  for (const [id, c] of byId) {
+    c.changedProps = [...(propSets.get(id) ?? new Set())].sort();
+    out.push(c);
+  }
+  out.sort((a, b) => (a.nodeId < b.nodeId ? -1 : a.nodeId > b.nodeId ? 1 : 0));
+  return out;
+}
+
+/**
+ * Stamp one ComponentChange into a fully-formed ChangeFrame (pure). Coerces
+ * absent/loose fields to safe defaults so a frame crossing the wire always lands
+ * on disk well-formed (nodeName→null, changedProps→[], origin→LOCAL).
+ */
+export function buildChangeFrame(change: ComponentChange, meta: ChangeBatchMeta, ts: number): ChangeFrame {
+  const origin: ChangeOrigin = change.origin === 'REMOTE' ? 'REMOTE' : 'LOCAL';
+  return {
+    v: CHANGE_LOG_SCHEMA_VERSION,
+    ts,
+    op: change.op,
+    nodeId: change.nodeId,
+    nodeName: change.nodeName ?? null,
+    nodeType: change.nodeType ?? '',
+    changedProps: Array.isArray(change.changedProps) ? change.changedProps : [],
+    origin,
+    scopeHint: deriveScopeHint(origin),
+    page: meta.page,
+    fileKey: meta.fileKey ?? null,
+  };
+}

--- a/figma-agent/shared/protocol.ts
+++ b/figma-agent/shared/protocol.ts
@@ -70,7 +70,10 @@ export type ReplyMsg = ReplyOk | ReplyErr;
 // cannot detect a half-open socket via WS control frames. It sends {type:'PING'}
 // JSON frames and the broker answers {type:'PONG'}; a missed PONG ⇒ socket dead.
 export interface EventMsg {
-  type: 'BROKER_HELLO' | 'PLUGIN_HELLO' | 'FILE_INFO' | 'PLUGIN_GONE' | 'PING' | 'PONG';
+  // DOC_CHANGE (spec 004 P1): the plugin's coalesced documentchange batch, carried
+  // plugin → broker; the broker appends it to design/figma.changes.jsonl. Payload
+  // shape: { changes: ComponentChange[], page: string, fileKey: string|null }.
+  type: 'BROKER_HELLO' | 'PLUGIN_HELLO' | 'FILE_INFO' | 'PLUGIN_GONE' | 'PING' | 'PONG' | 'DOC_CHANGE';
   data: Record<string, unknown>;
 }
 

--- a/figma-agent/tests/change-log.test.ts
+++ b/figma-agent/tests/change-log.test.ts
@@ -1,0 +1,103 @@
+// spec 004 P1 — the broker's change-log fs layer: append-only JSONL, one frame
+// per line, cursor = line count. Mirrors the design-memory ledger; this is the
+// on-disk contract reconcile (P2/P4) walks.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  CHANGE_LOG_FILENAME, appendChangeFrames, changeLogDir, changeLogLineCount, changeLogPath,
+} from '../cli/src/transport/change-log.ts';
+import { CHANGE_LOG_SCHEMA_VERSION, type ComponentChange } from '../shared/figma-changes.ts';
+
+const change = (over: Partial<ComponentChange>): ComponentChange => ({
+  op: 'updated', nodeId: 'n1', nodeName: 'Button', nodeType: 'COMPONENT',
+  changedProps: ['fills'], origin: 'LOCAL', ...over,
+});
+
+let dir: string;
+let path: string;
+const prevEnv = process.env['FIGMA_AGENT_CHANGES_DIR'];
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fa-changes-'));
+  process.env['FIGMA_AGENT_CHANGES_DIR'] = dir;
+  path = changeLogPath();
+});
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env['FIGMA_AGENT_CHANGES_DIR'];
+  else process.env['FIGMA_AGENT_CHANGES_DIR'] = prevEnv;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const readLines = (): string[] => readFileSync(path, 'utf8').split('\n').filter((l) => l.trim().length > 0);
+
+describe('changeLogDir / changeLogPath — env override', () => {
+  it('honours FIGMA_AGENT_CHANGES_DIR and names the file', () => {
+    expect(changeLogDir()).toBe(dir);
+    expect(changeLogPath()).toBe(join(dir, CHANGE_LOG_FILENAME));
+  });
+  it('defaults to <cwd>/design when the env is unset', () => {
+    delete process.env['FIGMA_AGENT_CHANGES_DIR'];
+    expect(changeLogDir()).toBe(join(process.cwd(), 'design'));
+  });
+});
+
+describe('appendChangeFrames — one JSONL line per change', () => {
+  it('writes a well-formed frame line for each change and creates the dir', () => {
+    const written = appendChangeFrames(
+      path,
+      [change({ nodeId: 'a' }), change({ nodeId: 'b', op: 'deleted', nodeName: null, origin: 'REMOTE' })],
+      { page: 'Components', fileKey: 'KEY1' },
+      42,
+    );
+    expect(written).toBe(2);
+    const lines = readLines();
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]);
+    expect(first).toMatchObject({
+      v: CHANGE_LOG_SCHEMA_VERSION, ts: 42, op: 'updated', nodeId: 'a',
+      scopeHint: 'local', page: 'Components', fileKey: 'KEY1',
+    });
+    const second = JSON.parse(lines[1]);
+    expect(second).toMatchObject({ op: 'deleted', nodeId: 'b', origin: 'REMOTE', scopeHint: 'global', nodeName: null });
+  });
+
+  it('appends across calls (append-only, never truncates)', () => {
+    appendChangeFrames(path, [change({ nodeId: 'a' })], { page: 'P', fileKey: null }, 1);
+    appendChangeFrames(path, [change({ nodeId: 'b' })], { page: 'P', fileKey: null }, 2);
+    expect(readLines().map((l) => JSON.parse(l).nodeId)).toEqual(['a', 'b']);
+  });
+
+  it('skips malformed entries but keeps the valid ones (untrusted wire input)', () => {
+    const batch = [
+      change({ nodeId: 'ok' }),
+      { op: 'updated' } as unknown as ComponentChange, // no nodeId
+      { nodeId: 'x', op: 'bogus' } as unknown as ComponentChange, // bad op
+      null as unknown as ComponentChange,
+    ];
+    const written = appendChangeFrames(path, batch, { page: 'P', fileKey: null }, 1);
+    expect(written).toBe(1);
+    expect(readLines()).toHaveLength(1);
+    expect(JSON.parse(readLines()[0]).nodeId).toBe('ok');
+  });
+
+  it('writes nothing (no file) for an empty batch', () => {
+    const written = appendChangeFrames(path, [], { page: 'P', fileKey: null }, 1);
+    expect(written).toBe(0);
+  });
+});
+
+describe('changeLogLineCount — reconcile cursor', () => {
+  it('is 0 when the log is absent', () => {
+    expect(changeLogLineCount(path)).toBe(0);
+  });
+  it('counts non-blank lines and advances with each append', () => {
+    expect(changeLogLineCount(path)).toBe(0);
+    appendChangeFrames(path, [change({ nodeId: 'a' }), change({ nodeId: 'b' })], { page: 'P', fileKey: null }, 1);
+    expect(changeLogLineCount(path)).toBe(2);
+    appendChangeFrames(path, [change({ nodeId: 'c' })], { page: 'P', fileKey: null }, 2);
+    expect(changeLogLineCount(path)).toBe(3);
+    expect(existsSync(path)).toBe(true);
+  });
+});

--- a/figma-agent/tests/figma-changes-coalesce.test.ts
+++ b/figma-agent/tests/figma-changes-coalesce.test.ts
@@ -1,0 +1,129 @@
+// spec 004 P1 — the pure change contract: coalesce to one record per component,
+// map Figma change types, derive scope hints, and stamp frames. No fs, no figma.
+import { describe, it, expect } from 'vitest';
+import {
+  CHANGE_LOG_SCHEMA_VERSION,
+  buildChangeFrame, coalesceChanges, deriveScopeHint, mapChangeType,
+  type ComponentChange,
+} from '../shared/figma-changes.ts';
+
+const change = (over: Partial<ComponentChange>): ComponentChange => ({
+  op: 'updated', nodeId: 'n1', nodeName: 'Button', nodeType: 'COMPONENT',
+  changedProps: [], origin: 'LOCAL', ...over,
+});
+
+describe('mapChangeType — Figma type → component op', () => {
+  it('maps the three node change types', () => {
+    expect(mapChangeType('CREATE')).toBe('created');
+    expect(mapChangeType('DELETE')).toBe('deleted');
+    expect(mapChangeType('PROPERTY_CHANGE')).toBe('updated');
+  });
+  it('ignores STYLE_* and unknown types (components only in P1)', () => {
+    for (const t of ['STYLE_CREATE', 'STYLE_DELETE', 'STYLE_PROPERTY_CHANGE', 'WAT']) {
+      expect(mapChangeType(t)).toBeNull();
+    }
+  });
+});
+
+describe('deriveScopeHint — origin → scope hint', () => {
+  it('REMOTE ⇒ global, LOCAL ⇒ local', () => {
+    expect(deriveScopeHint('REMOTE')).toBe('global');
+    expect(deriveScopeHint('LOCAL')).toBe('local');
+  });
+});
+
+describe('coalesceChanges — one record per component', () => {
+  it('collapses many raw changes on one id, unioning + sorting props', () => {
+    const out = coalesceChanges([
+      change({ nodeId: 'a', changedProps: ['fills'] }),
+      change({ nodeId: 'a', changedProps: ['cornerRadius', 'fills'] }),
+      change({ nodeId: 'a', changedProps: ['name'] }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].nodeId).toBe('a');
+    expect(out[0].changedProps).toEqual(['cornerRadius', 'fills', 'name']); // deduped + sorted
+  });
+
+  it('op precedence: deleted > created > updated', () => {
+    const del = coalesceChanges([
+      change({ nodeId: 'a', op: 'updated' }),
+      change({ nodeId: 'a', op: 'deleted' }),
+      change({ nodeId: 'a', op: 'created' }),
+    ]);
+    expect(del[0].op).toBe('deleted');
+    const created = coalesceChanges([
+      change({ nodeId: 'a', op: 'updated' }),
+      change({ nodeId: 'a', op: 'created' }),
+    ]);
+    expect(created[0].op).toBe('created');
+  });
+
+  it('promotes origin to REMOTE if any contributing change is remote', () => {
+    const out = coalesceChanges([
+      change({ nodeId: 'a', origin: 'LOCAL' }),
+      change({ nodeId: 'a', origin: 'REMOTE' }),
+    ]);
+    expect(out[0].origin).toBe('REMOTE');
+  });
+
+  it('keeps the first non-null name (a delete contributes null)', () => {
+    const out = coalesceChanges([
+      change({ nodeId: 'a', op: 'deleted', nodeName: null }),
+      change({ nodeId: 'a', op: 'updated', nodeName: 'Card' }),
+    ]);
+    expect(out[0].nodeName).toBe('Card');
+  });
+
+  it('emits deterministic order sorted by nodeId across components', () => {
+    const out = coalesceChanges([
+      change({ nodeId: 'z' }), change({ nodeId: 'a' }), change({ nodeId: 'm' }),
+    ]);
+    expect(out.map((c) => c.nodeId)).toEqual(['a', 'm', 'z']);
+  });
+
+  it('is idempotent on already-coalesced input', () => {
+    const once = coalesceChanges([
+      change({ nodeId: 'a', changedProps: ['fills'] }),
+      change({ nodeId: 'b', changedProps: ['width'] }),
+    ]);
+    expect(coalesceChanges(once)).toEqual(once);
+  });
+
+  it('returns [] for an empty batch', () => {
+    expect(coalesceChanges([])).toEqual([]);
+  });
+});
+
+describe('buildChangeFrame — stamped, well-formed frame', () => {
+  it('stamps v/ts/scopeHint + per-batch page/fileKey', () => {
+    const frame = buildChangeFrame(
+      change({ op: 'updated', nodeId: 'a', nodeName: 'Button', changedProps: ['fills'], origin: 'REMOTE' }),
+      { page: 'Components', fileKey: 'FILEKEY123' },
+      1_700_000_000_000,
+    );
+    expect(frame).toEqual({
+      v: CHANGE_LOG_SCHEMA_VERSION,
+      ts: 1_700_000_000_000,
+      op: 'updated',
+      nodeId: 'a',
+      nodeName: 'Button',
+      nodeType: 'COMPONENT',
+      changedProps: ['fills'],
+      origin: 'REMOTE',
+      scopeHint: 'global',
+      page: 'Components',
+      fileKey: 'FILEKEY123',
+    });
+  });
+
+  it('coerces loose/absent wire fields to safe defaults', () => {
+    const loose = { op: 'deleted', nodeId: 'x' } as unknown as ComponentChange;
+    const frame = buildChangeFrame(loose, { page: 'P', fileKey: null }, 1);
+    expect(frame.nodeName).toBeNull();
+    expect(frame.nodeType).toBe('');
+    expect(frame.changedProps).toEqual([]);
+    expect(frame.origin).toBe('LOCAL');
+    expect(frame.scopeHint).toBe('local');
+    expect(frame.fileKey).toBeNull();
+  });
+});


### PR DESCRIPTION
## Spec 004 P1 — Capture read-only (foundation)

One-way Figma→registry live-sync, **capture stage only**. Proves the change stream before anything consumes it. No reconcile, no registry write, no idle timer, no panel (those are P2/P4).

### Tier 1 — Plugin capture (`plugin/src/main/main.ts`)
- `figma.loadAllPagesAsync()` at boot, THEN subscribe `figma.on('documentchange', …)` — required by the `dynamic-page` manifest for whole-document events (else current-page only).
- `resolveComponentIdentity`: walks each changed node to its canonical component container (enclosing `COMPONENT_SET` for variants, else nearest `COMPONENT`); changes not under any component are filtered out (volume control).
- Coalesce to one record per component → `postMessage({type:'DOC_CHANGE', data:{changes, page, fileKey}})`.

### Tier 2 — Transport + log
- `shared/protocol.ts`: `DOC_CHANGE` added to `EventMsg` union.
- `plugin/src/ui/ui-relay.ts`: forwards DOC_CHANGE plugin→broker.
- `cli/src/transport/broker-daemon.ts`: on DOC_CHANGE, appends each frame to `design/figma.changes.jsonl` (broker is the long-lived process → catches edits with no CLI running). Best-effort; a log write never disrupts the relay.
- `cli/src/transport/change-log.ts`: fs layer — mirrors `src/core/memory-store.ts` (appendFileSync + line-count cursor).
- `shared/figma-changes.ts`: the pure contract (coalesce / mapChangeType / buildChangeFrame), inlined into both bundles like protocol.ts.

### JSONL schema (contract for P2/P4)
One line per coalesced component change:
```
{ v, ts, op: created|updated|deleted, nodeId, nodeName, nodeType,
  changedProps[], origin: LOCAL|REMOTE, scopeHint: local|global, page, fileKey }
```
`v` = 1 (`CHANGE_LOG_SCHEMA_VERSION`); `ts` stamped at broker append; `scopeHint` derived from origin (REMOTE⇒global) — a hint, reconcile decides authoritatively.

### Verification
- **Unit-verified (20 new tests, figma-agent suite 180→200 green):** coalesce (op precedence, prop union+sort, origin promotion, determinism, idempotence), frame shape, broker append (valid + malformed-skip), append-only, cursor line-count, env-override path.
- **Gates:** figma-agent `tsc` (plugin+cli) + build clean; root typecheck/lint/build/test (1810 pass) + `ui knowledge check` (0 findings).
- **⚠ Needs owner LIVE-verify (not runnable headless):** real `documentchange` on a Figma Desktop file with the plugin open — measure event coverage + volume, `loadAllPagesAsync` RAM cost, and DELETE behaviour (see below).

### Known P1 limitations (for the dogfood to measure)
- **DELETE loses name + ancestor:** Figma gives a `RemovedNode` (id + type only — **no name, no parent**). So we capture only *whole-component* deletions (`nodeName: null`); a deleted descendant *inside* a component can't be resolved upward and is dropped. (The task brief assumed name was snapshottable on RemovedNode — the typings prove otherwise.)
- Broker resolves the log dir once from cwd (or `FIGMA_AGENT_CHANGES_DIR`); multi-project partitioning is deferred (each frame carries `fileKey`).

Not for merge — review foundation before P2 builds on the schema.