### PR TITLE
spec005 SPIKE: reverse-walker node→FigmaExportNode + fixed-point proof

### DIFF
--- a/figma-agent/cli/src/commands/scan-node.ts
+++ b/figma-agent/cli/src/commands/scan-node.ts
@@ -1,0 +1,62 @@
+// `figma-agent scan-node <nodeId>` — the LIVE half of the spec-005 spike.
+// Reuses the EXEC_JS transport: bundles the reverse-walker (plugin/src/main/
+// scan-node.ts) into a self-contained IIFE, injects it, resolves the node by id,
+// and returns `nodeToSpec(node)` as JSON. Bundling the ACTUAL walker source (not a
+// hand-copied string) keeps the injected code drift-free with the unit-tested one.
+//
+// SPIKE NOTE: bundling reads the walker TS source at runtime, so this command needs
+// the repo checkout present (dist-only installs won't have plugin/src). That is
+// acceptable for the spike — the owner runs it from the repo during the live pass.
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import {
+  COMMAND_TIMEOUTS,
+  EXEC_JS_MAX_TIMEOUT_MS,
+} from '../../../shared/protocol.ts';
+import type { CommandArgs } from '../figma-agent.ts';
+import { CliError } from '../transport/protocol-helpers.ts';
+import { runCommand } from '../transport/broker-client.ts';
+
+const WIRE_MARGIN_MS = 2_000;
+
+/** Bundle the reverse-walker module into an IIFE exposing `__scan.nodeToSpec`. */
+async function bundleWalker(): Promise<string> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // From cli/dist (bundled) OR cli/src/commands (ts-run) → plugin/src/main.
+  const src = resolve(here, '../../plugin/src/main/scan-node.ts');
+  const srcAlt = resolve(here, '../../../plugin/src/main/scan-node.ts');
+  for (const entry of [src, srcAlt]) {
+    try {
+      const res = await build({
+        entryPoints: [entry],
+        bundle: true,
+        format: 'iife',
+        globalName: '__scan',
+        platform: 'browser', // Figma sandbox: no node APIs
+        target: 'es2020',
+        write: false,
+        logLevel: 'silent',
+      });
+      return res.outputFiles[0].text;
+    } catch {
+      // try the next candidate path
+    }
+  }
+  throw new CliError('E_INVALID_ARGS', 'cannot locate plugin/src/main/scan-node.ts (repo checkout required)');
+}
+
+export async function run(args: CommandArgs): Promise<unknown> {
+  const nodeId = args.positionals[0];
+  if (!nodeId) throw new CliError('E_INVALID_ARGS', 'scan-node requires a <nodeId>');
+
+  const walker = await bundleWalker();
+  const code = `${walker}
+const node = figma.getNodeById(${JSON.stringify(nodeId)});
+if (!node) throw new Error('node not found: ' + ${JSON.stringify(nodeId)});
+return __scan.nodeToSpec(node);`;
+
+  const requested = args.num('timeout') ?? COMMAND_TIMEOUTS.EXEC_JS ?? 30_000;
+  const timeoutMs = Math.min(requested, EXEC_JS_MAX_TIMEOUT_MS);
+  return runCommand('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS });
+}

--- a/figma-agent/cli/src/figma-agent.ts
+++ b/figma-agent/cli/src/figma-agent.ts
@@ -16,6 +16,7 @@ import * as exportPng from './commands/export-png.ts';
 import * as getSelection from './commands/get-selection.ts';
 import * as htmlToFigma from './commands/html-to-figma.ts';
 import * as scanDesignSystem from './commands/scan-design-system.ts';
+import * as scanNode from './commands/scan-node.ts';
 import * as scanConventions from './commands/scan-conventions.ts';
 import * as auditDs from './commands/audit-ds.ts';
 import * as setAutolayout from './commands/set-autolayout.ts';
@@ -33,6 +34,7 @@ const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<unknown>
   seat,
   'get-selection': getSelection,
   'scan-design-system': scanDesignSystem,
+  'scan-node': scanNode,
   'scan-conventions': scanConventions,
   'audit-ds': auditDs,
   'create-frame': createFrame,
@@ -59,6 +61,7 @@ Commands:
   seat                 Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]
   get-selection        Serialize the current selection [--depth 1]
   scan-design-system   Components/variables/styles registry [--out file.json --timeout ms]
+  scan-node            [SPIKE] Reverse-walk one node → FigmaExportNode spec <nodeId> [--timeout ms]
   scan-conventions     Convention-DNA walk over sections → usage-dna.json [<sectionId...> --out file.json --budget 14000 --timeout ms]
   audit-ds             DS-hygiene audit of the open file's component library [--out file.json --sections "01 A,02 B" --facts raw.json --from-facts raw.json --timeout ms]
   create-frame         --name n --w 400 --h 300 [--parent id --x 0 --y 0]

