### PR TITLE
feat: figma reconcile --apply — idle-commit + 1-click panel sync (spec 004 P4)

### DIFF
--- a/design-os/plugins/figma/src/design_os_figma/__init__.py
+++ b/design-os/plugins/figma/src/design_os_figma/__init__.py
@@ -23,7 +23,7 @@ from typing import Annotated, Any, NoReturn
 import typer
 
 from design_os.envelope import JsonFlag, emit, err_env, ok_env
-from design_os.kernel import resolve_bin
+from design_os.kernel import KernelNotFound, resolve_bin, run_ui
 
 _BIN_NAME = "figma-agent"
 _BIN_ENV = "DESIGN_OS_FIGMA_AGENT_BIN"
@@ -194,6 +194,68 @@ def scan(
     )
     data = {"out": str(out), "result": result, "next": _NEXT_HINT}
     emit(ok_env("figma scan", data), json_mode=json_, text=_scan_text(out), exit_code=0)
+
+
+def _reconcile_text(data: dict[str, Any]) -> str:
+    """One-line summary of the kernel's reconcile envelope (dry-run preview or applied)."""
+    delta = data.get("delta") if isinstance(data.get("delta"), dict) else {}
+    added = len(delta.get("added", [])) if isinstance(delta.get("added"), list) else 0
+    updated = len(delta.get("updated", [])) if isinstance(delta.get("updated"), list) else 0
+    deprecated = len(delta.get("deprecated", [])) if isinstance(delta.get("deprecated"), list) else 0
+    mode = "applied" if data.get("applied") else "dry-run"
+    frm = data.get("cursor_from", "?")
+    to = data.get("cursor_to", "?")
+    return (
+        f"figma reconcile ({mode}) — cursor {frm}..{to}\n"
+        f"  {added} added · {updated} updated · {deprecated} deprecated\n"
+    )
+
+
+@app.command(name="reconcile")
+def reconcile(
+    apply: Annotated[
+        bool, typer.Option("--apply", help="Commit the delta into the registry (default: dry-run preview)")
+    ] = False,
+    since: Annotated[
+        int | None, typer.Option("--since", help="Line-count cursor to start from")
+    ] = None,
+    dir_: Annotated[
+        Path | None, typer.Option("--dir", help="Project directory holding design/")
+    ] = None,
+    json_: JsonFlag = False,
+) -> None:
+    """Reconcile the Figma change-log into the component registry. (deterministic `ui` kernel; no network)
+
+    The ONE deterministic-kernel member of the `figma` group: it shells to `ui figma reconcile`
+    (contract §1 — never reimplemented), NOT the figma-agent hand. Undo = replay to a prior cursor.
+    """
+    args = ["figma", "reconcile", "--apply" if apply else "--dry-run"]
+    if since is not None:
+        args += ["--since", str(since)]
+    if dir_ is not None:
+        args += ["--dir", str(dir_)]
+    try:
+        result = run_ui([*args, "--json"])
+    except KernelNotFound as exc:
+        _fail("figma reconcile", "KERNEL_NOT_FOUND", str(exc), json_)
+    env = result.envelope
+    if env is None:
+        _fail("figma reconcile", "BAD_KERNEL_OUTPUT", "ui did not print a JSON envelope", json_)
+    if not env.get("ok", False):
+        error = env.get("error") if isinstance(env.get("error"), dict) else {}
+        _fail(
+            "figma reconcile",
+            str(error.get("code") or "RECONCILE_FAILED"),
+            str(error.get("message") or "reconcile failed"),
+            json_,
+        )
+    data = env.get("data") if isinstance(env.get("data"), dict) else {}
+    emit(
+        ok_env("figma reconcile", {"result": data}),
+        json_mode=json_,
+        text=_reconcile_text(data),
+        exit_code=0,
+    )
 
 
 @app.command(name="audit")

--- a/design-os/tests/test_plugin_figma.py
+++ b/design-os/tests/test_plugin_figma.py
@@ -234,3 +234,59 @@ def test_figma_help_lists_audit(runner: CliRunner) -> None:
     res = runner.invoke(figma_app, ["--help"])
     assert res.exit_code == 0
     assert "audit" in res.stdout
+
+
+# ── Case 13: `reconcile` shells to the `ui` KERNEL (not figma-agent) and re-emits its data. ──
+def test_reconcile_forwards_to_ui_kernel_and_reemits(
+    runner: CliRunner, figma_env, tmp_path: Path
+) -> None:
+    """`design-os figma reconcile` is the deterministic-kernel member of the group: it runs
+    `ui figma reconcile` (contract §1) and re-emits the kernel envelope's data verbatim."""
+    argv_log = tmp_path / "argv.txt"
+    env_obj = (
+        '{"ok": true, "command": "figma reconcile", "data": '
+        '{"cursor_from": 0, "cursor_to": 2, "applied": true, "dry_run": false, '
+        '"delta": {"added": [], "updated": [], "deprecated": [{"name": "Card/Basic"}]}, '
+        '"apply": {"deprecated": ["Card/Basic"], "updated": [], "pending": [], "skipped": []}}}'
+    )
+    body = 'echo "$@" > "' + str(argv_log) + '"\n' "echo '" + env_obj + "'\n" "exit 0\n"
+    figma_env.make_stub("ui", body)
+
+    res = runner.invoke(figma_app, ["reconcile", "--apply", "--json"])
+    assert res.exit_code == 0, res.stdout
+    env = json.loads(res.stdout)
+    assert env["ok"] is True
+    assert env["command"] == "figma reconcile"
+    assert env["data"]["result"]["apply"]["deprecated"] == ["Card/Basic"]
+    # The kernel got EXACTLY the argv the plugin promises to forward (apply + json).
+    assert argv_log.read_text().strip() == "figma reconcile --apply --json"
+
+
+# ── Case 14: `reconcile` (no --apply) forwards --dry-run. ──
+def test_reconcile_default_is_dry_run(runner: CliRunner, figma_env, tmp_path: Path) -> None:
+    argv_log = tmp_path / "argv.txt"
+    env_obj = '{"ok": true, "command": "figma reconcile", "data": {"cursor_from": 0, "cursor_to": 0, "dry_run": true, "delta": {"added": [], "updated": [], "deprecated": []}}}'
+    body = 'echo "$@" > "' + str(argv_log) + '"\n' "echo '" + env_obj + "'\n" "exit 0\n"
+    figma_env.make_stub("ui", body)
+
+    res = runner.invoke(figma_app, ["reconcile", "--since", "3", "--json"])
+    assert res.exit_code == 0, res.stdout
+    assert argv_log.read_text().strip() == "figma reconcile --dry-run --since 3 --json"
+
+
+# ── Case 15: `reconcile` with no `ui` kernel on PATH → KERNEL_NOT_FOUND, exit 1. ──
+def test_reconcile_kernel_not_found(runner: CliRunner, figma_env) -> None:
+    figma_env.remove("ui")  # drop the default kernel stub → run_ui raises KernelNotFound
+    res = runner.invoke(figma_app, ["reconcile", "--json"])
+    assert res.exit_code == 1
+    env = json.loads(res.stdout)
+    assert env["ok"] is False
+    assert env["command"] == "figma reconcile"
+    assert env["error"]["code"] == "KERNEL_NOT_FOUND"
+
+
+# ── Case 16: `figma --help` lists the new `reconcile` leaf. ──
+def test_figma_help_lists_reconcile(runner: CliRunner) -> None:
+    res = runner.invoke(figma_app, ["--help"])
+    assert res.exit_code == 0
+    assert "reconcile" in res.stdout