--- a/figma-agent/plugin/src/main/scan-node.ts
+++ b/figma-agent/plugin/src/main/scan-node.ts
@@ -1,0 +1,275 @@
+// Reverse-walker (spec 005 SPIKE): live SceneNode subtree → FigmaExportNode.
+// The SYMMETRIC inverse of the build path — where build-frame.ts walks DOM+CSS
+// into a FigmaExportNode and executor-frame.createFigmaNode replays that spec onto
+// the canvas, `nodeToSpec` reads the ACTUAL node fields the executor writes back
+// into a FigmaExportNode, so `node → spec → node` can be proven a fixed point.
+//
+// Pure + self-contained (only TYPE imports, erased at runtime) so the CLI
+// `scan-node` command can inject `nodeToSpec.toString()` as an EXEC_JS script and
+// the fixed-point harness can unit-test it against mock nodes. Runs in the Figma
+// plugin sandbox (browser platform, no node APIs) — never throws on a missing field.
+//
+// SPIKE SCOPE — what is DELIBERATELY only *captured as an extension*, not modelled
+// as a reversible field (documented as the reversibility gap, see the *.figmaScan
+// keys below): variable bindings (boundVariables), instance/component references
+// (mainComponent), and nested-variant composition. These have NO slot in
+// FigmaExportNode and NO build-path in createFigmaNode today, so they cannot survive
+// a round-trip — the spike's job is to prove exactly that.
+
+import type {
+  FigmaColor, FigmaExportEffect, FigmaExportFill, FigmaExportNode,
+} from '../../../shared/figma-payload-types';
+
+/** Non-reversible material captured for the spike's gap analysis (never fed back to build). */
+export interface ScanExtensions {
+  // A binding was found on this node — records field → variable id (NOT the token
+  // NAME that tokenRefs needs). Recovering tokenRefs requires an id→name resolver.
+  figmaScanBindings?: Record<string, string>;
+  // This node is an INSTANCE / COMPONENT — records the source. FigmaExportNode has
+  // no instance type and createFigmaNode has no instance build-case → link is lost.
+  figmaScanSourceType?: string;      // the raw node.type (INSTANCE / COMPONENT / …)
+  figmaScanMainComponent?: string;   // mainComponent.id for an INSTANCE
+}
+
+export type ScannedNode = FigmaExportNode & ScanExtensions;
+
+const r2 = (n: number): number => Math.round(n * 100) / 100;
+
+/** Figma node.type → FigmaExportNode.type (the only 5 the schema models). */
+function mapType(t: string): FigmaExportNode['type'] {
+  if (t === 'TEXT') return 'TEXT';
+  if (t === 'GROUP') return 'GROUP';
+  if (t === 'RECTANGLE' || t === 'ELLIPSE' || t === 'VECTOR'
+    || t === 'LINE' || t === 'STAR' || t === 'POLYGON') return 'RECTANGLE';
+  return 'FRAME'; // FRAME / COMPONENT / COMPONENT_SET / INSTANCE / SECTION
+}
+
+/** Read a possibly-mixed / throwing field; returns undefined on symbol/throw. */
+function safe<T>(read: () => T): T | undefined {
+  try {
+    const v = read();
+    if (typeof v === 'symbol') return undefined; // figma.mixed
+    return v;
+  } catch {
+    return undefined;
+  }
+}
+
+/** One Figma Paint → FigmaExportFill (SOLID alpha lives in paint.opacity → color.a). */
+function paintToFill(p: Paint): FigmaExportFill | null {
+  if (p.type === 'SOLID') {
+    const a = typeof p.opacity === 'number' ? p.opacity : 1;
+    return { type: 'SOLID', color: { r: p.color.r, g: p.color.g, b: p.color.b, a } };
+  }
+  if (p.type === 'GRADIENT_LINEAR' || p.type === 'GRADIENT_RADIAL' || p.type === 'GRADIENT_ANGULAR') {
+    const g = p as GradientPaint;
+    return {
+      type: p.type,
+      gradientStops: g.gradientStops.map((s) => ({
+        color: { r: s.color.r, g: s.color.g, b: s.color.b, a: s.color.a },
+        position: s.position,
+      })),
+      gradientTransform: g.gradientTransform as unknown as [number, number, number][],
+    };
+  }
+  return null; // IMAGE / VIDEO paints not modelled by this spike
+}
+
+/** Figma Effect → FigmaExportEffect (inverse of executor-styles.mapExportEffects). */
+function effectToExport(e: Effect): FigmaExportEffect | null {
+  if (e.type === 'LAYER_BLUR' || e.type === 'BACKGROUND_BLUR') {
+    return { type: e.type, radius: e.radius };
+  }
+  const s = e as DropShadowEffect;
+  const c = s.color;
+  return {
+    type: e.type as FigmaExportEffect['type'],
+    offset: { x: s.offset.x, y: s.offset.y },
+    radius: s.radius,
+    spread: s.spread ?? 0,
+    color: { r: c.r, g: c.g, b: c.b, a: c.a },
+  };
+}
+
+const asFills = (v: unknown): FigmaExportFill[] | undefined => {
+  if (!Array.isArray(v) || v.length === 0) return undefined;
+  const out = (v as Paint[]).map(paintToFill).filter((f): f is FigmaExportFill => f !== null);
+  return out.length ? out : undefined;
+};
+
+/** Auto-layout + sizing block — the symmetric core of applyAutoLayout/child-sizing. */
+function readLayout(n: Record<string, unknown>, out: ScannedNode): void {
+  const mode = n.layoutMode as string | undefined;
+  if (mode && mode !== 'NONE') {
+    out.layoutMode = mode as FigmaExportNode['layoutMode'];
+    if (typeof n.itemSpacing === 'number') out.itemSpacing = n.itemSpacing;
+    for (const k of ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'] as const) {
+      if (typeof n[k] === 'number') out[k] = n[k] as number;
+    }
+    if (n.primaryAxisSizingMode) out.primaryAxisSizingMode = n.primaryAxisSizingMode as 'AUTO' | 'FIXED';
+    if (n.counterAxisSizingMode) out.counterAxisSizingMode = n.counterAxisSizingMode as 'AUTO' | 'FIXED';
+    if (n.primaryAxisAlignItems) out.primaryAxisAlignItems = n.primaryAxisAlignItems as FigmaExportNode['primaryAxisAlignItems'];
+    if (n.counterAxisAlignItems) out.counterAxisAlignItems = n.counterAxisAlignItems as FigmaExportNode['counterAxisAlignItems'];
+    if (n.layoutWrap === 'WRAP') out.layoutWrap = 'WRAP';
+    if (typeof n.counterAxisSpacing === 'number') out.counterAxisSpacing = n.counterAxisSpacing;
+    if (n.counterAxisAlignContent === 'SPACE_BETWEEN') out.counterAxisAlignContent = 'SPACE_BETWEEN';
+    if (mode === 'GRID') {
+      for (const k of ['gridColumnCount', 'gridRowCount', 'gridRowGap', 'gridColumnGap'] as const) {
+        if (typeof n[k] === 'number') out[k] = n[k] as number;
+      }
+    }
+  }
+}
+
+/** Self-sizing — set by the PARENT's child-sizing loop; readable on ANY child (incl. TEXT). */
+function readSelfSizing(n: Record<string, unknown>, out: ScannedNode): void {
+  const h = safe(() => n.layoutSizingHorizontal as string);
+  const v = safe(() => n.layoutSizingVertical as string);
+  if (h === 'FILL' || h === 'FIXED' || h === 'HUG') out.layoutSizingHorizontal = h;
+  if (v === 'FILL' || v === 'FIXED' || v === 'HUG') out.layoutSizingVertical = v;
+  if (typeof n.layoutGrow === 'number' && n.layoutGrow > 0) out.layoutGrow = n.layoutGrow;
+}
+
+// Inverse of executor-fonts.getFontStyleVariants: a Figma style name → numeric
+// weight. Only recovers the weight the build path could have emitted; unknown
+// styles leave fontWeight unset (documented reversibility limit).
+function styleToWeight(style: string): number | undefined {
+  const s = style.toLowerCase().replace(/\s|italic/g, '');
+  const map: Record<string, number> = {
+    thin: 100, hairline: 100, extralight: 200, ultralight: 200, light: 300,
+    regular: 400, normal: 400, book: 400, medium: 500, semibold: 600, demibold: 600,
+    bold: 700, extrabold: 800, ultrabold: 800, black: 900, heavy: 900,
+  };
+  return map[s];
+}
+
+/** Text-only fields — inverse of executor-text.createTextNode. */
+function readText(n: Record<string, unknown>, out: ScannedNode): void {
+  if (typeof n.characters === 'string') out.characters = n.characters;
+  const font = safe(() => n.fontName as FontName);
+  if (font && typeof font === 'object' && 'family' in font) {
+    out.fontFamily = font.family;
+    if (font.style.toLowerCase().includes('italic')) out.fontStyle = 'italic';
+    const w = styleToWeight(font.style);
+    if (w !== undefined) out.fontWeight = w;
+  }
+  if (typeof n.fontSize === 'number') out.fontSize = n.fontSize;
+  const lh = safe(() => n.lineHeight as LineHeight);
+  if (lh && typeof lh === 'object' && lh.unit === 'PIXELS') out.lineHeight = lh.value;
+  const ls = safe(() => n.letterSpacing as LetterSpacing);
+  if (ls && typeof ls === 'object' && ls.unit === 'PIXELS') out.letterSpacing = ls.value;
+  if (n.textAlignHorizontal) out.textAlignHorizontal = n.textAlignHorizontal as FigmaExportNode['textAlignHorizontal'];
+  if (n.textAutoResize) out.textAutoResize = n.textAutoResize as FigmaExportNode['textAutoResize'];
+  if (n.textDecoration && n.textDecoration !== 'NONE') out.textDecoration = n.textDecoration as FigmaExportNode['textDecoration'];
+  if (n.textCase && n.textCase !== 'ORIGINAL') out.textCase = n.textCase as FigmaExportNode['textCase'];
+  // TEXT colour lives in fills[0]; surface it as textColor (build-path convention).
+  const fills = asFills(n.fills);
+  if (fills && fills[0]?.type === 'SOLID' && fills[0].color) out.textColor = fills[0].color as FigmaColor;
+}
+
+/** Read a variable-alias id off a boundVariables entry (array field or scalar field). */
+function aliasId(val: unknown): string | undefined {
+  const alias = Array.isArray(val) ? val[0] : val;
+  return (alias as { id?: string } | undefined)?.id;
+}
+
+/** Capture the non-reversible material (bindings / instance ref) for gap analysis. */
+function readExtensions(n: Record<string, unknown>, out: ScannedNode): void {
+  const rec: Record<string, string> = {};
+  // Scalar fields (cornerRadius, itemSpacing, padding…) live on node.boundVariables.
+  const bound = safe(() => n.boundVariables as Record<string, unknown>);
+  if (bound && typeof bound === 'object') {
+    for (const [field, val] of Object.entries(bound)) {
+      const id = aliasId(val);
+      if (id) rec[field] = id;
+    }
+  }
+  // Paint fields (fills/strokes) record the alias on the PAINT, not the node.
+  for (const field of ['fills', 'strokes'] as const) {
+    const paints = safe(() => n[field] as Array<Record<string, unknown>>);
+    if (!Array.isArray(paints)) continue;
+    for (const p of paints) {
+      const id = aliasId((p.boundVariables as { color?: unknown } | undefined)?.color);
+      if (id) { rec[field] = id; break; }
+    }
+  }
+  if (Object.keys(rec).length) out.figmaScanBindings = rec;
+  const type = n.type as string;
+  if (type === 'INSTANCE' || type === 'COMPONENT' || type === 'COMPONENT_SET') {
+    out.figmaScanSourceType = type;
+    const main = safe(() => (n.mainComponent as { id?: string } | null)?.id);
+    if (main) out.figmaScanMainComponent = main;
+  }
+}
+
+/**
+ * Walk one live SceneNode subtree → FigmaExportNode (+ scan extensions).
+ * INSTANCE composition is NOT recursed (audit rule L106) — its inner tree is the
+ * component's, not the instance's, and has no reversible representation here.
+ */
+export function nodeToSpec(node: SceneNode): ScannedNode {
+  const n = node as unknown as Record<string, unknown>;
+  const type = node.type;
+  const out: ScannedNode = { type: mapType(type), name: node.name };
+
+  const w = safe(() => node.width);
+  const h = safe(() => node.height);
+  if (typeof w === 'number' && w > 0) out.width = r2(w);
+  if (typeof h === 'number' && h > 0) out.height = r2(h);
+
+  readSelfSizing(n, out); // applies to text + frame children alike
+
+  if (out.type === 'TEXT') {
+    readText(n, out);
+  } else {
+    readLayout(n, out);
+    out.fills = asFills(n.fills);
+    if (out.fills === undefined) delete out.fills;
+
+    // Corner radius: uniform number, else per-corner (getter throws figma.mixed).
+    const cr = safe(() => n.cornerRadius as number);
+    if (typeof cr === 'number' && cr > 0) {
+      out.cornerRadius = cr;
+    } else {
+      const tl = safe(() => n.topLeftRadius as number) ?? 0;
+      const tr = safe(() => n.topRightRadius as number) ?? 0;
+      const br = safe(() => n.bottomRightRadius as number) ?? 0;
+      const bl = safe(() => n.bottomLeftRadius as number) ?? 0;
+      if (tl || tr || br || bl) out.cornerRadii = { tl, tr, br, bl };
+    }
+
+    const strokes = asFills(n.strokes);
+    if (strokes) {
+      out.strokes = strokes;
+      if (typeof n.strokeWeight === 'number') out.strokeWeight = n.strokeWeight;
+      if (n.strokeAlign) out.strokeAlign = n.strokeAlign as FigmaExportNode['strokeAlign'];
+    }
+
+    for (const k of ['maxWidth', 'minWidth', 'maxHeight', 'minHeight'] as const) {
+      if (typeof n[k] === 'number') out[k] = n[k] as number;
+    }
+    if (n.clipsContent === true) out.clipsContent = true;
+    if (n.blendMode && n.blendMode !== 'PASS_THROUGH' && n.blendMode !== 'NORMAL') {
+      out.blendMode = n.blendMode as string;
+    }
+  }
+
+  // Shared visual fields (frame + text): effects, opacity, rotation.
+  const effects = safe(() => n.effects as Effect[]);
+  if (Array.isArray(effects) && effects.length) {
+    const mapped = effects.map(effectToExport).filter((e): e is FigmaExportEffect => e !== null);
+    if (mapped.length) out.effects = mapped;
+  }
+  if (typeof n.opacity === 'number' && n.opacity < 1 && n.opacity > 0) out.opacity = n.opacity;
+  if (typeof n.rotation === 'number' && Math.abs(n.rotation) > 0.001) out.rotation = n.rotation;
+
+  readExtensions(n, out);
+
+  // Children — recurse, EXCEPT into an instance (composition is the component's).
+  if (type !== 'INSTANCE' && 'children' in node) {
+    const kids = (node as SceneNode & ChildrenMixin).children;
+    if (kids.length) out.children = kids.map((c) => nodeToSpec(c as SceneNode));
+  }
+
+  return out;
+}

--- a/figma-agent/scripts/build.mjs
+++ b/figma-agent/scripts/build.mjs
@@ -21,7 +21,9 @@ async function buildCli() {
     banner: { js: '#!/usr/bin/env node' },
     // ws + the capture-only optional deps stay external (resolved at runtime;
     // playwright is heavy + has native deps and must not be inlined).
-    external: ['ws', 'playwright', 'playwright-core', 'puppeteer-core', 'pixelmatch', 'pngjs'],
+    // esbuild stays external: the `scan-node` spike bundles the reverse-walker at
+    // runtime, so the CLI must resolve esbuild from node_modules, not inline it.
+    external: ['ws', 'esbuild', 'playwright', 'playwright-core', 'puppeteer-core', 'pixelmatch', 'pngjs'],
   });
 }
 

--- a/figma-agent/tests/helpers/mock-figma.ts
+++ b/figma-agent/tests/helpers/mock-figma.ts
@@ -1,0 +1,121 @@
+// Faithful-enough mock of the Figma plugin `figma` global for the spec-005 spike
+// fixed-point harness. It runs the REAL forward builder (executor-frame.createFigmaNode)
+// so the round-trip exercises production code, not a re-implementation.
+//
+// The mock reproduces the THREE Figma behaviours that actually drive the spike's
+// findings (everything else is verbatim property storage):
+//   1. layoutSizingHorizontal/Vertical THROW unless the node sits in an auto-layout
+//      parent — this is why a ROOT frame's own sizing never round-trips.
+//   2. cornerRadius GETTER returns figma.mixed when the four corners differ — the
+//      walker must fall back to per-corner reads.
+//   3. variable bindings are recorded on node.boundVariables (scalar fields) and on
+//      the PAINT's boundVariables (fills/strokes) — the split the walker must scan.
+// It does NOT emulate Figma's layout re-flow (a child's FILL coercing the parent's
+// sizing mode). That is exactly the class of loss the LIVE half must confirm.
+
+let idSeq = 0;
+export const FIGMA_MIXED = Symbol('figma.mixed');
+
+type Corners = { tl: number; tr: number; br: number; bl: number };
+
+export class FakeNode {
+  id = `S:${idSeq++}`;
+  name = 'Node';
+  type: string;
+  width = 0;
+  height = 0;
+  parent: FakeNode | null = null;
+  children: FakeNode[] = [];
+  boundVariables: Record<string, unknown> = {};
+  private _corners: Corners = { tl: 0, tr: 0, br: 0, bl: 0 };
+  private _lsh: string | undefined;
+  private _lsv: string | undefined;
+  [key: string]: unknown;
+
+  constructor(type: string) {
+    this.type = type;
+  }
+
+  resize(w: number, h: number): void {
+    this.width = w;
+    this.height = h;
+  }
+
+  appendChild(child: FakeNode): void {
+    child.parent = this;
+    this.children.push(child);
+  }
+
+  setBoundVariable(field: string, variable: { id: string }): void {
+    this.boundVariables[field] = { type: 'VARIABLE_ALIAS', id: variable.id };
+  }
+
+  private get inAutoLayout(): boolean {
+    const m = this.parent?.layoutMode as string | undefined;
+    return !!m && m !== 'NONE';
+  }
+
+  // ── cornerRadius: uniform value, or figma.mixed when corners differ ──
+  set cornerRadius(v: number) { this._corners = { tl: v, tr: v, br: v, bl: v }; }
+  get cornerRadius(): number | symbol {
+    const { tl, tr, br, bl } = this._corners;
+    return tl === tr && tr === br && br === bl ? tl : (FIGMA_MIXED as unknown as symbol);
+  }
+  set topLeftRadius(v: number) { this._corners.tl = v; }
+  get topLeftRadius(): number { return this._corners.tl; }
+  set topRightRadius(v: number) { this._corners.tr = v; }
+  get topRightRadius(): number { return this._corners.tr; }
+  set bottomRightRadius(v: number) { this._corners.br = v; }
+  get bottomRightRadius(): number { return this._corners.br; }
+  set bottomLeftRadius(v: number) { this._corners.bl = v; }
+  get bottomLeftRadius(): number { return this._corners.bl; }
+
+  // ── layoutSizing: only settable inside an auto-layout parent (Figma throws otherwise) ──
+  set layoutSizingHorizontal(v: string) {
+    if (!this.inAutoLayout) throw new Error('layoutSizingHorizontal needs an auto-layout parent');
+    this._lsh = v;
+  }
+  get layoutSizingHorizontal(): string | undefined { return this._lsh; }
+  set layoutSizingVertical(v: string) {
+    if (!this.inAutoLayout) throw new Error('layoutSizingVertical needs an auto-layout parent');
+    this._lsv = v;
+  }
+  get layoutSizingVertical(): string | undefined { return this._lsv; }
+}
+
+/** Clone a paint and stamp a variable alias onto its color (Figma's paint-copy binding). */
+function setBoundVariableForPaint(paint: Record<string, unknown>, _field: 'color', variable: { id: string }): Record<string, unknown> {
+  return { ...paint, boundVariables: { color: { type: 'VARIABLE_ALIAS', id: variable.id } } };
+}
+
+export interface MockFigma {
+  mixed: symbol;
+  createFrame(): FakeNode;
+  createText(): FakeNode;
+  createRectangle(): FakeNode;
+  loadFontAsync(font: FontName): Promise<void>;
+  listAvailableFontsAsync(): Promise<Array<{ fontName: FontName }>>;
+  variables: {
+    setBoundVariableForPaint: typeof setBoundVariableForPaint;
+  };
+}
+
+/** Install a fresh mock on globalThis.figma; returns it. Call once per test file. */
+export function installMockFigma(): MockFigma {
+  const mk = (type: string): FakeNode => {
+    const n = new FakeNode(type);
+    if (type === 'TEXT') n.name = 'Text';
+    return n;
+  };
+  const figma: MockFigma = {
+    mixed: FIGMA_MIXED,
+    createFrame: () => mk('FRAME'),
+    createText: () => mk('TEXT'),
+    createRectangle: () => mk('RECTANGLE'),
+    loadFontAsync: async () => { /* every font "exists" */ },
+    listAvailableFontsAsync: async () => [],
+    variables: { setBoundVariableForPaint },
+  };
+  (globalThis as unknown as { figma: MockFigma }).figma = figma;
+  return figma;
+}