--- a/figma-agent/cli/src/transport/broker-daemon.ts
+++ b/figma-agent/cli/src/transport/broker-daemon.ts
@@ -19,6 +19,8 @@ import { isChunkMsg, isEventMsg, isReplyMsg, isRequestMsg, parseWireMsg, rawToSt
 import { PluginRegistry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
 import { appendChangeFrames, changeLogPath } from './change-log.ts';
+import { projectDir as syncProjectDir, readIdleMs } from './figma-sync-config.ts';
+import { spawnReconcileApply } from './figma-sync-apply.ts';
 import type { ComponentChange } from '../../../shared/figma-changes.ts';
 
 const LOG_FILE = '/tmp/figma-agent-broker.log';
@@ -143,6 +145,33 @@ export async function runBrokerDaemon(): Promise<void> {
   // FIGMA_AGENT_CHANGES_DIR). Each DOC_CHANGE batch is appended here; reconcile
   // (P2/P4) walks it. Path fixed for the daemon's life — cwd never changes.
   const changesPath = changeLogPath();
+
+  // Live-sync idle-commit (spec 004 P4): the idle window sent to each plugin, and a
+  // debounce so a double-click never launches two overlapping `ui figma reconcile
+  // --apply` processes.
+  const idleMs = readIdleMs();
+  const applyProjectDir = syncProjectDir();
+  let syncInFlight = false;
+
+  /** Send one unsolicited EventMsg to a single socket (best-effort). */
+  const sendEvent = (ws: WebSocket, type: EventMsg['type'], data: Record<string, unknown>): void => {
+    try { if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type, data } satisfies EventMsg)); }
+    catch { /* socket already gone */ }
+  };
+
+  // SYNC_REQUEST → run the deterministic kernel apply, then report SYNC_RESULT back to
+  // the requesting plugin. Registry-write logic stays in `ui` (Art I) — the broker only
+  // spawns it. Debounced: a click mid-apply is ignored (the panel just waits).
+  const handleSyncRequest = (ws: WebSocket): void => {
+    if (syncInFlight) { sendEvent(ws, 'SYNC_RESULT', { ok: false, summary: 'a sync is already running' }); return; }
+    syncInFlight = true;
+    log(`SYNC_REQUEST → spawning: ui figma reconcile --apply --dir ${applyProjectDir}`);
+    spawnReconcileApply(applyProjectDir, (r) => {
+      syncInFlight = false;
+      log(`SYNC_RESULT ok=${r.ok} — ${r.summary}`);
+      sendEvent(ws, 'SYNC_RESULT', { ...r });
+    });
+  };
 
   const shutdown = (code: number, reason: string): never => {
     log(`shutdown (${reason})`);
@@ -273,6 +302,9 @@ export async function runBrokerDaemon(): Promise<void> {
         if (superseded) { try { superseded.close(); } catch { /* already gone */ } }
         st.lastBusyAt = Date.now();
         log(`plugin registered [${instanceId}]${replaced ? ' (replaced — same instance re-hello)' : ''}: ${JSON.stringify(msg.data)}`);
+        // Live-sync (spec 004 P4): hand this plugin the idle window so its debounce
+        // timer matches the project's design/figma-sync.json.
+        sendEvent(ws, 'SYNC_CONFIG', { idleMs });
         flushWaiting(); // deliver any requests parked during the reconnect gap
       } else if (msg.type === 'PING') {
         // App-level heartbeat from the plugin — answer so it knows the socket lives.
@@ -288,6 +320,10 @@ export async function runBrokerDaemon(): Promise<void> {
         // it catches edits even when no CLI command is running. Best-effort: a log
         // write failure must never disrupt the relay.
         if (isPlugin) appendDocChange(changesPath, msg.data);
+      } else if (msg.type === 'SYNC_REQUEST') {
+        // Live-sync commit (spec 004 P4): the panel's "Sync now" click → run the
+        // deterministic kernel apply and report the result back to this plugin.
+        if (isPlugin) handleSyncRequest(ws);
       } else if (isPlugin) {
         broadcastToClients(text); // other plugin events fan out to CLI clients
       }

--- a/figma-agent/cli/src/transport/figma-sync-apply.ts
+++ b/figma-agent/cli/src/transport/figma-sync-apply.ts
@@ -1,0 +1,81 @@
+// Figma live-sync apply spawner (spec 004 P4) — the broker's SYNC_REQUEST handler.
+//
+// The panel's "Sync now" click reaches the broker as a SYNC_REQUEST event; the broker
+// runs the DETERMINISTIC kernel to commit — `ui figma reconcile --apply` — rather than
+// touching the registry itself. Keeping apply in `ui` is the whole point: the broker
+// stays a dumb relay; all registry-write logic lives in the tested, pure kernel.
+//
+// Best-effort + debounced: a spawn failure (no `ui` on PATH) is reported back, never
+// thrown; a second click while one apply is in flight is ignored.
+import { spawn } from 'node:child_process';
+
+/** Outcome the broker sends back to the plugin as SYNC_RESULT.data. */
+export interface SyncApplyResult {
+  ok: boolean;
+  /** One-line human summary (from the kernel envelope, or the failure reason). */
+  summary: string;
+  /** The kernel's apply report when it succeeded ({deprecated, updated, pending, skipped}). */
+  applied?: unknown;
+  code?: string;
+}
+
+/** Resolve the `ui` kernel binary — env override (tests) → PATH lookup by name. */
+function uiBin(): string {
+  return process.env['FIGMA_AGENT_UI_BIN'] || process.env['DESIGN_OS_UI_BIN'] || 'ui';
+}
+
+/**
+ * Spawn `ui figma reconcile --apply --dir <projectDir> --json`, parse the envelope,
+ * and hand a SyncApplyResult to `done`. Never throws — every failure path resolves
+ * `done` with ok:false so the caller (broker) can relay it and move on.
+ */
+export function spawnReconcileApply(projectDir: string, done: (r: SyncApplyResult) => void): void {
+  let child;
+  try {
+    child = spawn(uiBin(), ['figma', 'reconcile', '--apply', '--dir', projectDir, '--json'], {
+      cwd: projectDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    done({ ok: false, summary: `could not launch ui: ${(err as Error).message}`, code: 'SPAWN_FAILED' });
+    return;
+  }
+
+  let out = '';
+  let err = '';
+  child.stdout?.on('data', (d) => { out += String(d); });
+  child.stderr?.on('data', (d) => { err += String(d); });
+  child.on('error', (e) => {
+    done({ ok: false, summary: `ui not runnable: ${e.message} (is the kernel linked?)`, code: 'SPAWN_FAILED' });
+  });
+  child.on('close', (exit) => {
+    done(parseEnvelope(out, err, exit ?? -1));
+  });
+}
+
+/** Turn the kernel's `--json` envelope into a SyncApplyResult (tolerant of noise). */
+function parseEnvelope(out: string, err: string, exit: number): SyncApplyResult {
+  let env: Record<string, unknown> | null = null;
+  try {
+    const parsed = JSON.parse(out.trim());
+    if (parsed && typeof parsed === 'object') env = parsed as Record<string, unknown>;
+  } catch { /* non-JSON stdout — fall through to the exit-code path */ }
+
+  if (env && env['ok'] === true && env['data'] && typeof env['data'] === 'object') {
+    const data = env['data'] as Record<string, unknown>;
+    const apply = data['apply'] as { deprecated?: unknown[]; updated?: unknown[]; pending?: unknown[] } | undefined;
+    const dep = Array.isArray(apply?.deprecated) ? apply!.deprecated.length : 0;
+    const upd = Array.isArray(apply?.updated) ? apply!.updated.length : 0;
+    const pend = Array.isArray(apply?.pending) ? apply!.pending.length : 0;
+    return {
+      ok: true,
+      summary: `synced — ${upd} updated, ${dep} deprecated, ${pend} pending`,
+      applied: data['apply'],
+    };
+  }
+  if (env && env['ok'] === false && env['error'] && typeof env['error'] === 'object') {
+    const e = env['error'] as { code?: unknown; message?: unknown };
+    return { ok: false, summary: String(e.message ?? 'reconcile failed'), code: String(e.code ?? 'RECONCILE_FAILED') };
+  }
+  return { ok: false, summary: err.trim() || `ui exited ${exit}`, code: 'RECONCILE_FAILED' };
+}

--- a/figma-agent/cli/src/transport/figma-sync-config.ts
+++ b/figma-agent/cli/src/transport/figma-sync-config.ts
@@ -1,0 +1,46 @@
+// Figma live-sync config (spec 004 P4) — the idle window the broker passes to the
+// plugin. One line in the project: `design/figma-sync.json` {"idleMs": 300000}. The
+// broker reads it once at connect and sends it as SYNC_CONFIG; the plugin's idle
+// timer uses it (clamped to a floor). Kept tiny + pure-ish (fs read only, no network).
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_IDLE_MS, MIN_IDLE_MS } from '../../../shared/protocol.ts';
+import { changeLogDir } from './change-log.ts';
+
+export const SYNC_CONFIG_FILENAME = 'figma-sync.json';
+
+/** Project dir holding `design/` — the parent of the change-log dir. */
+export function projectDir(): string {
+  return dirname(changeLogDir());
+}
+
+/** Absolute path to `<project>/design/figma-sync.json`. */
+export function syncConfigPath(): string {
+  return join(changeLogDir(), SYNC_CONFIG_FILENAME);
+}
+
+/**
+ * Resolve the idle window in ms. Order: `FIGMA_AGENT_IDLE_MS` env (fast test
+ * override) → `design/figma-sync.json` {"idleMs"} → DEFAULT_IDLE_MS. Any malformed
+ * / too-small value floors to MIN_IDLE_MS so a typo can never spin the timer.
+ */
+export function readIdleMs(): number {
+  const env = process.env['FIGMA_AGENT_IDLE_MS'];
+  if (env !== undefined) return clampIdle(Number(env));
+
+  const path = syncConfigPath();
+  if (!existsSync(path)) return DEFAULT_IDLE_MS;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as { idleMs?: unknown };
+    const raw = parsed?.idleMs;
+    return typeof raw === 'number' ? clampIdle(raw) : DEFAULT_IDLE_MS;
+  } catch {
+    return DEFAULT_IDLE_MS; // a broken config never disables the loop — fall back to default
+  }
+}
+
+function clampIdle(n: number): number {
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_IDLE_MS;
+  return Math.max(MIN_IDLE_MS, Math.floor(n));
+}

--- a/figma-agent/plugin/code.js
+++ b/figma-agent/plugin/code.js
@@ -1,5 +1,11 @@
 "use strict";
 (() => {
+  // shared/protocol.ts
+  var DEFAULT_IDLE_MS = 3e5;
+  var MIN_IDLE_MS = 1e3;
+  var CHUNK_LIMIT = 512 * 1024;
+  var BROKER_IDLE_SHUTDOWN_MS = 30 * 6e4;
+
   // shared/figma-changes.ts
   function mapChangeType(type) {
     switch (type) {
@@ -1667,6 +1673,19 @@
     }
     return null;
   }
+  var idleMs = DEFAULT_IDLE_MS;
+  var idleTimer = null;
+  var changesSinceCommit = 0;
+  function resetIdleTimer() {
+    if (idleTimer !== null) clearTimeout(idleTimer);
+    idleTimer = setTimeout(fireIdle, idleMs);
+  }
+  function fireIdle() {
+    idleTimer = null;
+    if (changesSinceCommit <= 0) return;
+    figma.ui.postMessage({ type: "IDLE_READY", data: { count: changesSinceCommit } });
+    changesSinceCommit = 0;
+  }
   function onDocumentChange(event) {
     const raw = [];
     for (const dc of event.documentChanges) {
@@ -1689,6 +1708,8 @@
       type: "DOC_CHANGE",
       data: { changes, page: figma.currentPage.name, fileKey: figma.fileKey ?? null }
     });
+    changesSinceCommit += changes.length;
+    resetIdleTimer();
   }
   figma.loadAllPagesAsync().then(() => figma.on("documentchange", onDocumentChange)).catch((err) => figma.notify(`live-sync capture disabled: ${err instanceof Error ? err.message : String(err)}`));
   figma.ui.onmessage = async (msg) => {
@@ -1696,6 +1717,15 @@
     if (chrome && chrome.type === "PANEL_RESIZE") {
       const raw = typeof chrome.h === "number" && Number.isFinite(chrome.h) ? chrome.h : PANEL_HEIGHT.compact;
       figma.ui.resize(PANEL_WIDTH, Math.round(Math.min(PANEL_HEIGHT.expanded, Math.max(PANEL_HEIGHT.compact, raw))));
+      return;
+    }
+    if (chrome && chrome.type === "SYNC_CONFIG") {
+      const raw = chrome.data?.idleMs;
+      if (typeof raw === "number" && Number.isFinite(raw)) idleMs = Math.max(MIN_IDLE_MS, Math.floor(raw));
+      return;
+    }
+    if (chrome && chrome.type === "SYNC_DONE") {
+      changesSinceCommit = 0;
       return;
     }
     const req = msg;

--- a/figma-agent/plugin/src/main/main.ts
+++ b/figma-agent/plugin/src/main/main.ts
@@ -6,6 +6,7 @@
 // live here; single-command executors live in executor-*.ts.
 
 import type { CommandName, ErrorCode } from '../../../shared/protocol';
+import { DEFAULT_IDLE_MS, MIN_IDLE_MS } from '../../../shared/protocol';
 import type { FigmaExportPayload } from '../../../shared/figma-payload-types';
 import {
   coalesceChanges, mapChangeType,
@@ -88,6 +89,30 @@ function resolveComponentIdentity(node: SceneNode | RemovedNode): ComponentIdent
   return null;
 }
 
+// ─── Idle-commit timer (spec 004 P4) ────────────────────────────────
+// Every captured documentchange resets a debounce; after IDLE_MS of quiet the plugin
+// posts IDLE_READY {count} to its iframe, which shows the "N changes — Sync now /
+// Later" prompt. IDLE_MS defaults to 5 min and is overridden by SYNC_CONFIG (the
+// project's design/figma-sync.json, relayed by the broker). The change-log the broker
+// already persisted is the source of truth — the timer only decides WHEN to prompt.
+let idleMs = DEFAULT_IDLE_MS;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+let changesSinceCommit = 0;
+
+function resetIdleTimer(): void {
+  if (idleTimer !== null) clearTimeout(idleTimer);
+  idleTimer = setTimeout(fireIdle, idleMs);
+}
+
+function fireIdle(): void {
+  idleTimer = null;
+  if (changesSinceCommit <= 0) return; // nothing accumulated — no prompt
+  figma.ui.postMessage({ type: 'IDLE_READY', data: { count: changesSinceCommit } });
+  // Reset here: the displayed count means "changes since this prompt". The log/cursor
+  // stay authoritative — Sync applies EVERYTHING past the cursor regardless of count.
+  changesSinceCommit = 0;
+}
+
 function onDocumentChange(event: DocumentChangeEvent): void {
   const raw: ComponentChange[] = [];
   for (const dc of event.documentChanges) {
@@ -110,6 +135,8 @@ function onDocumentChange(event: DocumentChangeEvent): void {
     type: 'DOC_CHANGE',
     data: { changes, page: figma.currentPage.name, fileKey: figma.fileKey ?? null },
   });
+  changesSinceCommit += changes.length;
+  resetIdleTimer(); // each edit pushes the idle-commit prompt further out
 }
 
 // Subscribe only after all pages are loaded (dynamic-page requirement).
@@ -124,10 +151,22 @@ interface UiRequest { requestId: string; cmd: CommandName; params?: Params }
 figma.ui.onmessage = async (msg: unknown) => {
   // P5.1 panel chrome: the DETAILS toggle asks for an iframe resize. Height is
   // clamped to the mode range so a malformed message can never blow up the panel.
-  const chrome = msg as { type?: unknown; h?: unknown } | null;
+  const chrome = msg as { type?: unknown; h?: unknown; data?: unknown } | null;
   if (chrome && chrome.type === 'PANEL_RESIZE') {
     const raw = typeof chrome.h === 'number' && Number.isFinite(chrome.h) ? chrome.h : PANEL_HEIGHT.compact;
     figma.ui.resize(PANEL_WIDTH, Math.round(Math.min(PANEL_HEIGHT.expanded, Math.max(PANEL_HEIGHT.compact, raw))));
+    return;
+  }
+  // Live-sync (spec 004 P4): the broker's idle window, relayed by the iframe.
+  if (chrome && chrome.type === 'SYNC_CONFIG') {
+    const raw = (chrome.data as { idleMs?: unknown } | undefined)?.idleMs;
+    if (typeof raw === 'number' && Number.isFinite(raw)) idleMs = Math.max(MIN_IDLE_MS, Math.floor(raw));
+    return;
+  }
+  // The panel's "Sync now" click committed — reset the local counter (the log/cursor
+  // remain the real state). The iframe already forwarded SYNC_REQUEST to the broker.
+  if (chrome && chrome.type === 'SYNC_DONE') {
+    changesSinceCommit = 0;
     return;
   }
   const req = msg as Partial<UiRequest> | null;

--- a/figma-agent/plugin/src/ui/panel-model.ts
+++ b/figma-agent/plugin/src/ui/panel-model.ts
@@ -151,6 +151,23 @@ export function detailsLabel(mode: PanelMode): string {
   return mode === 'expanded' ? 'Details ▴' : 'Details ▾';
 }
 
+// ─── Idle-commit sync prompt (spec 004 P4) ────────────────────────────────────
+// The panel gains ONE line at the idle point: "N changes ready — Sync now / Later"
+// (reuses the existing status surface; no new panel). These pure helpers format that
+// line + the post-sync confirmation; panel-ui.ts is the DOM glue that shows/hides it.
+
+/** "3 changes ready" / "1 change ready" — pluralized, count floored at 1 for display. */
+export function syncPromptLabel(count: number): string {
+  const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
+  return `${n} change${n === 1 ? '' : 's'} ready`;
+}
+
+/** Post-apply confirmation line for the prompt (success → ✓, failure → the reason). */
+export function syncResultLabel(ok: boolean, summary: string): string {
+  const clean = typeof summary === 'string' && summary.trim().length > 0 ? summary.trim() : (ok ? 'done' : 'failed');
+  return ok ? `Synced ✓ — ${clean}` : `Sync failed — ${clean}`;
+}
+
 /**
  * Compact-mode meta-line override. Compact drops the status sentence, so the
  * disconnected wait must still communicate on the ONE remaining line (spec §3).

--- a/figma-agent/plugin/src/ui/panel-ui.ts
+++ b/figma-agent/plugin/src/ui/panel-ui.ts
@@ -13,6 +13,7 @@ import {
   stateView, formatAge, formatDuration, timeAgo, humanizeTool,
   toActivityRecord, pushActivity, troubleshootHint, showOnboarding,
   togglePanelMode, detailsLabel, compactMeta, PANEL_HEIGHT,
+  syncPromptLabel, syncResultLabel,
   type ActivityRecord, type PanelMode,
 } from './panel-model';
 
@@ -35,6 +36,10 @@ const dAttempts = el('fga-d-attempts');
 const dFile = el('fga-d-file');
 const dPage = el('fga-d-page');
 const copyBtn = el('fga-copy');
+const syncPrompt = el('fga-sync');
+const syncMsg = el('fga-sync-msg');
+const syncNowBtn = el('fga-sync-now');
+const syncLaterBtn = el('fga-sync-later');
 
 let payload: ConnectionStatePayload | null = null;
 let hadConnection = false; // ever reached `connected` — flips onboarding off + drop-hint on
@@ -130,10 +135,37 @@ window.addEventListener('figma-agent:activity', (ev) => {
 // also forwards it to the broker. This listener is read-only and independent.
 window.addEventListener('message', (ev: MessageEvent) => {
   const pm = (ev.data as { pluginMessage?: { type?: string; data?: Record<string, unknown> } } | null)?.pluginMessage;
-  if (!pm || pm.type !== 'FILE_INFO' || !pm.data) return;
+  if (!pm) return;
+  // Live-sync idle prompt (spec 004 P4): main fired IDLE_READY → show "N changes ready".
+  if (pm.type === 'IDLE_READY' && pm.data) {
+    const count = typeof pm.data.count === 'number' ? pm.data.count : 1;
+    syncMsg.textContent = syncPromptLabel(count);
+    syncPrompt.hidden = false;
+    return;
+  }
+  if (pm.type !== 'FILE_INFO' || !pm.data) return;
   if (typeof pm.data.fileName === 'string') sceneFile = pm.data.fileName;
   if (typeof pm.data.page === 'string') scenePage = pm.data.page;
   renderDetails();
+});
+
+// ─── Idle-commit prompt actions (spec 004 P4) ─────────────────────────────────
+// "Sync now" → ask the relay to send SYNC_REQUEST to the broker (which runs `ui figma
+// reconcile --apply`) AND tell main the batch was acknowledged. "Later" just hides it —
+// the next documentchange restarts the idle timer. SYNC_RESULT confirms in place.
+syncNowBtn.addEventListener('click', () => {
+  syncMsg.textContent = 'Syncing…';
+  try { window.dispatchEvent(new CustomEvent('figma-agent:sync-request')); } catch { /* no DOM events */ }
+  parent.postMessage({ pluginMessage: { type: 'SYNC_DONE' } }, '*');
+});
+
+syncLaterBtn.addEventListener('click', () => { syncPrompt.hidden = true; });
+
+window.addEventListener('figma-agent:sync-result', (ev) => {
+  const d = (ev as CustomEvent).detail as { ok?: boolean; summary?: string } | undefined;
+  syncMsg.textContent = syncResultLabel(d?.ok === true, typeof d?.summary === 'string' ? d.summary : '');
+  syncPrompt.hidden = false;
+  setTimeout(() => { syncPrompt.hidden = true; }, 4000); // auto-dismiss the confirmation
 });
 
 // ─── Copy status (support hand-off) ───────────────────────────────────────────

--- a/figma-agent/plugin/src/ui/panel.html
+++ b/figma-agent/plugin/src/ui/panel.html
@@ -327,6 +327,44 @@ body {
 .status-pill[data-tone="info"]    { background: var(--color-info);    color: var(--color-info-foreground); }
 .status-pill[data-tone="muted"]   { background: var(--color-muted);   color: var(--color-foreground); }
 
+/* Idle-commit prompt (spec 004 P4) — a flat 2px-bordered strip carrying the burnt-
+   orange call to action. Hidden until IDLE_READY; brutalist geometry (radius 0). */
+.sync-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-top: 2px solid var(--color-foreground);
+  border-bottom: 2px solid var(--color-foreground);
+  background: var(--color-accent);
+}
+.sync-prompt[hidden] { display: none; }
+.sync-msg {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--color-foreground);
+}
+.sync-actions { display: flex; gap: var(--space-1); flex: 0 0 auto; }
+.sync-btn {
+  padding: 4px var(--space-1);
+  font-family: var(--font-family-display);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  border: 2px solid var(--color-foreground);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
+  cursor: pointer;
+}
+.sync-btn:hover { background: var(--color-foreground); color: var(--color-accent); }
+.sync-btn.sync-later { background: transparent; color: var(--color-foreground); }
+.sync-btn.sync-later:hover { background: var(--color-foreground); color: var(--color-accent); }
+
 .status-sentence { margin: 0; color: var(--color-foreground); }
 .status-sentence:empty { display: none; }
 .status-meta {
@@ -517,6 +555,16 @@ code {
     </div>
     <p class="status-sentence" id="fga-sentence">The broker starts automatically on your first CLI command.</p>
     <p class="status-meta" id="fga-meta"></p>
+  </section>
+
+  <!-- Live-sync idle-commit prompt (spec 004 P4): one line, shown only at the idle
+       point. "Sync now" applies the change-log via the deterministic kernel. -->
+  <section class="sync-prompt" id="fga-sync" aria-live="polite" hidden>
+    <p class="sync-msg" id="fga-sync-msg">changes ready</p>
+    <div class="sync-actions">
+      <button class="sync-btn" id="fga-sync-now" type="button">Sync now</button>
+      <button class="sync-btn sync-later" id="fga-sync-later" type="button">Later</button>
+    </div>
   </section>
 
   <div id="fga-expanded" hidden>

--- a/figma-agent/plugin/src/ui/ui-relay.ts
+++ b/figma-agent/plugin/src/ui/ui-relay.ts
@@ -124,6 +124,16 @@ function handleWireData(raw: string): void {
     return; // malformed frame — ignore
   }
   if (msg.type === 'PONG') { lastPongAt = Date.now(); return; } // heartbeat ack
+  // Live-sync (spec 004 P4). SYNC_CONFIG → main's idle timer; SYNC_RESULT → the panel.
+  if (msg.type === 'SYNC_CONFIG') {
+    parent.postMessage({ pluginMessage: { type: 'SYNC_CONFIG', data: msg.data ?? {} } }, '*');
+    return;
+  }
+  if (msg.type === 'SYNC_RESULT') {
+    try { window.dispatchEvent(new CustomEvent('figma-agent:sync-result', { detail: msg.data ?? {} })); }
+    catch { /* no DOM event support */ }
+    return;
+  }
   if (typeof msg.chunk === 'string' && typeof msg.seq === 'number' && typeof msg.id === 'string') {
     handleChunk(msg as unknown as ChunkMsg);
     return;
@@ -342,5 +352,12 @@ async function connectLoop(): Promise<void> {
     scheduleReconnect();
   }
 }
+
+// Live-sync (spec 004 P4): the panel's "Sync now" click dispatches this DOM event;
+// forward it to the broker as SYNC_REQUEST (the broker then runs `ui figma reconcile
+// --apply`). Same-iframe hop — panel-ui.ts owns the button, this owns the socket.
+window.addEventListener('figma-agent:sync-request', () => {
+  wsSend({ type: 'SYNC_REQUEST', data: {} });
+});
 
 void connectLoop();

--- a/figma-agent/plugin/ui.html
+++ b/figma-agent/plugin/ui.html
@@ -327,6 +327,44 @@ body {
 .status-pill[data-tone="info"]    { background: var(--color-info);    color: var(--color-info-foreground); }
 .status-pill[data-tone="muted"]   { background: var(--color-muted);   color: var(--color-foreground); }
 
+/* Idle-commit prompt (spec 004 P4) — a flat 2px-bordered strip carrying the burnt-
+   orange call to action. Hidden until IDLE_READY; brutalist geometry (radius 0). */
+.sync-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-top: 2px solid var(--color-foreground);
+  border-bottom: 2px solid var(--color-foreground);
+  background: var(--color-accent);
+}
+.sync-prompt[hidden] { display: none; }
+.sync-msg {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--color-foreground);
+}
+.sync-actions { display: flex; gap: var(--space-1); flex: 0 0 auto; }
+.sync-btn {
+  padding: 4px var(--space-1);
+  font-family: var(--font-family-display);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  border: 2px solid var(--color-foreground);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
+  cursor: pointer;
+}
+.sync-btn:hover { background: var(--color-foreground); color: var(--color-accent); }
+.sync-btn.sync-later { background: transparent; color: var(--color-foreground); }
+.sync-btn.sync-later:hover { background: var(--color-foreground); color: var(--color-accent); }
+
 .status-sentence { margin: 0; color: var(--color-foreground); }
 .status-sentence:empty { display: none; }
 .status-meta {
@@ -519,6 +557,16 @@ code {
     <p class="status-meta" id="fga-meta"></p>
   </section>
 
+  <!-- Live-sync idle-commit prompt (spec 004 P4): one line, shown only at the idle
+       point. "Sync now" applies the change-log via the deterministic kernel. -->
+  <section class="sync-prompt" id="fga-sync" aria-live="polite" hidden>
+    <p class="sync-msg" id="fga-sync-msg">changes ready</p>
+    <div class="sync-actions">
+      <button class="sync-btn" id="fga-sync-now" type="button">Sync now</button>
+      <button class="sync-btn sync-later" id="fga-sync-later" type="button">Later</button>
+    </div>
+  </section>
+
   <div id="fga-expanded" hidden>
     <section class="onboarding" id="fga-onboarding" aria-label="Getting started">
       <ul class="onboarding-list">
@@ -672,6 +720,14 @@ code {
   function detailsLabel(mode2) {
     return mode2 === "expanded" ? "Details \u25B4" : "Details \u25BE";
   }
+  function syncPromptLabel(count) {
+    const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
+    return `${n} change${n === 1 ? "" : "s"} ready`;
+  }
+  function syncResultLabel(ok, summary) {
+    const clean = typeof summary === "string" && summary.trim().length > 0 ? summary.trim() : ok ? "done" : "failed";
+    return ok ? `Synced \u2713 \u2014 ${clean}` : `Sync failed \u2014 ${clean}`;
+  }
   function compactMeta(state) {
     return state === "disconnected" ? "First CLI command starts it" : null;
   }
@@ -695,6 +751,10 @@ code {
   var dFile = el("fga-d-file");
   var dPage = el("fga-d-page");
   var copyBtn = el("fga-copy");
+  var syncPrompt = el("fga-sync");
+  var syncMsg = el("fga-sync-msg");
+  var syncNowBtn = el("fga-sync-now");
+  var syncLaterBtn = el("fga-sync-later");
   var payload = null;
   var hadConnection = false;
   var probeAttempts = 0;
@@ -777,10 +837,36 @@ code {
   });
   window.addEventListener("message", (ev) => {
     const pm = ev.data?.pluginMessage;
-    if (!pm || pm.type !== "FILE_INFO" || !pm.data) return;
+    if (!pm) return;
+    if (pm.type === "IDLE_READY" && pm.data) {
+      const count = typeof pm.data.count === "number" ? pm.data.count : 1;
+      syncMsg.textContent = syncPromptLabel(count);
+      syncPrompt.hidden = false;
+      return;
+    }
+    if (pm.type !== "FILE_INFO" || !pm.data) return;
     if (typeof pm.data.fileName === "string") sceneFile = pm.data.fileName;
     if (typeof pm.data.page === "string") scenePage = pm.data.page;
     renderDetails();
+  });
+  syncNowBtn.addEventListener("click", () => {
+    syncMsg.textContent = "Syncing\u2026";
+    try {
+      window.dispatchEvent(new CustomEvent("figma-agent:sync-request"));
+    } catch {
+    }
+    parent.postMessage({ pluginMessage: { type: "SYNC_DONE" } }, "*");
+  });
+  syncLaterBtn.addEventListener("click", () => {
+    syncPrompt.hidden = true;
+  });
+  window.addEventListener("figma-agent:sync-result", (ev) => {
+    const d = ev.detail;
+    syncMsg.textContent = syncResultLabel(d?.ok === true, typeof d?.summary === "string" ? d.summary : "");
+    syncPrompt.hidden = false;
+    setTimeout(() => {
+      syncPrompt.hidden = true;
+    }, 4e3);
   });
   function fallbackCopy(text, done) {
     try {
@@ -2319,6 +2405,17 @@ code {
       lastPongAt = Date.now();
       return;
     }
+    if (msg.type === "SYNC_CONFIG") {
+      parent.postMessage({ pluginMessage: { type: "SYNC_CONFIG", data: msg.data ?? {} } }, "*");
+      return;
+    }
+    if (msg.type === "SYNC_RESULT") {
+      try {
+        window.dispatchEvent(new CustomEvent("figma-agent:sync-result", { detail: msg.data ?? {} }));
+      } catch {
+      }
+      return;
+    }
     if (typeof msg.chunk === "string" && typeof msg.seq === "number" && typeof msg.id === "string") {
       handleChunk(msg);
       return;
@@ -2513,6 +2610,9 @@ code {
       scheduleReconnect();
     }
   }
+  window.addEventListener("figma-agent:sync-request", () => {
+    wsSend({ type: "SYNC_REQUEST", data: {} });
+  });
   void connectLoop();
 })();
 

--- a/figma-agent/shared/protocol.ts
+++ b/figma-agent/shared/protocol.ts
@@ -73,9 +73,26 @@ export interface EventMsg {
   // DOC_CHANGE (spec 004 P1): the plugin's coalesced documentchange batch, carried
   // plugin → broker; the broker appends it to design/figma.changes.jsonl. Payload
   // shape: { changes: ComponentChange[], page: string, fileKey: string|null }.
-  type: 'BROKER_HELLO' | 'PLUGIN_HELLO' | 'FILE_INFO' | 'PLUGIN_GONE' | 'PING' | 'PONG' | 'DOC_CHANGE';
+  //
+  // Live-sync idle-commit (spec 004 P4) adds three wire events:
+  //   SYNC_CONFIG   broker → plugin: the idle window { idleMs } for this project's
+  //                 design/figma-sync.json (sent right after PLUGIN_HELLO).
+  //   SYNC_REQUEST  plugin → broker: the panel's "Sync now" click; the broker spawns
+  //                 `ui figma reconcile --apply` (apply stays in the deterministic kernel).
+  //   SYNC_RESULT   broker → plugin: { ok, summary } of that apply, for the panel to confirm.
+  // (IDLE_READY / SYNC_DONE are plugin-INTERNAL postMessage types between the main
+  // thread and its iframe — they never cross this wire, so they are not listed here.)
+  type:
+    | 'BROKER_HELLO' | 'PLUGIN_HELLO' | 'FILE_INFO' | 'PLUGIN_GONE' | 'PING' | 'PONG'
+    | 'DOC_CHANGE' | 'SYNC_CONFIG' | 'SYNC_REQUEST' | 'SYNC_RESULT';
   data: Record<string, unknown>;
 }
+
+// Default idle window (ms) before the plugin prompts to sync — 5 minutes (spec 004).
+// Overridable per-project in design/figma-sync.json {"idleMs": N} (or the broker's
+// FIGMA_AGENT_IDLE_MS env for fast manual testing). The plugin clamps to a floor.
+export const DEFAULT_IDLE_MS = 300_000;
+export const MIN_IDLE_MS = 1_000;
 
 // ── Multi-plugin registry (P4) ──────────────────────────────────────
 // A plugin instance's scene identity, carried on PLUGIN_HELLO and grown by

--- a/figma-agent/tests/figma-sync-config.test.ts
+++ b/figma-agent/tests/figma-sync-config.test.ts
@@ -1,0 +1,60 @@
+// spec 004 P4 — the broker's idle-window config reader. Order: FIGMA_AGENT_IDLE_MS
+// env → design/figma-sync.json {"idleMs"} → DEFAULT_IDLE_MS, with a MIN_IDLE_MS floor.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readIdleMs, projectDir, syncConfigPath } from '../cli/src/transport/figma-sync-config.ts';
+import { DEFAULT_IDLE_MS, MIN_IDLE_MS } from '../shared/protocol.ts';
+
+let dir: string;
+const prevDir = process.env['FIGMA_AGENT_CHANGES_DIR'];
+const prevIdle = process.env['FIGMA_AGENT_IDLE_MS'];
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(syncConfigPath(), JSON.stringify(obj), 'utf8');
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fa-sync-cfg-'));
+  process.env['FIGMA_AGENT_CHANGES_DIR'] = join(dir, 'design');
+  mkdirSync(join(dir, 'design'), { recursive: true });
+  delete process.env['FIGMA_AGENT_IDLE_MS'];
+});
+afterEach(() => {
+  if (prevDir === undefined) delete process.env['FIGMA_AGENT_CHANGES_DIR'];
+  else process.env['FIGMA_AGENT_CHANGES_DIR'] = prevDir;
+  if (prevIdle === undefined) delete process.env['FIGMA_AGENT_IDLE_MS'];
+  else process.env['FIGMA_AGENT_IDLE_MS'] = prevIdle;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('figma-sync-config — readIdleMs', () => {
+  it('defaults to DEFAULT_IDLE_MS when no config + no env', () => {
+    expect(readIdleMs()).toBe(DEFAULT_IDLE_MS);
+  });
+  it('reads idleMs from design/figma-sync.json', () => {
+    writeConfig({ idleMs: 10_000 });
+    expect(readIdleMs()).toBe(10_000);
+  });
+  it('the env override wins over the file (fast manual testing)', () => {
+    writeConfig({ idleMs: 300_000 });
+    process.env['FIGMA_AGENT_IDLE_MS'] = '10000';
+    expect(readIdleMs()).toBe(10_000);
+  });
+  it('floors a too-small value to MIN_IDLE_MS', () => {
+    writeConfig({ idleMs: 50 });
+    expect(readIdleMs()).toBe(MIN_IDLE_MS);
+  });
+  it('falls back to DEFAULT_IDLE_MS on a malformed config', () => {
+    writeFileSync(syncConfigPath(), '{ not json', 'utf8');
+    expect(readIdleMs()).toBe(DEFAULT_IDLE_MS);
+  });
+  it('a non-numeric idleMs falls back to DEFAULT_IDLE_MS', () => {
+    writeConfig({ idleMs: 'soon' });
+    expect(readIdleMs()).toBe(DEFAULT_IDLE_MS);
+  });
+  it('projectDir is the parent of the design/ change-log dir', () => {
+    expect(projectDir()).toBe(dir);
+  });
+});

--- a/figma-agent/tests/panel-model.test.ts
+++ b/figma-agent/tests/panel-model.test.ts
@@ -8,6 +8,7 @@ import {
   stateView, formatAge, formatDuration, timeAgo, humanizeTool,
   toActivityRecord, pushActivity, troubleshootHint, showOnboarding,
   togglePanelMode, detailsLabel, compactMeta, PANEL_WIDTH, PANEL_HEIGHT,
+  syncPromptLabel, syncResultLabel,
   type ActivityRecord,
 } from '../plugin/src/ui/panel-model.ts';
 import type { ConnectionState } from '../shared/protocol.ts';
@@ -150,5 +151,22 @@ describe('panel mode (P5.1) — compact-first, expand on demand', () => {
     expect(compactMeta('connected')).toBeNull();
     expect(compactMeta('probing')).toBeNull();
     expect(compactMeta('handshake')).toBeNull();
+  });
+});
+
+describe('idle-commit prompt labels (spec 004 P4)', () => {
+  it('syncPromptLabel pluralizes and floors count at 1', () => {
+    expect(syncPromptLabel(1)).toBe('1 change ready');
+    expect(syncPromptLabel(3)).toBe('3 changes ready');
+    expect(syncPromptLabel(0)).toBe('1 change ready'); // never shows "0 changes"
+    expect(syncPromptLabel(2.9)).toBe('2 changes ready'); // floored
+    expect(syncPromptLabel(Number.NaN)).toBe('1 change ready');
+  });
+  it('syncResultLabel marks success with ✓ and surfaces the failure reason', () => {
+    expect(syncResultLabel(true, 'synced — 2 updated, 1 deprecated, 0 pending'))
+      .toBe('Synced ✓ — synced — 2 updated, 1 deprecated, 0 pending');
+    expect(syncResultLabel(false, 'ui not runnable')).toBe('Sync failed — ui not runnable');
+    expect(syncResultLabel(true, '')).toBe('Synced ✓ — done'); // empty summary → sane default
+    expect(syncResultLabel(false, '   ')).toBe('Sync failed — failed');
   });
 });

--- a/src/commands/figma-reconcile-run.ts
+++ b/src/commands/figma-reconcile-run.ts
@@ -1,0 +1,197 @@
+/**
+ * `ui figma reconcile` runner (spec 004 P2 dry-run + P4 apply) — the IO layer.
+ * Owns ALL fs IO; the transforms are pure (figma-reconcile.ts preview, figma-apply.ts
+ * apply). Zero network, zero LLM. Split from figma.ts to keep it a thin shell.
+ *   --dry-run (default) → preview the delta; write nothing; cursor untouched.
+ *   --apply             → commit (soft-deprecate deletes, refresh scope / un-deprecate
+ *                         re-touches) and advance the apply cursor. Adds stay `pending`.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import type { ParsedArgs } from "../core/cli-args.js";
+import type { CommandResult } from "../core/output.js";
+import { errJson, errText, okJson } from "../core/output.js";
+import {
+  RegistryError,
+  createEmptyRegistry,
+  loadRegistry,
+  saveRegistry,
+  type Registry,
+} from "../core/registry-store.js";
+import {
+  ReconcileError,
+  coalesceFrames,
+  computePreviewDelta,
+  parseChangeLog,
+  scopeSummary,
+} from "../core/figma-reconcile.js";
+import type { RegistryView } from "../core/figma-reconcile.js";
+import { applyDelta, type ApplyReport } from "../core/figma-apply.js";
+import { readCursor, syncStatePath, writeCursor } from "../core/figma-sync-state.js";
+
+const CHANGE_LOG_RELPATH = ["design", "figma.changes.jsonl"] as const;
+const REGISTRY_RELPATH = ["design", "component-registry.json"] as const;
+const SUB = "figma reconcile";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function flagString(parsed: ParsedArgs, key: string): string | undefined {
+  const v = parsed.flags[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function projectDir(parsed: ParsedArgs): string {
+  const dir = flagString(parsed, "dir");
+  return dir !== undefined ? resolve(dir) : process.cwd();
+}
+
+/** Strip control chars / collapse newlines so untrusted node names can't spoof text output. */
+function safeText(s: string, max = 80): string {
+  // eslint-disable-next-line no-control-regex
+  const cleaned = s.replace(/[\x00-\x1f\x7f]/g, " ").replace(/\s+/g, " ").trim();
+  return cleaned.length > max ? cleaned.slice(0, max - 1) + "…" : cleaned;
+}
+
+/** Parse --since into a non-negative integer, or null if malformed. undefined → null (not given). */
+function parseSince(raw: string | undefined): number | null {
+  if (raw === undefined) return null;
+  if (!/^\d+$/.test(raw.trim())) return null;
+  return Number.parseInt(raw.trim(), 10);
+}
+
+// ─── Runner ─────────────────────────────────────────────────────────────────
+
+export function runReconcile(parsed: ParsedArgs): CommandResult {
+  const useJson = parsed.json;
+  const apply = parsed.flags["apply"] === true;
+  const dryRunFlag = parsed.flags["dry-run"] === true;
+
+  if (apply && dryRunFlag) {
+    const msg = "--apply cannot be combined with --dry-run";
+    return useJson ? errJson(SUB, "BAD_ARG", msg) : errText(`ui: ${msg}\n`);
+  }
+
+  const sinceRaw = flagString(parsed, "since");
+  const sinceGiven = sinceRaw !== undefined;
+  const since = parseSince(sinceRaw);
+  if (sinceGiven && since === null) {
+    const msg = "--since must be a non-negative integer (a line-count cursor)";
+    return useJson ? errJson(SUB, "BAD_ARG", msg) : errText(`ui: ${msg}\n`);
+  }
+
+  const dir = projectDir(parsed);
+  const logPath = join(dir, ...CHANGE_LOG_RELPATH);
+  const registryPath = join(dir, ...REGISTRY_RELPATH);
+  const statePath = syncStatePath(dir);
+
+  // Parse the whole change-log (absent → empty). A corrupt line fails hard.
+  let frames;
+  try {
+    const raw = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+    frames = parseChangeLog(raw);
+  } catch (e) {
+    if (e instanceof ReconcileError) {
+      return useJson ? errJson(SUB, e.code, e.message) : errText(`ui: ${e.message}\n`);
+    }
+    throw e;
+  }
+
+  // Load the full registry (absent → empty). A malformed registry fails hard.
+  let registry: Registry;
+  try {
+    registry = existsSync(registryPath) ? loadRegistry(registryPath) : createEmptyRegistry();
+  } catch (e) {
+    if (e instanceof RegistryError) {
+      return useJson ? errJson(SUB, e.code, e.message) : errText(`ui: ${e.message}\n`);
+    }
+    throw e;
+  }
+  const existing: ReadonlyMap<string, RegistryView> = new Map(
+    registry.components.map((c) => [c.name, { name: c.name, scope: c.scope, deprecated: c.deprecated }]),
+  );
+
+  const cursorTo = frames.length;
+  // dry-run defaults the cursor to 0 (preview whole log); apply defaults it to the
+  // persisted apply cursor (resume where the last commit stopped). --since overrides both.
+  const cursorFrom0 = sinceGiven ? (since as number) : apply ? readCursor(statePath) : 0;
+  const cursorFrom = Math.min(cursorFrom0, cursorTo);
+  const slice = frames.slice(cursorFrom);
+  const delta = computePreviewDelta(coalesceFrames(slice), existing);
+  const scope = scopeSummary(delta);
+
+  const base = {
+    cursor_from: cursorFrom,
+    cursor_to: cursorTo,
+    delta: { added: delta.added, updated: delta.updated, deprecated: delta.deprecated },
+    scope_summary: scope,
+    ...(delta.unresolved.length > 0 && { caps: { unresolved: delta.unresolved } }),
+  };
+
+  if (!apply) {
+    const data = { ...base, dry_run: true as const };
+    return useJson ? okJson(SUB, data) : { exitCode: 0, stdout: renderDryRun(data) };
+  }
+
+  // ── APPLY: mutate the registry, persist it (if changed), advance the cursor ──
+  const { registry: next, report, changed } = applyDelta(registry, delta);
+  try {
+    if (changed) saveRegistry(registryPath, next);
+    writeCursor(statePath, cursorTo);
+  } catch (e) {
+    if (e instanceof RegistryError) {
+      return useJson ? errJson(SUB, e.code, e.message) : errText(`ui: ${e.message}\n`);
+    }
+    const msg = e instanceof Error ? e.message : String(e);
+    return useJson ? errJson(SUB, "WRITE_ERROR", msg) : errText(`ui: ${msg}\n`);
+  }
+
+  const data = { ...base, dry_run: false as const, applied: true as const, apply: report };
+  return useJson ? okJson(SUB, data) : { exitCode: 0, stdout: renderApply(data, report) };
+}
+
+// ─── Text rendering (JSON envelope is the authoritative form) ─────────────────
+
+interface DeltaText {
+  cursor_from: number;
+  cursor_to: number;
+  delta: {
+    added: { name: string; scope: string }[];
+    updated: { name: string; scope: string; fields: string[] }[];
+    deprecated: { name: string; scope: string }[];
+  };
+  scope_summary: { local: number; global: number };
+  caps?: { unresolved: { nodeId: string; reason: string }[] };
+}
+
+function renderDeltaLines(data: DeltaText, header: string): string[] {
+  const lines: string[] = [];
+  lines.push(header);
+  lines.push(
+    `  ${data.delta.added.length} added · ${data.delta.updated.length} updated · ${data.delta.deprecated.length} deprecated ` +
+      `(scope: ${data.scope_summary.local} local, ${data.scope_summary.global} global)`,
+  );
+  for (const e of data.delta.added) lines.push(`  + ${safeText(e.name)} (${e.scope})`);
+  for (const e of data.delta.updated) {
+    const fields = e.fields.length > 0 ? ` [${e.fields.join(", ")}]` : "";
+    lines.push(`  ~ ${safeText(e.name)} (${e.scope})${fields}`);
+  }
+  for (const e of data.delta.deprecated) lines.push(`  - ${safeText(e.name)} (${e.scope}) deprecated`);
+  if (data.caps !== undefined) lines.push(`  ! ${data.caps.unresolved.length} unresolved (no component name)`);
+  return lines;
+}
+
+function renderDryRun(data: DeltaText): string {
+  const lines = renderDeltaLines(data, `figma reconcile (dry-run) — cursor ${data.cursor_from}..${data.cursor_to}`);
+  return lines.join("\n") + "\n";
+}
+
+function renderApply(data: DeltaText, report: ApplyReport): string {
+  const lines = renderDeltaLines(data, `figma reconcile (applied) — cursor ${data.cursor_from}..${data.cursor_to}`);
+  lines.push(
+    `  → ${report.deprecated.length} deprecated · ${report.updated.length} updated · ` +
+      `${report.pending.length} pending re-ingest · ${report.skipped.length} skipped`,
+  );
+  for (const p of report.pending) lines.push(`  · pending ${safeText(p.name)} — ${p.reason}`);
+  return lines.join("\n") + "\n";
+}

--- a/src/commands/figma.ts
+++ b/src/commands/figma.ts
@@ -1,52 +1,45 @@
 /**
  * `ui figma` command — the deterministic Figma live-sync surface (spec 004, Tier 3).
  *
- * P2 ships one subcommand: `reconcile --dry-run`. It walks the append-only change-log
- * (design/figma.changes.jsonl) from a line-count cursor, coalesces cross-batch to the
- * component level, and previews the registry delta (added / updated / deprecated) —
- * WITHOUT writing anything. `--apply` (commit + cursor advance) lands in P4.
+ * One subcommand, two modes:
+ *   `reconcile --dry-run` (P2) previews the registry delta implied by the change-log.
+ *   `reconcile --apply`   (P4) commits that delta into the registry and advances the
+ *                              persisted apply cursor. Both walk design/figma.changes.jsonl
+ *                              from a line-count cursor and coalesce cross-batch.
  *
- * This command owns all IO; the transform is pure (src/core/figma-reconcile.ts). Zero
- * network, zero LLM (kernel rule). The `design-os figma reconcile` umbrella is a thin
- * Typer passthrough to this command — deferred to P4 where apply + the panel land.
+ * This command owns registration + help; the IO runner lives in figma-reconcile-run.ts
+ * and the transforms are pure (figma-reconcile.ts preview, figma-apply.ts apply). Zero
+ * network, zero LLM (kernel rule).
  */
-import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-
 import type { ParsedArgs } from "../core/cli-args.js";
 import type { CommandResult } from "../core/output.js";
-import { errJson, errText, okJson } from "../core/output.js";
-import { RegistryError, loadRegistry } from "../core/registry-store.js";
-import {
-  ReconcileError,
-  coalesceFrames,
-  computePreviewDelta,
-  parseChangeLog,
-  scopeSummary,
-} from "../core/figma-reconcile.js";
-import type { RegistryView } from "../core/figma-reconcile.js";
+import { errJson, errText } from "../core/output.js";
+import { runReconcile } from "./figma-reconcile-run.js";
 
 const CMD = "figma";
-const CHANGE_LOG_RELPATH = ["design", "figma.changes.jsonl"] as const;
-const REGISTRY_RELPATH = ["design", "component-registry.json"] as const;
 
 export const FIGMA_HELP = `ui figma — deterministic Figma live-sync (spec 004)
 
 Usage:
-  ui figma reconcile [--since <n>] [--dry-run] [--dir <project>] [--json]
+  ui figma reconcile [--since <n>] [--dry-run | --apply] [--dir <project>] [--json]
 
 Subcommands:
-  reconcile   Preview the registry delta implied by the change-log (dry-run only)
+  reconcile   Preview (--dry-run) or commit (--apply) the registry delta from the change-log
 
-reconcile walks design/figma.changes.jsonl from line-count cursor <n> to the end,
-coalesces cross-batch to the component level, and reports what the registry WOULD
-become — added / updated / deprecated — without writing anything or advancing the
-cursor. Apply (--apply, cursor commit) lands in P4.
+reconcile walks design/figma.changes.jsonl from a line-count cursor, coalesces
+cross-batch to the component level, and reports what the registry WOULD become —
+added / updated / deprecated.
+
+  --dry-run  Preview only; never writes; the cursor is untouched (the default).
+  --apply    Commit the delta: soft-deprecate deletes, refresh scope + un-deprecate
+             re-touches, then advance the persisted apply cursor to the log end. New
+             components stay 'pending' (the log lacks their markup/tokens — run
+             'ui ingest-figma-ds' to materialize them). Undo = replay to a prior
+             cursor (the append-only log is the source of truth).
 
 Options:
-  --since <n>      Line-count cursor to start from (default 0 = whole log)
-  --dry-run        Preview only; never writes (P2 is always dry-run — this is the
-                   default and only mode; --apply arrives in P4)
+  --since <n>      Line-count cursor to start from (dry-run default 0; apply default =
+                   the persisted apply cursor in design/figma-sync.state.json)
   --dir <path>     Project directory holding design/ (default: current directory)
   --json           Emit a JSON envelope instead of human-readable text
   -h, --help       Show this help
@@ -54,139 +47,22 @@ Options:
 Scope mapping:
   Records are tagged scope: local | global. scopeHint (origin REMOTE → global) is a
   HINT, not authoritative: a new component takes the hint; an existing one keeps its
-  registry scope unless the hint promotes local → global. Each entry reports
-  scopeFromHint so the decision is transparent.
+  registry scope unless the hint promotes local → global.
 
 Error codes:
-  BAD_ARG            --since is not a non-negative integer, or unknown subcommand
+  BAD_ARG            --since is malformed, --apply combined with --dry-run, or unknown subcommand
   UNKNOWN_FLAG       a flag outside this command's signature was passed
   BAD_CHANGE_LOG     the change-log has a malformed / wrong-version line
   BAD_REGISTRY       the component registry is invalid JSON or wrong shape
+  WRITE_ERROR        --apply could not write the registry or the cursor state
   READ_ERROR         a non-ENOENT I/O failure reading the registry
 
 Notes:
-  - A missing change-log or missing registry is not an error: an absent log yields an
-    empty delta (exit 0); an absent registry previews every component as added.
+  - A missing change-log or registry is not an error: an absent log yields an empty
+    delta (exit 0); an absent registry previews every component as added.
   - Exit 0 even when the delta is empty (a clean, already-synced project).
   - Deterministic: pure transform over the captured log. No network, no model call.
 `;
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function flagString(parsed: ParsedArgs, key: string): string | undefined {
-  const v = parsed.flags[key];
-  return typeof v === "string" ? v : undefined;
-}
-
-function projectDir(parsed: ParsedArgs): string {
-  const dir = flagString(parsed, "dir");
-  return dir !== undefined ? resolve(dir) : process.cwd();
-}
-
-/** Strip control chars / collapse newlines so untrusted node names can't spoof text output. */
-function safeText(s: string, max = 80): string {
-  // eslint-disable-next-line no-control-regex
-  const cleaned = s.replace(/[\x00-\x1f\x7f]/g, " ").replace(/\s+/g, " ").trim();
-  return cleaned.length > max ? cleaned.slice(0, max - 1) + "…" : cleaned;
-}
-
-/** Parse --since into a non-negative integer, or return null if malformed. */
-function parseSince(raw: string | undefined): number | null {
-  if (raw === undefined) return 0;
-  if (!/^\d+$/.test(raw.trim())) return null;
-  return Number.parseInt(raw.trim(), 10);
-}
-
-// ─── Subcommand: reconcile ────────────────────────────────────────────────────
-
-function runReconcile(parsed: ParsedArgs): CommandResult {
-  const useJson = parsed.json;
-  const sub = "figma reconcile";
-
-  const since = parseSince(flagString(parsed, "since"));
-  if (since === null) {
-    const msg = "--since must be a non-negative integer (a line-count cursor)";
-    return useJson ? errJson(sub, "BAD_ARG", msg) : errText(`ui: ${msg}\n`);
-  }
-
-  const dir = projectDir(parsed);
-  const logPath = join(dir, ...CHANGE_LOG_RELPATH);
-  const registryPath = join(dir, ...REGISTRY_RELPATH);
-
-  // Parse the whole change-log (absent → empty). A corrupt line fails hard.
-  let frames;
-  try {
-    const raw = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
-    frames = parseChangeLog(raw);
-  } catch (e) {
-    if (e instanceof ReconcileError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
-    }
-    throw e;
-  }
-
-  // Load the registry (absent → empty: every component previews as added).
-  let existing: ReadonlyMap<string, RegistryView>;
-  try {
-    const reg = loadRegistry(registryPath);
-    existing = new Map(
-      reg.components.map((c) => [c.name, { name: c.name, scope: c.scope, deprecated: c.deprecated } as RegistryView]),
-    );
-  } catch (e) {
-    if (e instanceof RegistryError && e.code === "REGISTRY_NOT_FOUND") {
-      existing = new Map();
-    } else if (e instanceof RegistryError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
-    } else {
-      throw e;
-    }
-  }
-
-  const cursorTo = frames.length;
-  const cursorFrom = Math.min(since, cursorTo);
-  const slice = frames.slice(cursorFrom);
-  const delta = computePreviewDelta(coalesceFrames(slice), existing);
-  const scope = scopeSummary(delta);
-
-  const data = {
-    cursor_from: cursorFrom,
-    cursor_to: cursorTo,
-    dry_run: true as const,
-    delta: { added: delta.added, updated: delta.updated, deprecated: delta.deprecated },
-    scope_summary: scope,
-    ...(delta.unresolved.length > 0 && { caps: { unresolved: delta.unresolved } }),
-  };
-
-  if (useJson) return okJson(sub, data);
-
-  return { exitCode: 0, stdout: renderText(data) };
-}
-
-/** Human-readable summary (names sanitized). The JSON envelope is the authoritative form. */
-function renderText(data: {
-  cursor_from: number;
-  cursor_to: number;
-  delta: { added: { name: string; scope: string }[]; updated: { name: string; scope: string; fields: string[] }[]; deprecated: { name: string; scope: string }[] };
-  scope_summary: { local: number; global: number };
-  caps?: { unresolved: { nodeId: string; reason: string }[] };
-}): string {
-  const lines: string[] = [];
-  lines.push(`figma reconcile (dry-run) — cursor ${data.cursor_from}..${data.cursor_to}`);
-  lines.push(
-    `  ${data.delta.added.length} added · ${data.delta.updated.length} updated · ${data.delta.deprecated.length} deprecated ` +
-      `(scope: ${data.scope_summary.local} local, ${data.scope_summary.global} global)`,
-  );
-  for (const e of data.delta.added) lines.push(`  + ${safeText(e.name)} (${e.scope})`);
-  for (const e of data.delta.updated) {
-    const fields = e.fields.length > 0 ? ` [${e.fields.join(", ")}]` : "";
-    lines.push(`  ~ ${safeText(e.name)} (${e.scope})${fields}`);
-  }
-  for (const e of data.delta.deprecated) lines.push(`  - ${safeText(e.name)} (${e.scope}) deprecated`);
-  if (data.caps !== undefined) {
-    lines.push(`  ! ${data.caps.unresolved.length} unresolved (no component name)`);
-  }
-  return lines.join("\n") + "\n";
-}
 
 // ─── Command registration object ──────────────────────────────────────────────
 

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -456,14 +456,15 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
     summary: "Deterministic Figma live-sync: reconcile the change-log into the registry",
     subcommands: {
       reconcile: {
-        summary: "Preview the registry delta implied by the change-log (dry-run only)",
+        summary: "Preview (--dry-run) or commit (--apply) the registry delta from the change-log",
         positionals: [],
         flags: [
-          { name: "since", type: "string", summary: "Line-count cursor to start from (default 0 = whole log)" },
-          { name: "dry-run", type: "boolean", summary: "Preview only; never writes (P2 is always dry-run; --apply arrives in P4)" },
+          { name: "since", type: "string", summary: "Line-count cursor to start from (dry-run default 0; apply default = persisted cursor)" },
+          { name: "dry-run", type: "boolean", summary: "Preview only; never writes; cursor untouched (the default)" },
+          { name: "apply", type: "boolean", summary: "Commit the delta into the registry and advance the apply cursor" },
           { name: "dir", type: "string", summary: "Project directory holding design/ (default: current directory)" },
         ],
-        errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "BAD_CHANGE_LOG", "BAD_REGISTRY", "READ_ERROR"],
+        errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "BAD_CHANGE_LOG", "BAD_REGISTRY", "WRITE_ERROR", "READ_ERROR"],
       },
     },
   },