--- a/figma-agent/tests/scan-node-fixed-point.test.ts
+++ b/figma-agent/tests/scan-node-fixed-point.test.ts
@@ -1,0 +1,185 @@
+// spec-005 SPIKE — reversibility proof for the Figma component representation.
+// Runs the REAL forward builder (executor-frame.createFigmaNode) against a mock
+// `figma` global, then the reverse-walker (scan-node.nodeToSpec), and asks the
+// central question: is `spec → node → spec` a FIXED POINT?
+//
+// Definition used: idempotence of (nodeToSpec ∘ createFigmaNode) on its OWN output.
+// spec0 (authored) → node1 → spec1 → node2 → spec2. A field "survives" iff
+// spec1 === spec2 (the build/normalisation settles after one pass). The spec0→spec1
+// delta is normalisation (defaults materialised), reported but not a failure.
+//
+// RESULT SUMMARY (asserted below):
+//   SURVIVE (fixed point): auto-layout topology (mode/spacing/padding/sizing/align),
+//     GRID counts+gaps, fills+alpha, corner radius (uniform & per-corner), strokes,
+//     child self-sizing (HUG/FILL/FIXED), text chars/size/family/weight/colour/align.
+//   DO NOT SURVIVE (documented gaps):
+//     - variable bindings: recovered as a variable *id*, never as the token *name*
+//       tokenRefs needs → tokenRefs is dropped, so a rebuild loses the binding.
+//     - instance / component references: FigmaExportNode has no instance type and
+//       createFigmaNode has no instance build-case → an INSTANCE degrades to a plain
+//       FRAME and its inner composition is not recursed.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { installMockFigma, FakeNode } from './helpers/mock-figma.ts';
+import type { FigmaExportNode } from '../shared/figma-payload-types.ts';
+import type { ScannedNode } from '../plugin/src/main/scan-node.ts';
+
+// Install the mock BEFORE any builder call (executors read `figma` at call time).
+beforeAll(() => { installMockFigma(); });
+
+// Imported lazily inside tests would also work; static import is safe because the
+// executor modules only touch `figma` inside function bodies.
+const { createFigmaNode } = await import('../plugin/src/main/executor-frame.ts');
+const { nodeToSpec } = await import('../plugin/src/main/scan-node.ts');
+
+type Vars = Map<string, { id: string; name: string }>;
+
+async function build(spec: FigmaExportNode, vars?: Vars): Promise<ScannedNode> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const node = await createFigmaNode(spec as any, new Map(), vars as any);
+  if (!node) throw new Error('builder returned null');
+  return nodeToSpec(node);
+}
+
+/** One round of forward+reverse; returns [spec1, spec2] to check the fixed point. */
+async function roundTrips(spec0: FigmaExportNode, vars?: Vars): Promise<[ScannedNode, ScannedNode]> {
+  const spec1 = await build(spec0, vars);
+  const spec2 = await build(spec1); // second pass, no vars — bindings cannot rebuild
+  return [spec1, spec2];
+}
+
+describe('fixed point — auto-layout FRAME with text children', () => {
+  const card: FigmaExportNode = {
+    type: 'FRAME', name: 'Card', width: 320, height: 200,
+    layoutMode: 'VERTICAL', itemSpacing: 12,
+    paddingTop: 16, paddingRight: 16, paddingBottom: 16, paddingLeft: 16,
+    primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'FIXED',
+    primaryAxisAlignItems: 'MIN', counterAxisAlignItems: 'CENTER',
+    fills: [{ type: 'SOLID', color: { r: 0.1, g: 0.1, b: 0.12, a: 1 } }],
+    cornerRadius: 12,
+    strokes: [{ type: 'SOLID', color: { r: 1, g: 1, b: 1, a: 0.1 } }],
+    strokeWeight: 1, strokeAlign: 'INSIDE',
+    children: [
+      { type: 'TEXT', name: 'Title', characters: 'Hello', fontSize: 20, fontWeight: 700, textAutoResize: 'WIDTH_AND_HEIGHT', textColor: { r: 1, g: 1, b: 1, a: 1 } },
+      { type: 'TEXT', name: 'Body', characters: 'World', fontSize: 14, fontWeight: 400, textAutoResize: 'WIDTH_AND_HEIGHT', textColor: { r: 0.8, g: 0.8, b: 0.8, a: 1 } },
+    ],
+  };
+
+  it('reaches a fixed point (spec1 === spec2)', async () => {
+    const [spec1, spec2] = await roundTrips(card);
+    expect(spec2).toEqual(spec1);
+  });
+
+  it('preserves auto-layout topology, fills, radius, strokes', async () => {
+    const [s] = await roundTrips(card);
+    expect(s).toMatchObject({
+      type: 'FRAME', name: 'Card', width: 320, height: 200,
+      layoutMode: 'VERTICAL', itemSpacing: 12,
+      paddingTop: 16, paddingLeft: 16,
+      primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'FIXED',
+      counterAxisAlignItems: 'CENTER', cornerRadius: 12,
+      strokeWeight: 1, strokeAlign: 'INSIDE',
+    });
+    expect(s.fills?.[0]).toMatchObject({ type: 'SOLID', color: { r: 0.1, a: 1 } });
+    // stroke alpha (0.1) survived the paint.opacity ↔ color.a hop
+    expect(s.strokes?.[0]?.color?.a).toBeCloseTo(0.1, 5);
+  });
+
+  it('preserves text content + weight + colour, and materialises child self-sizing', async () => {
+    const [s] = await roundTrips(card);
+    const title = s.children?.[0];
+    expect(title).toMatchObject({ type: 'TEXT', characters: 'Hello', fontSize: 20, fontWeight: 700 });
+    expect(title?.textColor).toMatchObject({ r: 1, g: 1, b: 1 });
+    // VERTICAL parent → text children are hugged on the main axis (build convention)
+    expect(title?.layoutSizingHorizontal).toBe('HUG');
+  });
+
+  it('does NOT capture the ROOT frame own sizing (no auto-layout parent)', async () => {
+    const [s] = await roundTrips(card);
+    expect(s.layoutSizingHorizontal).toBeUndefined();
+    expect(s.layoutSizingVertical).toBeUndefined();
+  });
+});
+
+describe('fixed point — native GRID', () => {
+  const grid: FigmaExportNode = {
+    type: 'FRAME', name: 'Grid', width: 600, height: 400, layoutMode: 'GRID',
+    gridColumnCount: 3, gridRowCount: 2, gridColumnGap: 16, gridRowGap: 16,
+    paddingTop: 8, paddingRight: 8, paddingBottom: 8, paddingLeft: 8,
+    fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0, a: 1 } }],
+  };
+  it('round-trips grid counts + gaps', async () => {
+    const [spec1, spec2] = await roundTrips(grid);
+    expect(spec2).toEqual(spec1);
+    expect(spec1).toMatchObject({
+      layoutMode: 'GRID', gridColumnCount: 3, gridRowCount: 2, gridColumnGap: 16, gridRowGap: 16,
+    });
+  });
+});
+
+describe('fixed point — per-corner radius (figma.mixed path)', () => {
+  const chip: FigmaExportNode = {
+    type: 'FRAME', name: 'Chip', width: 80, height: 32, layoutMode: 'HORIZONTAL',
+    primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'AUTO',
+    cornerRadii: { tl: 16, tr: 4, br: 16, bl: 4 },
+    fills: [{ type: 'SOLID', color: { r: 0.2, g: 0.2, b: 0.2, a: 1 } }],
+  };
+  it('recovers cornerRadii via the mixed-getter fallback', async () => {
+    const [spec1, spec2] = await roundTrips(chip);
+    expect(spec2).toEqual(spec1);
+    expect(spec1.cornerRadii).toEqual({ tl: 16, tr: 4, br: 16, bl: 4 });
+    expect(spec1.cornerRadius).toBeUndefined();
+  });
+});
+
+describe('reversibility GAP — variable bindings do not survive', () => {
+  const btn: FigmaExportNode = {
+    type: 'FRAME', name: 'Btn', width: 120, height: 40, layoutMode: 'HORIZONTAL',
+    primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'AUTO',
+    fills: [{ type: 'SOLID', color: { r: 0.5, g: 0.2, b: 0.9, a: 1 } }],
+    cornerRadius: 8,
+    tokenRefs: { fill: 'color/brand', radius: 'radius/sm' },
+  };
+  const vars: Vars = new Map([
+    ['color/brand', { id: 'VariableID:1', name: 'color/brand' }],
+    ['radius/sm', { id: 'VariableID:2', name: 'radius/sm' }],
+  ]);
+
+  it('detects the binding as a variable id but drops tokenRefs (name unrecoverable)', async () => {
+    const spec1 = await build(btn, vars);
+    expect(spec1.figmaScanBindings).toEqual({ fills: 'VariableID:1', cornerRadius: 'VariableID:2' });
+    expect(spec1.tokenRefs).toBeUndefined(); // the token NAME is gone
+  });
+
+  it('is NOT a fixed point — rebuilding spec1 loses the binding entirely', async () => {
+    const spec1 = await build(btn, vars);
+    const spec2 = await build(spec1); // no tokenRefs on spec1 → nothing to bind
+    expect(spec2.figmaScanBindings).toBeUndefined();
+    expect(spec2).not.toEqual(spec1);
+  });
+});
+
+describe('reversibility GAP — instance / component references do not survive', () => {
+  it('degrades an INSTANCE to a FRAME and does not recurse its composition', async () => {
+    const inst = new FakeNode('INSTANCE');
+    inst.name = 'Button/Primary';
+    inst.resize(120, 40);
+    inst.layoutMode = 'HORIZONTAL';
+    inst.itemSpacing = 8;
+    inst.primaryAxisSizingMode = 'AUTO';
+    inst.mainComponent = { id: 'C:99' };
+    const label = new FakeNode('TEXT');
+    label.characters = 'Click';
+    inst.appendChild(label);
+
+    const spec1 = nodeToSpec(inst as unknown as SceneNode);
+    expect(spec1.type).toBe('FRAME');                 // no INSTANCE type in the schema
+    expect(spec1.figmaScanSourceType).toBe('INSTANCE'); // detected, but only as metadata
+    expect(spec1.figmaScanMainComponent).toBe('C:99');
+    expect(spec1.children).toBeUndefined();            // composition NOT recursed (audit rule)
+
+    // Rebuild → a plain frame; the instance identity is gone.
+    const spec2 = await build(spec1);
+    expect(spec2.figmaScanSourceType).toBeUndefined();
+    expect(spec2.type).toBe('FRAME');
+  });
+});