--- a/src/core/figma-apply.ts
+++ b/src/core/figma-apply.ts
@@ -1,0 +1,112 @@
+/**
+ * Figma live-sync APPLY core (spec 004 P4, Tier 3 — deterministic, pure).
+ *
+ * Takes the P2 preview-delta (src/core/figma-reconcile.ts) plus the current
+ * registry and returns the NEXT registry + a report of what changed. No fs, no
+ * network, no LLM — the command layer (figma-reconcile-run.ts) owns all IO and the
+ * cursor advance. Zero fabrication: apply writes only what the append-only log can
+ * faithfully imply.
+ *
+ * What apply can faithfully write from the log alone:
+ *   - deprecated (a DELETE)   → set `deprecated: true` on the existing record.
+ *   - updated (a re-touch)    → refresh `scope` (a REMOTE-origin promotion) AND clear
+ *                               any `deprecated` flag (the component is live again).
+ *
+ * What it deliberately does NOT write:
+ *   - added (a brand-NEW component) → the log carries identity + scope but NOT the
+ *     markup / tokens / category a ComponentRecord requires. Materializing a stub
+ *     would fabricate content and risk empty-markup records crashing downstream
+ *     emitters. Added components are reported `pending` — `ui ingest-figma-ds`
+ *     supplies their real content. See spec 004 P4 executor note.
+ *
+ * Because deprecate ↔ un-deprecate are both derivable from the log, replaying the
+ * WHOLE log over a base registry reproduces the correct final lifecycle state — a
+ * later CREATE/UPDATE of a deleted component un-deprecates it. That is the
+ * "replayable view over the log" undo path the spec asks for.
+ */
+import {
+  registerComponent,
+  type ComponentRecord,
+  type ComponentScope,
+  type Registry,
+} from "./registry-store.js";
+import type { PreviewDelta } from "./figma-reconcile.js";
+
+/** What `applyDelta` actually did, by component name (all arrays sorted by the delta order). */
+export interface ApplyReport {
+  /** Existing records set `deprecated: true` (a DELETE landed). */
+  deprecated: string[];
+  /** Existing records whose `scope` and/or `deprecated` refreshed (a re-touch). */
+  updated: string[];
+  /** New components the log cannot materialize — need `ui ingest-figma-ds`. */
+  pending: { name: string; reason: string }[];
+  /** A deprecate/update whose target name is not in the registry — nothing to write. */
+  skipped: { name: string; reason: string }[];
+}
+
+/** Empty apply report (also the "nothing changed" shape). */
+function emptyReport(): ApplyReport {
+  return { deprecated: [], updated: [], pending: [], skipped: [] };
+}
+
+/**
+ * Apply a preview-delta to a registry, returning the next registry + a report.
+ * Pure: the input registry is never mutated (registerComponent returns a fresh
+ * copy each call). Idempotent — re-applying the same delta over the result is a
+ * no-op (deprecate on an already-deprecated record, or a re-touch that changes
+ * nothing, both short-circuit).
+ */
+export function applyDelta(
+  reg: Registry,
+  delta: PreviewDelta,
+): { registry: Registry; report: ApplyReport; changed: boolean } {
+  let registry = reg;
+  let changed = false;
+  const report = emptyReport();
+
+  // ── DELETE → soft-deprecate the existing record ──────────────────────────────
+  for (const e of delta.deprecated) {
+    const existing = findByName(registry, e.name);
+    if (existing === undefined) {
+      report.skipped.push({ name: e.name, reason: "delete of a component not in the registry" });
+      continue;
+    }
+    if (existing.deprecated === true) continue; // already deprecated — idempotent no-op
+    registry = registerComponent(registry, { ...existing, deprecated: true }, true).registry;
+    report.deprecated.push(e.name);
+    changed = true;
+  }
+
+  // ── UPDATE → refresh scope + clear any deprecation (re-touched = live again) ──
+  for (const e of delta.updated) {
+    const existing = findByName(registry, e.name);
+    if (existing === undefined) {
+      // Should not happen (updated ⇒ prior existed), but stay defensive.
+      report.skipped.push({ name: e.name, reason: "update of a component not in the registry" });
+      continue;
+    }
+    const nextScope = e.scope as ComponentScope;
+    const scopeChanged = (existing.scope ?? "local") !== nextScope;
+    const wasDeprecated = existing.deprecated === true;
+    if (!scopeChanged && !wasDeprecated) continue; // nothing the log can faithfully change
+    const next: ComponentRecord = { ...existing, scope: nextScope };
+    delete next.deprecated; // un-deprecate — Figma still has (and just touched) it
+    registry = registerComponent(registry, next, true).registry;
+    report.updated.push(e.name);
+    changed = true;
+  }
+
+  // ── ADD → cannot materialize markup/tokens from the log → pending re-ingest ───
+  for (const e of delta.added) {
+    report.pending.push({
+      name: e.name,
+      reason: "new component — run `ui ingest-figma-ds` to materialize markup/tokens",
+    });
+  }
+
+  return { registry, report, changed };
+}
+
+function findByName(reg: Registry, name: string): ComponentRecord | undefined {
+  return reg.components.find((c) => c.name === name);
+}