### PR DESCRIPTION
## What this is

A **derisking SPIKE** for spec 005 (NOT the full spec). Question: is the Figma-native structural representation **reversible** — is `node → FigmaExportNode spec → node` a **fixed point**? Answer decides whether spec 005 is feasible.

Scope = **CODE + test proof only**. NO wiring into reconcile/registry/storage (that's spec 005). One command (`scan-node`) is the LIVE half the owner runs against real Figma.

## What landed

| File | Role |
|---|---|
| `figma-agent/plugin/src/main/scan-node.ts` | **Reverse-walker** `nodeToSpec(node): FigmaExportNode` — pure, self-contained, symmetric inverse of `build-frame` + `executor-frame.createFigmaNode`. |
| `figma-agent/cli/src/commands/scan-node.ts` | `figma-agent scan-node <nodeId>` — LIVE half. Reuses EXEC_JS; **bundles the actual walker** (esbuild, no drift). |
| `figma-agent/tests/scan-node-fixed-point.test.ts` + `tests/helpers/mock-figma.ts` | Fixed-point harness: runs the **REAL forward builder** against a faithful mock `figma`, asserts idempotence. |

## Fixed-point RESULT (the point of the spike — honest)

Definition: idempotence of `nodeToSpec ∘ createFigmaNode` on its own output (spec1 === spec2). 9/9 tests pass.

**✅ SURVIVE (proven fixed point, mock):**
- Auto-layout topology — layoutMode, itemSpacing, padding×4, primary/counterAxisSizingMode, align
- Native GRID — column/row counts + gaps
- Fills (+ alpha via the `paint.opacity ↔ color.a` hop), strokes + weight + align
- Corner radius — uniform AND per-corner (`figma.mixed` getter fallback)
- Child self-sizing — HUG / FILL / FIXED / layoutGrow
- Text — characters, fontSize, fontFamily, **fontWeight** (via style-name→weight inverse), textColor, align

**❌ DO NOT SURVIVE (documented gaps → spec 005 must design for these):**
1. **Variable bindings.** Walker recovers a variable **id** (from `node.boundVariables` + paint `boundVariables`), never the token **name** that `tokenRefs` needs. `tokenRefs` is dropped → a rebuild loses the binding. Needs an **id→name resolver** to reconstruct.
2. **Instance / component references.** `FigmaExportNode` has **no INSTANCE type** and `createFigmaNode` has **no instance build-case**. An INSTANCE degrades to a plain FRAME; its inner composition is not recursed (audit rule). Needs a **schema extension + an INSTANCE executor path**.

Normalisation deltas spec0→spec1 (expected, not loss): defaults materialised (padding/itemSpacing 0), child sizing made explicit, `fontStack` dropped (input-only), text dims materialised.

### Fidelity caveat
The mock proves **walker↔executor field symmetry** deterministically. It does **NOT** emulate Figma's own layout re-flow (a child FILL coercing a parent's sizing mode). That class of loss is exactly what the LIVE half must confirm.

## LIVE STEPS (owner + orchestrator run — NOT done here)

Requires the Figma Design Agent plugin open in Figma Desktop.

```bash
cd figma-agent && npm run build:cli
# 1. Pick a real component/instance node id (Figma: right-click → Copy/Paste as → or get-selection)
node cli/dist/figma-agent.js get-selection --depth 0
# 2. Reverse-walk it to a spec
node cli/dist/figma-agent.js scan-node <nodeId> > /tmp/spec.json
# 3. Rebuild the spec onto the canvas (exec-js IMPORT_PAYLOAD or html-to-figma path) and
#    scan-node the REBUILT node, then diff:
node cli/dist/figma-agent.js scan-node <rebuiltNodeId> > /tmp/spec2.json
diff <(jq -S . /tmp/spec.json) <(jq -S . /tmp/spec2.json)
```
Confirm on real data: (a) auto-layout/text survive as the mock predicts; (b) variable bindings + instances degrade as documented; (c) Figma re-flow introduces no *additional* loss on plain auto-layout frames.

Note: `scan-node` bundles the walker source at runtime → needs the **repo checkout** present (dist-only installs won't have `plugin/src`). Acceptable for the spike.

## Verdict — is spec 005 feasible?

**YES, feasible — with two required extensions, both now precisely scoped:**
- The Figma-native `FigmaExportNode` spec **is reversible** for the structural core (layout + sizing + fills + text). The reverse-walker exists and is proven idempotent.
- Two things are **not reversible as-is** and must be built in spec 005, not assumed: (1) a variable-id→token-name resolver, (2) an instance-reference schema field + INSTANCE executor build-case.
- Recommend spec 005 keep the **two-halves** split from the harvest research: Figma-native spec (reversible) + markup (one-way), and gate acceptance on a LIVE round-trip diff (this PR's LIVE STEPS), not a mock alone.

## Checks
figma-agent: typecheck ✅ · build ✅ · 218 tests ✅ (9 new). Root ease-design: typecheck ✅ · lint ✅ · build ✅ · 1843 tests ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)