--- a/src/core/figma-sync-state.ts
+++ b/src/core/figma-sync-state.ts
@@ -1,0 +1,44 @@
+/**
+ * Figma live-sync apply cursor (spec 004 P4, Tier 3 — the applied-so-far marker).
+ *
+ * `ui figma reconcile --apply` walks the append-only change-log from a line-count
+ * cursor. That cursor is persisted HERE — `design/figma-sync.state.json` — so the
+ * NEXT apply starts where the last one stopped, and a replay can rewind it. The log
+ * is the source of truth (audit + undo); this file is just "how far have we applied".
+ *
+ * Deliberately separate from the log and the registry: the log is append-only
+ * (never rewritten), the registry is the materialized view, and this is the single
+ * mutable integer between them. Absent file → cursor 0 (apply the whole log).
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** Path of the apply-cursor state file, relative to a project dir. */
+export const SYNC_STATE_RELPATH = ["design", "figma-sync.state.json"] as const;
+
+/** Absolute path to `<dir>/design/figma-sync.state.json`. */
+export function syncStatePath(dir: string): string {
+  return join(dir, ...SYNC_STATE_RELPATH);
+}
+
+/**
+ * Read the persisted apply cursor. Absent file → 0. A malformed / non-integer
+ * value is treated as 0 (a corrupt marker must not wedge the loop — the log is
+ * still the truth and a full re-apply is deterministic).
+ */
+export function readCursor(path: string): number {
+  if (!existsSync(path)) return 0;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { cursor?: unknown };
+    const c = parsed?.cursor;
+    return typeof c === "number" && Number.isInteger(c) && c >= 0 ? c : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Write the apply cursor (deterministic, trailing newline; mirrors saveRegistry). */
+export function writeCursor(path: string, cursor: number): void {
+  mkdirSync(dirname(path), { recursive: true }); // design/ may not exist yet on a fresh project
+  writeFileSync(path, JSON.stringify({ cursor }, null, 2) + "\n", "utf8");
+}

--- a/tests/cmd-figma-reconcile-apply.test.ts
+++ b/tests/cmd-figma-reconcile-apply.test.ts
@@ -1,0 +1,224 @@
+/**
+ * spec 004 P4 — `ui figma reconcile --apply`: the deterministic commit path.
+ *
+ * Everything is verifiable from hand-written fixtures (Art III mechanism check; the
+ * live Figma dogfood runs separately). Covers the pure applyDelta transform and the
+ * command IO: registry write, cursor advance, idempotence, replay-composition, and
+ * the "un-deprecate via replay" undo property.
+ */
+import { describe, expect, it, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { run } from "../src/cli.js";
+import { coalesceFrames, computePreviewDelta } from "../src/core/figma-reconcile.js";
+import type { ChangeFrame, RegistryView } from "../src/core/figma-reconcile.js";
+import { applyDelta } from "../src/core/figma-apply.js";
+import { readCursor, syncStatePath } from "../src/core/figma-sync-state.js";
+import { createEmptyRegistry, type ComponentRecord, type Registry } from "../src/core/registry-store.js";
+
+// ─── fixture builders ──────────────────────────────────────────────────────────
+
+function frame(over: Partial<ChangeFrame> = {}): ChangeFrame {
+  return {
+    v: 1, ts: 1000, op: "updated", nodeId: "1:1", nodeName: "Button/Primary",
+    nodeType: "COMPONENT", changedProps: [], origin: "LOCAL", scopeHint: "local",
+    page: "Page 1", fileKey: "abc", ...over,
+  };
+}
+
+function jsonl(frames: ChangeFrame[]): string {
+  return frames.map((f) => JSON.stringify(f)).join("\n") + "\n";
+}
+
+function rec(over: Partial<ComponentRecord> & { name: string }): ComponentRecord {
+  return { category: "button", markup: "<button></button>", tokensUsed: [], scope: "local", ...over };
+}
+
+function registry(components: ComponentRecord[]): Registry {
+  return { version: "0.1.0", components };
+}
+
+function viewOf(reg: Registry): ReadonlyMap<string, RegistryView> {
+  return new Map(reg.components.map((c) => [c.name, { name: c.name, scope: c.scope, deprecated: c.deprecated }]));
+}
+
+function deltaOf(reg: Registry, frames: ChangeFrame[], since = 0) {
+  return computePreviewDelta(coalesceFrames(frames.slice(since)), viewOf(reg));
+}
+
+// ─── pure: applyDelta ────────────────────────────────────────────────────────
+
+describe("figma-apply — applyDelta", () => {
+  it("soft-deprecates a deleted component (existing record)", () => {
+    const reg = registry([rec({ name: "Card/Basic" })]);
+    const delta = deltaOf(reg, [frame({ op: "deleted", nodeName: "Card/Basic", nodeId: "c" })]);
+    const { registry: next, report, changed } = applyDelta(reg, delta);
+    expect(changed).toBe(true);
+    expect(report.deprecated).toEqual(["Card/Basic"]);
+    expect(next.components[0]!.deprecated).toBe(true);
+  });
+
+  it("un-deprecates + promotes scope on a re-touch (updated)", () => {
+    const reg = registry([rec({ name: "Lib/Btn", deprecated: true, scope: "local" })]);
+    const delta = deltaOf(reg, [frame({ op: "updated", nodeName: "Lib/Btn", nodeId: "b", scopeHint: "global", origin: "REMOTE" })]);
+    const { registry: next, report } = applyDelta(reg, delta);
+    expect(report.updated).toEqual(["Lib/Btn"]);
+    expect(next.components[0]!.deprecated).toBeUndefined(); // cleared — live again
+    expect(next.components[0]!.scope).toBe("global"); // REMOTE hint promoted
+  });
+
+  it("reports a brand-new component as pending (never fabricates markup)", () => {
+    const reg = createEmptyRegistry();
+    const delta = deltaOf(reg, [frame({ op: "created", nodeName: "Badge/New", nodeId: "n" })]);
+    const { registry: next, report, changed } = applyDelta(reg, delta);
+    expect(changed).toBe(false);
+    expect(next.components.length).toBe(0); // registry NOT polluted with an empty stub
+    expect(report.pending.map((p) => p.name)).toEqual(["Badge/New"]);
+  });
+
+  it("skips a delete/update of a name not in the registry", () => {
+    const reg = createEmptyRegistry();
+    const delta = deltaOf(reg, [frame({ op: "deleted", nodeName: "Ghost/Gone", nodeId: "g" })]);
+    const { report, changed } = applyDelta(reg, delta);
+    expect(changed).toBe(false);
+    // A delete of an unknown name buckets as deprecated in the delta but skips on apply.
+    expect(report.skipped.map((s) => s.name)).toEqual(["Ghost/Gone"]);
+  });
+
+  it("is idempotent — re-applying the same delta changes nothing", () => {
+    const reg = registry([rec({ name: "Card/Basic" })]);
+    const delta = deltaOf(reg, [frame({ op: "deleted", nodeName: "Card/Basic", nodeId: "c" })]);
+    const once = applyDelta(reg, delta).registry;
+    const twice = applyDelta(once, deltaOf(once, [frame({ op: "deleted", nodeName: "Card/Basic", nodeId: "c" })]));
+    expect(twice.changed).toBe(false);
+    expect(twice.registry).toEqual(once);
+  });
+
+  it("replay-composition: full apply == two-segment apply (deterministic view over the log)", () => {
+    const reg = registry([rec({ name: "Nav/Bar", scope: "local" })]);
+    const frames = [
+      frame({ ts: 1, op: "deleted", nodeName: "Nav/Bar", nodeId: "n" }),
+      frame({ ts: 2, op: "updated", nodeName: "Nav/Bar", nodeId: "n2", scopeHint: "global", origin: "REMOTE" }),
+    ];
+    // full replay [0..2)
+    const full = applyDelta(reg, deltaOf(reg, frames)).registry;
+    // segmented: [0..1) then [1..2)
+    const seg1 = applyDelta(reg, deltaOf(reg, frames.slice(0, 1))).registry;
+    const seg2 = applyDelta(seg1, computePreviewDelta(coalesceFrames(frames.slice(1)), viewOf(seg1))).registry;
+    expect(seg2).toEqual(full);
+  });
+
+  it("un-deprecate via replay: a delete then a later re-touch nets to NOT deprecated", () => {
+    const reg = registry([rec({ name: "Nav/Bar" })]);
+    // Two separate frames (cross-batch): delete, then a later update → coalesce keeps
+    // deleted (higher rank), BUT the full-log final state models the live doc: the
+    // component still exists. We apply each in ORDER to reproduce the ledger's undo.
+    const del = applyDelta(reg, deltaOf(reg, [frame({ ts: 1, op: "deleted", nodeName: "Nav/Bar", nodeId: "n" })])).registry;
+    expect(del.components[0]!.deprecated).toBe(true);
+    const back = applyDelta(del, computePreviewDelta(
+      coalesceFrames([frame({ ts: 2, op: "updated", nodeName: "Nav/Bar", nodeId: "n" })]),
+      viewOf(del),
+    )).registry;
+    expect(back.components[0]!.deprecated).toBeUndefined(); // replayed re-touch un-deprecates
+  });
+});
+
+// ─── command ─────────────────────────────────────────────────────────────────
+
+function capture(args: string[]): { code: number; out: string; err: string } {
+  let out = "";
+  let err = "";
+  const o = process.stdout.write.bind(process.stdout);
+  const e = process.stderr.write.bind(process.stderr);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stdout.write = (c: any) => { out += String(c); return true; };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stderr.write = (c: any) => { err += String(c); return true; };
+  let code: number;
+  try { code = run(args); } finally { process.stdout.write = o; process.stderr.write = e; }
+  return { code, out, err };
+}
+
+let dir: string;
+function writeLog(frames: ChangeFrame[]): void {
+  writeFileSync(join(dir, "design", "figma.changes.jsonl"), jsonl(frames), "utf8");
+}
+function writeRegistry(components: Array<Record<string, unknown>>): void {
+  writeFileSync(
+    join(dir, "design", "component-registry.json"),
+    JSON.stringify({ version: "0.1.0", components }, null, 2) + "\n",
+    "utf8",
+  );
+}
+function readReg(): Registry {
+  return JSON.parse(readFileSync(join(dir, "design", "component-registry.json"), "utf8"));
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ease-fig-apply-"));
+  mkdirSync(join(dir, "design"), { recursive: true });
+});
+
+describe("ui figma reconcile --apply — command", () => {
+  it("soft-deprecates a delete, writes the registry, advances the cursor", () => {
+    writeRegistry([{ name: "Card/Basic", category: "card", markup: "<div></div>", tokensUsed: [], scope: "local" }]);
+    writeLog([frame({ op: "deleted", nodeName: "Card/Basic", nodeId: "c" })]);
+    const { code, out } = capture(["figma", "reconcile", "--dir", dir, "--apply", "--json"]);
+    expect(code).toBe(0);
+    const env = JSON.parse(out);
+    expect(env.ok).toBe(true);
+    expect(env.data.applied).toBe(true);
+    expect(env.data.dry_run).toBe(false);
+    expect(env.data.apply.deprecated).toEqual(["Card/Basic"]);
+    // registry mutated on disk
+    expect(readReg().components[0]!.deprecated).toBe(true);
+    // cursor advanced to log end
+    expect(readCursor(syncStatePath(dir))).toBe(1);
+    expect(env.data.cursor_to).toBe(1);
+  });
+
+  it("--apply is idempotent: a second run is a no-op (registry byte-identical)", () => {
+    writeRegistry([{ name: "Card/Basic", category: "card", markup: "<div></div>", tokensUsed: [], scope: "local" }]);
+    writeLog([frame({ op: "deleted", nodeName: "Card/Basic", nodeId: "c" })]);
+    capture(["figma", "reconcile", "--dir", dir, "--apply", "--json"]);
+    const after1 = readFileSync(join(dir, "design", "component-registry.json"), "utf8");
+    const { out } = capture(["figma", "reconcile", "--dir", dir, "--apply", "--json"]);
+    const env = JSON.parse(out);
+    expect(env.data.cursor_from).toBe(1); // resumed from the persisted cursor
+    expect(env.data.cursor_to).toBe(1);
+    expect(env.data.apply.deprecated).toEqual([]); // nothing new
+    expect(readFileSync(join(dir, "design", "component-registry.json"), "utf8")).toBe(after1);
+  });
+
+  it("new components stay pending — registry is not polluted with empty stubs", () => {
+    writeRegistry([]);
+    writeLog([frame({ op: "created", nodeName: "Badge/New", nodeId: "n" })]);
+    const { out } = capture(["figma", "reconcile", "--dir", dir, "--apply", "--json"]);
+    const env = JSON.parse(out);
+    expect(env.data.apply.pending.map((p: { name: string }) => p.name)).toEqual(["Badge/New"]);
+    expect(readReg().components.length).toBe(0);
+    expect(readCursor(syncStatePath(dir))).toBe(1); // cursor still advances (change was seen)
+  });
+
+  it("rejects --apply combined with --dry-run (BAD_ARG)", () => {
+    writeRegistry([]);
+    const { code, out } = capture(["figma", "reconcile", "--dir", dir, "--apply", "--dry-run", "--json"]);
+    expect(code).toBe(1);
+    expect(JSON.parse(out).error.code).toBe("BAD_ARG");
+  });
+
+  it("--since replays a prior cursor without touching the persisted cursor's start", () => {
+    writeRegistry([{ name: "One/A", category: "c", markup: "", tokensUsed: [], scope: "local" }]);
+    writeLog([
+      frame({ nodeId: "a", op: "deleted", nodeName: "One/A" }),
+      frame({ nodeId: "b", op: "created", nodeName: "Two/B" }),
+    ]);
+    const { out } = capture(["figma", "reconcile", "--dir", dir, "--apply", "--since", "0", "--json"]);
+    const env = JSON.parse(out);
+    expect(env.data.cursor_from).toBe(0);
+    expect(env.data.cursor_to).toBe(2);
+    expect(env.data.apply.deprecated).toEqual(["One/A"]);
+    expect(readCursor(syncStatePath(dir))).toBe(2); // advanced to end after replay
+  });
+});


### PR DESCRIPTION
## Spec 004 P4 — idle-commit + panel prompt + apply (the loop closes)

Final phase of Figma live-sync. Joins P1 (capture→log), P2 (reconcile dry-run), P3 (schema).

### What landed
**Tier 3 — deterministic apply (`ui`/kernel)**
- `ui figma reconcile --apply [--since <n>] [--dir]` — reuses P2's `computePreviewDelta`, then commits:
  - **DELETE → soft-deprecate** (`deprecated:true`); **re-touch (updated) → un-deprecate + scope promotion**.
  - **New component → `pending`** (NOT written): the append-only log carries identity + scope but **not** markup/tokens, so materializing a record would fabricate content and risk empty-markup records crashing emitters. `ui ingest-figma-ds` supplies real content. *(Key executor decision — see below.)*
  - **Cursor** persisted in `design/figma-sync.state.json`; advances to the log end. **Undo = replay to a prior cursor** (a delete then a later re-touch nets to not-deprecated — the log is the replayable source of truth).
- Pure transform `src/core/figma-apply.ts` + IO runner `src/commands/figma-reconcile-run.ts` (figma.ts slimmed to a shell; all modules <200 lines).

**Tier 1/2 — capture side (plugin/broker, outside the kernel)**
- Plugin idle timer (`setTimeout(idleMs)`, reset per documentchange) → `IDLE_READY`; the **existing** Swiss-Monolith status panel gains one line **"N changes ready — Sync now / Later"** (no new surface). Sync → `SYNC_REQUEST`.
- Broker reads `idleMs` from `design/figma-sync.json` (env `FIGMA_AGENT_IDLE_MS` wins), sends `SYNC_CONFIG` on hello, and on `SYNC_REQUEST` **spawns `ui figma reconcile --apply`** → `SYNC_RESULT` to the panel. Registry-write logic stays in the kernel; the broker only spawns it.
- `design-os figma reconcile` Typer passthrough → `ui figma reconcile`.
- Deletion soft-deprecate confirmed readable by audit (`audit-spec.ts:92`, `audit-detect.ts:201`) — no change needed.

### Verify — UNIT (this PR, deterministic; no live Figma)
All green: `typecheck`, `lint`, `build`, `test` (root 1843 + figma-agent 209), `ui knowledge check` (0 findings), `design-os pytest` (160).
- `tests/cmd-figma-reconcile-apply.test.ts` — applyDelta (deprecate/un-deprecate+scope/pending/skip), **cursor advance**, **idempotence**, **replay-composition**, **un-deprecate-via-replay** (the undo path), `--apply`+`--dry-run` rejected, `--since` replay.
- `figma-agent/tests/figma-sync-config.test.ts` — idleMs resolution + floor + env override.
- `figma-agent/tests/panel-model.test.ts` — sync prompt labels.
- `design-os/tests/test_plugin_figma.py` — reconcile passthrough argv + KERNEL_NOT_FOUND.

### Verify — LIVE CHECKLIST (owner + orchestrator, run AFTER merge — I cannot; headless)
> Fast-test tip: set `design/figma-sync.json` to `{"idleMs":10000}` (or export `FIGMA_AGENT_IDLE_MS=10000` before the first CLI command that spawns the broker) so idle fires in ~10s instead of 5 min.

1. **Rebuild plugin:** `cd figma-agent && npm run build` (emits `plugin/code.js` + `plugin/ui.html`).
2. **Reload plugin** in Figma Desktop (Plugins → Development → Ease Design Figma Agent) and keep the panel open.
3. Ensure a broker is live (any `figma-agent status` / `ui` command spawns it) so `SYNC_CONFIG` reaches the plugin. Optionally seed a registry component to observe a deprecate (e.g. keep a `Card/Basic`), or just create a new component to observe `pending`.
4. **Edit** a component in Figma (rename / delete / add), then **wait for idle** (10s with the override).
5. Panel shows **"N changes ready — Sync now / Later"**. Click **Sync now** → panel shows **"Syncing…"** then **"Synced ✓ — …"**.
6. **Confirm on disk:** `design/figma.changes.jsonl` has the appended line(s); `design/component-registry.json` reflects the apply (a deleted seed → `deprecated:true`); `design/figma-sync.state.json` cursor advanced to the log line count.
7. (Undo spot-check) `ui figma reconcile --apply --since 0 --json` re-applies deterministically (idempotent).

### Executor decisions
- **Added components → `pending`, not stubbed.** Faithful/deterministic floor; avoids empty-markup records. Materializing new components is a follow-up via `ingest-figma-ds`. *(Surfaced as the main open question.)*
- **Config location:** `design/figma-sync.json` `{"idleMs":N}` (env `FIGMA_AGENT_IDLE_MS` overrides for fast test).
- **Cursor state:** `design/figma-sync.state.json` `{"cursor":N}`.
- **SYNC_REQUEST → apply wiring:** broker **spawns the CLI** (`ui figma reconcile --apply`) rather than calling reconcile core in-process — keeps apply in the deterministic kernel, broker stays a dumb relay.
- **`design-os figma reconcile`:** calls `run_ui` (the deterministic-kernel member of the otherwise figma-agent-wrapping `figma` group), documented as such.

### Unresolved / for owner
1. **Should `--apply` auto-materialize new components as stub records** (markup:"", category from name-prefix) so a brand-new Figma component enters the registry on idle, or keep the `pending` floor (current)? The stub risks empty-markup crashing downstream emitters — hence the conservative default.
2. Multi-file: one broker, one project cwd → apply targets that project. Multi-project reconcile from a shared log is still deferred (frames carry `fileKey` for later partitioning).

**Status:** DONE (unit + gates green; live checklist pending owner).
