### PR TITLE
spec 005 P1 — token bindings survive the round-trip (via token name)

### DIFF
--- a/figma-agent/cli/src/commands/scan-node.ts
+++ b/figma-agent/cli/src/commands/scan-node.ts
@@ -51,10 +51,13 @@ export async function run(args: CommandArgs): Promise<unknown> {
   if (!nodeId) throw new CliError('E_INVALID_ARGS', 'scan-node requires a <nodeId>');
 
   const walker = await bundleWalker();
+  // The id→name token map is read ONCE (async) and handed to the sync walker, so
+  // variable bindings come back as reversible tokenRefs (spec-005 P1).
   const code = `${walker}
 const node = figma.getNodeById(${JSON.stringify(nodeId)});
 if (!node) throw new Error('node not found: ' + ${JSON.stringify(nodeId)});
-return __scan.nodeToSpec(node);`;
+const tokenNames = await __scan.readTokenNameMap();
+return __scan.nodeToSpec(node, tokenNames);`;
 
   const requested = args.num('timeout') ?? COMMAND_TIMEOUTS.EXEC_JS ?? 30_000;
   const timeoutMs = Math.min(requested, EXEC_JS_MAX_TIMEOUT_MS);

--- a/figma-agent/plugin/code.js
+++ b/figma-agent/plugin/code.js
@@ -372,7 +372,10 @@
     const bind = (field, tokenName) => {
       if (!tokenName) return;
       const variable = tokenVars.get(tokenName);
-      if (!variable) return;
+      if (!variable) {
+        pushImportWarning(`token bind ${field}\u2192${tokenName} skipped on "${node.name}": no variable named "${tokenName}" in this file (library/remote token?) \u2014 literal value kept`);
+        return;
+      }
       try {
         bindVariableToField(node, field, variable);
       } catch (err) {

--- a/figma-agent/plugin/src/main/executor-variables.ts
+++ b/figma-agent/plugin/src/main/executor-variables.ts
@@ -119,6 +119,10 @@ export function bindVariableToField(node: SceneNode, field: string, variable: Va
  * fill/textColor → 'fills', stroke → 'strokes', radius → 'cornerRadius',
  * gap → 'itemSpacing', padding → all four padding fields. Failures warn and
  * skip — a missed binding must never abort the import.
+ *
+ * A tokenRef naming a variable this file has no local Variable for (a library /
+ * remote token, spec-005 P1's known edge) warns and leaves the literal value in
+ * place — never a crash, never a silent drop.
  */
 export function applyTokenRefs(
   node: SceneNode,
@@ -128,7 +132,10 @@ export function applyTokenRefs(
   const bind = (field: string, tokenName: string | undefined) => {
     if (!tokenName) return;
     const variable = tokenVars.get(tokenName);
-    if (!variable) return;
+    if (!variable) {
+      pushImportWarning(`token bind ${field}→${tokenName} skipped on "${node.name}": no variable named "${tokenName}" in this file (library/remote token?) — literal value kept`);
+      return;
+    }
     try {
       bindVariableToField(node, field, variable);
     } catch (err) {

--- a/figma-agent/plugin/src/main/scan-node.ts
+++ b/figma-agent/plugin/src/main/scan-node.ts
@@ -9,21 +9,23 @@
 // the fixed-point harness can unit-test it against mock nodes. Runs in the Figma
 // plugin sandbox (browser platform, no node APIs) — never throws on a missing field.
 //
-// SPIKE SCOPE — what is DELIBERATELY only *captured as an extension*, not modelled
-// as a reversible field (documented as the reversibility gap, see the *.figmaScan
-// keys below): variable bindings (boundVariables), instance/component references
-// (mainComponent), and nested-variant composition. These have NO slot in
-// FigmaExportNode and NO build-path in createFigmaNode today, so they cannot survive
-// a round-trip — the spike's job is to prove exactly that.
+// SCOPE — variable bindings ARE reversible since spec-005 P1: `nodeToSpec` takes the
+// file's id→name token map (see readTokenNameMap) and rebuilds `tokenRefs`, which the
+// build path already reattaches by name. Still only *captured as an extension*, with
+// no reversible slot: instance/component references (mainComponent) and nested-variant
+// composition — FigmaExportNode has no instance type and createFigmaNode no instance
+// build-case, so an INSTANCE cannot survive a round-trip (spec-005 P2's job).
 
 import type {
   FigmaColor, FigmaExportEffect, FigmaExportFill, FigmaExportNode,
 } from '../../../shared/figma-payload-types';
+import { bindingsToTokenRefs } from './scan-token-refs';
 
-/** Non-reversible material captured for the spike's gap analysis (never fed back to build). */
+/** Material captured beyond the reversible FigmaExportNode fields. */
 export interface ScanExtensions {
-  // A binding was found on this node — records field → variable id (NOT the token
-  // NAME that tokenRefs needs). Recovering tokenRefs requires an id→name resolver.
+  // Raw field → variable id, ALWAYS recorded. Ids that resolve against the token
+  // map also become `tokenRefs` (reversible); ids that don't (library/remote
+  // variables) stay here only — the loss stays visible instead of silent.
   figmaScanBindings?: Record<string, string>;
   // This node is an INSTANCE / COMPONENT — records the source. FigmaExportNode has
   // no instance type and createFigmaNode has no instance build-case → link is lost.
@@ -173,8 +175,29 @@ function aliasId(val: unknown): string | undefined {
   return (alias as { id?: string } | undefined)?.id;
 }
 
-/** Capture the non-reversible material (bindings / instance ref) for gap analysis. */
-function readExtensions(n: Record<string, unknown>, out: ScannedNode): void {
+/**
+ * The file's variable id → name map — the join source that makes bindings
+ * reversible. Same source as serializeDesignSystem's `tokens` (local variables
+ * only; library/remote variables are NOT listed → documented edge). Async, so it
+ * runs ONCE per scan and keeps `nodeToSpec` synchronous; never throws.
+ */
+export async function readTokenNameMap(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    const vars = await figma.variables.getLocalVariablesAsync();
+    for (const v of vars) map.set(v.id, v.name);
+  } catch {
+    // Variables API unavailable (older Figma / restricted plan) → no tokenRefs.
+  }
+  return map;
+}
+
+/** Capture bindings (→ tokenRefs when resolvable) + the instance ref (gap 2). */
+function readExtensions(
+  n: Record<string, unknown>,
+  out: ScannedNode,
+  tokenNames: Map<string, string> | undefined,
+): void {
   const rec: Record<string, string> = {};
   // Scalar fields (cornerRadius, itemSpacing, padding…) live on node.boundVariables.
   const bound = safe(() => n.boundVariables as Record<string, unknown>);
@@ -193,7 +216,11 @@ function readExtensions(n: Record<string, unknown>, out: ScannedNode): void {
       if (id) { rec[field] = id; break; }
     }
   }
-  if (Object.keys(rec).length) out.figmaScanBindings = rec;
+  if (Object.keys(rec).length) {
+    out.figmaScanBindings = rec;
+    const refs = bindingsToTokenRefs(rec, out.type, tokenNames);
+    if (refs) out.tokenRefs = refs;
+  }
   const type = n.type as string;
   if (type === 'INSTANCE' || type === 'COMPONENT' || type === 'COMPONENT_SET') {
     out.figmaScanSourceType = type;
@@ -204,10 +231,12 @@ function readExtensions(n: Record<string, unknown>, out: ScannedNode): void {
 
 /**
  * Walk one live SceneNode subtree → FigmaExportNode (+ scan extensions).
+ * `tokenNames` (from readTokenNameMap) turns variable ids into reversible
+ * tokenRefs; omit it and bindings degrade to raw ids only.
  * INSTANCE composition is NOT recursed (audit rule L106) — its inner tree is the
  * component's, not the instance's, and has no reversible representation here.
  */
-export function nodeToSpec(node: SceneNode): ScannedNode {
+export function nodeToSpec(node: SceneNode, tokenNames?: Map<string, string>): ScannedNode {
   const n = node as unknown as Record<string, unknown>;
   const type = node.type;
   const out: ScannedNode = { type: mapType(type), name: node.name };
@@ -263,12 +292,12 @@ export function nodeToSpec(node: SceneNode): ScannedNode {
   if (typeof n.opacity === 'number' && n.opacity < 1 && n.opacity > 0) out.opacity = n.opacity;
   if (typeof n.rotation === 'number' && Math.abs(n.rotation) > 0.001) out.rotation = n.rotation;
 
-  readExtensions(n, out);
+  readExtensions(n, out, tokenNames);
 
   // Children — recurse, EXCEPT into an instance (composition is the component's).
   if (type !== 'INSTANCE' && 'children' in node) {
     const kids = (node as SceneNode & ChildrenMixin).children;
-    if (kids.length) out.children = kids.map((c) => nodeToSpec(c as SceneNode));
+    if (kids.length) out.children = kids.map((c) => nodeToSpec(c as SceneNode, tokenNames));
   }
 
   return out;

--- a/figma-agent/plugin/src/main/scan-token-refs.ts
+++ b/figma-agent/plugin/src/main/scan-token-refs.ts
@@ -1,0 +1,63 @@
+// spec-005 P1 — the id→name join that makes a variable binding REVERSIBLE.
+//
+// A scanned node reports its bindings as variable IDs (`boundVariables`), but the
+// build path (executor-variables.applyTokenRefs) reattaches by token NAME. This
+// module is the pure join between the two: given the raw field→id record the
+// walker collected and the file's id→name token map, it rebuilds the
+// `FigmaExportNode.tokenRefs` slots the builder consumes.
+//
+// Pure + sync on purpose: the async Figma call that produces the id→name map
+// happens ONCE per scan (scan-node.readTokenNameMap), so the walker itself stays
+// synchronous and unit-testable against a plain Map.
+//
+// KNOWN EDGE (documented, not faked): an id absent from the map — a library /
+// remote variable, which `getLocalVariablesAsync` does not list — yields no
+// tokenRef. The raw id stays in `figmaScanBindings`, so the loss is visible
+// rather than silent, and such a node is NOT a round-trip fixed point.
+
+import type { FigmaExportNode } from '../../../shared/figma-payload-types';
+
+type TokenRefs = NonNullable<FigmaExportNode['tokenRefs']>;
+
+const PADDING_FIELDS = ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'] as const;
+
+/** Bound node field → the tokenRefs slot the builder binds it back from. */
+function slotForField(field: string, nodeType: FigmaExportNode['type']): keyof TokenRefs | null {
+  // TEXT colour lives in fills but is authored as textColor (build-path convention).
+  if (field === 'fills') return nodeType === 'TEXT' ? 'textColor' : 'fill';
+  if (field === 'strokes') return 'stroke';
+  if (field === 'cornerRadius') return 'radius';
+  if (field === 'itemSpacing') return 'gap';
+  return null; // padding is handled as a group; anything else has no tokenRefs slot
+}
+
+/**
+ * field→variable-id bindings + id→name token map → tokenRefs.
+ * Returns undefined when nothing resolved (so the caller can leave the key off).
+ * `padding` only resolves when ALL FOUR sides are bound to the SAME variable —
+ * tokenRefs models uniform padding only; a per-side binding has no slot and is
+ * left to `figmaScanBindings` (known edge, not reversible).
+ */
+export function bindingsToTokenRefs(
+  bindings: Record<string, string>,
+  nodeType: FigmaExportNode['type'],
+  tokenNames: Map<string, string> | undefined,
+): TokenRefs | undefined {
+  if (!tokenNames || tokenNames.size === 0) return undefined;
+  const refs: TokenRefs = {};
+
+  for (const [field, id] of Object.entries(bindings)) {
+    const slot = slotForField(field, nodeType);
+    if (!slot) continue;
+    const name = tokenNames.get(id);
+    if (name) refs[slot] = name;
+  }
+
+  const padIds = PADDING_FIELDS.map((f) => bindings[f]);
+  if (padIds.every((id) => id && id === padIds[0])) {
+    const name = tokenNames.get(padIds[0]);
+    if (name) refs.padding = name;
+  }
+
+  return Object.keys(refs).length > 0 ? refs : undefined;
+}

--- a/figma-agent/tests/helpers/mock-figma.ts
+++ b/figma-agent/tests/helpers/mock-figma.ts
@@ -88,6 +88,13 @@ function setBoundVariableForPaint(paint: Record<string, unknown>, _field: 'color
   return { ...paint, boundVariables: { color: { type: 'VARIABLE_ALIAS', id: variable.id } } };
 }
 
+/** The file's LOCAL variables, as getLocalVariablesAsync reports them. A binding
+ * to an id absent from this list = the library/remote-variable edge. */
+let localVariables: Array<{ id: string; name: string }> = [];
+export function setMockLocalVariables(vars: Array<{ id: string; name: string }>): void {
+  localVariables = vars;
+}
+
 export interface MockFigma {
   mixed: symbol;
   createFrame(): FakeNode;
@@ -97,6 +104,7 @@ export interface MockFigma {
   listAvailableFontsAsync(): Promise<Array<{ fontName: FontName }>>;
   variables: {
     setBoundVariableForPaint: typeof setBoundVariableForPaint;
+    getLocalVariablesAsync(): Promise<Array<{ id: string; name: string }>>;
   };
 }
 
@@ -114,7 +122,10 @@ export function installMockFigma(): MockFigma {
     createRectangle: () => mk('RECTANGLE'),
     loadFontAsync: async () => { /* every font "exists" */ },
     listAvailableFontsAsync: async () => [],
-    variables: { setBoundVariableForPaint },
+    variables: {
+      setBoundVariableForPaint,
+      getLocalVariablesAsync: async () => localVariables,
+    },
   };
   (globalThis as unknown as { figma: MockFigma }).figma = figma;
   return figma;

--- a/figma-agent/tests/scan-node-fixed-point.test.ts
+++ b/figma-agent/tests/scan-node-fixed-point.test.ts
@@ -11,15 +11,22 @@
 // RESULT SUMMARY (asserted below):
 //   SURVIVE (fixed point): auto-layout topology (mode/spacing/padding/sizing/align),
 //     GRID counts+gaps, fills+alpha, corner radius (uniform & per-corner), strokes,
-//     child self-sizing (HUG/FILL/FIXED), text chars/size/family/weight/colour/align.
+//     child self-sizing (HUG/FILL/FIXED), text chars/size/family/weight/colour/align,
+//     and — since spec-005 P1 — variable bindings, via the token NAME: the walker
+//     joins each bound variable id against the file's id→name map and re-emits
+//     tokenRefs, which the build path rebinds by name (fill/textColor/stroke/radius/
+//     gap/uniform padding).
 //   DO NOT SURVIVE (documented gaps):
-//     - variable bindings: recovered as a variable *id*, never as the token *name*
-//       tokenRefs needs → tokenRefs is dropped, so a rebuild loses the binding.
+//     - library / remote variable bindings: the id is not in the file's LOCAL
+//       variables, so no token name is recoverable → the binding is reported as a raw
+//       id in figmaScanBindings (visible, not silent) and a rebuild drops it.
+//     - per-side (non-uniform) padding bindings: tokenRefs models uniform padding
+//       only → no slot to carry them back.
 //     - instance / component references: FigmaExportNode has no instance type and
 //       createFigmaNode has no instance build-case → an INSTANCE degrades to a plain
-//       FRAME and its inner composition is not recursed.
+//       FRAME and its inner composition is not recursed. (spec-005 P2)
 import { describe, it, expect, beforeAll } from 'vitest';
-import { installMockFigma, FakeNode } from './helpers/mock-figma.ts';
+import { installMockFigma, setMockLocalVariables, FakeNode } from './helpers/mock-figma.ts';
 import type { FigmaExportNode } from '../shared/figma-payload-types.ts';
 import type { ScannedNode } from '../plugin/src/main/scan-node.ts';
 
@@ -29,21 +36,29 @@ beforeAll(() => { installMockFigma(); });
 // Imported lazily inside tests would also work; static import is safe because the
 // executor modules only touch `figma` inside function bodies.
 const { createFigmaNode } = await import('../plugin/src/main/executor-frame.ts');
-const { nodeToSpec } = await import('../plugin/src/main/scan-node.ts');
+const { nodeToSpec, readTokenNameMap } = await import('../plugin/src/main/scan-node.ts');
 
 type Vars = Map<string, { id: string; name: string }>;
 
-async function build(spec: FigmaExportNode, vars?: Vars): Promise<ScannedNode> {
+/** The file's id→name token map, as readTokenNameMap would produce it live. */
+const namesOf = (vars?: Vars): Map<string, string> =>
+  new Map([...(vars?.values() ?? [])].map((v) => [v.id, v.name]));
+
+async function build(spec: FigmaExportNode, vars?: Vars, tokenNames = namesOf(vars)): Promise<ScannedNode> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const node = await createFigmaNode(spec as any, new Map(), vars as any);
   if (!node) throw new Error('builder returned null');
-  return nodeToSpec(node);
+  return nodeToSpec(node, tokenNames);
 }
 
-/** One round of forward+reverse; returns [spec1, spec2] to check the fixed point. */
+/**
+ * One round of forward+reverse; returns [spec1, spec2] to check the fixed point.
+ * Both passes see the SAME token collection — a rebuild happens in a file whose
+ * variables exist, so withholding them would test a different question.
+ */
 async function roundTrips(spec0: FigmaExportNode, vars?: Vars): Promise<[ScannedNode, ScannedNode]> {
   const spec1 = await build(spec0, vars);
-  const spec2 = await build(spec1); // second pass, no vars — bindings cannot rebuild
+  const spec2 = await build(spec1, vars);
   return [spec1, spec2];
 }
 
@@ -131,30 +146,105 @@ describe('fixed point — per-corner radius (figma.mixed path)', () => {
   });
 });
 
-describe('reversibility GAP — variable bindings do not survive', () => {
+describe('fixed point — variable bindings survive via the token NAME (spec-005 P1)', () => {
   const btn: FigmaExportNode = {
     type: 'FRAME', name: 'Btn', width: 120, height: 40, layoutMode: 'HORIZONTAL',
+    itemSpacing: 8, paddingTop: 12, paddingRight: 12, paddingBottom: 12, paddingLeft: 12,
     primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'AUTO',
     fills: [{ type: 'SOLID', color: { r: 0.5, g: 0.2, b: 0.9, a: 1 } }],
+    strokes: [{ type: 'SOLID', color: { r: 1, g: 1, b: 1, a: 0.2 } }], strokeWeight: 1,
     cornerRadius: 8,
-    tokenRefs: { fill: 'color/brand', radius: 'radius/sm' },
+    tokenRefs: {
+      fill: 'color/brand', stroke: 'color/border', radius: 'radius/sm',
+      gap: 'space/sm', padding: 'space/md',
+    },
+    children: [
+      {
+        type: 'TEXT', name: 'Label', characters: 'Go', fontSize: 14,
+        textAutoResize: 'WIDTH_AND_HEIGHT', textColor: { r: 1, g: 1, b: 1, a: 1 },
+        tokenRefs: { textColor: 'color/on-brand' },
+      },
+    ],
   };
   const vars: Vars = new Map([
     ['color/brand', { id: 'VariableID:1', name: 'color/brand' }],
     ['radius/sm', { id: 'VariableID:2', name: 'radius/sm' }],
+    ['color/border', { id: 'VariableID:3', name: 'color/border' }],
+    ['space/sm', { id: 'VariableID:4', name: 'space/sm' }],
+    ['space/md', { id: 'VariableID:5', name: 'space/md' }],
+    ['color/on-brand', { id: 'VariableID:6', name: 'color/on-brand' }],
   ]);
 
-  it('detects the binding as a variable id but drops tokenRefs (name unrecoverable)', async () => {
+  it('recovers every bound field as a token NAME, not just an id', async () => {
     const spec1 = await build(btn, vars);
-    expect(spec1.figmaScanBindings).toEqual({ fills: 'VariableID:1', cornerRadius: 'VariableID:2' });
-    expect(spec1.tokenRefs).toBeUndefined(); // the token NAME is gone
+    expect(spec1.tokenRefs).toEqual({
+      fill: 'color/brand', stroke: 'color/border', radius: 'radius/sm',
+      gap: 'space/sm', padding: 'space/md',
+    });
+    // The raw ids stay recorded alongside (uniform padding → all four sides bound).
+    expect(spec1.figmaScanBindings).toMatchObject({
+      fills: 'VariableID:1', strokes: 'VariableID:3',
+      cornerRadius: 'VariableID:2', itemSpacing: 'VariableID:4',
+      paddingTop: 'VariableID:5', paddingLeft: 'VariableID:5',
+    });
   });
 
-  it('is NOT a fixed point — rebuilding spec1 loses the binding entirely', async () => {
-    const spec1 = await build(btn, vars);
-    const spec2 = await build(spec1); // no tokenRefs on spec1 → nothing to bind
+  it('recovers a TEXT colour binding as textColor (build-path convention)', async () => {
+    const [spec1] = await roundTrips(btn, vars);
+    expect(spec1.children?.[0]?.tokenRefs).toEqual({ textColor: 'color/on-brand' });
+  });
+
+  it('IS a fixed point — the rebuilt node carries the same bindings (spec1 === spec2)', async () => {
+    const [spec1, spec2] = await roundTrips(btn, vars);
+    expect(spec2.tokenRefs).toEqual(spec1.tokenRefs);
+    expect(spec2.figmaScanBindings).toEqual(spec1.figmaScanBindings);
+    expect(spec2).toEqual(spec1);
+  });
+
+  it('reads the id→name map from the file LOCAL variables (the live join source)', async () => {
+    setMockLocalVariables([{ id: 'VariableID:1', name: 'color/brand' }]);
+    const map = await readTokenNameMap();
+    expect(map.get('VariableID:1')).toBe('color/brand');
+    setMockLocalVariables([]);
+  });
+});
+
+describe('reversibility GAP that REMAINS — library / remote variable bindings', () => {
+  const card: FigmaExportNode = {
+    type: 'FRAME', name: 'LibCard', width: 100, height: 40, layoutMode: 'HORIZONTAL',
+    primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'AUTO',
+    fills: [{ type: 'SOLID', color: { r: 0.2, g: 0.4, b: 0.8, a: 1 } }],
+    tokenRefs: { fill: 'lib/color/primary' },
+  };
+  const vars: Vars = new Map([['lib/color/primary', { id: 'VariableID:9', name: 'lib/color/primary' }]]);
+
+  it('reports the binding as a raw id — a library variable has no LOCAL name to join', async () => {
+    // getLocalVariablesAsync does not list library variables → empty join map.
+    const spec1 = await build(card, vars, new Map());
+    expect(spec1.figmaScanBindings).toEqual({ fills: 'VariableID:9' });
+    expect(spec1.tokenRefs).toBeUndefined(); // no name recovered → nothing to rebind
+  });
+
+  it('is NOT a fixed point — the rebuild loses the library binding (loss is visible, not silent)', async () => {
+    const spec1 = await build(card, vars, new Map());
+    const spec2 = await build(spec1, vars, new Map());
     expect(spec2.figmaScanBindings).toBeUndefined();
     expect(spec2).not.toEqual(spec1);
+  });
+});
+
+describe('reversibility GAP that REMAINS — per-side (non-uniform) padding binding', () => {
+  it('leaves a single bound padding side as a raw id (tokenRefs models uniform padding only)', async () => {
+    const frame = new FakeNode('FRAME');
+    frame.name = 'PadOnTop';
+    frame.resize(100, 40);
+    frame.layoutMode = 'VERTICAL';
+    frame.paddingTop = 12;
+    frame.setBoundVariable('paddingTop', { id: 'VariableID:5' });
+
+    const spec1 = nodeToSpec(frame as unknown as SceneNode, new Map([['VariableID:5', 'space/md']]));
+    expect(spec1.figmaScanBindings).toEqual({ paddingTop: 'VariableID:5' });
+    expect(spec1.tokenRefs).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes gap 1 of the spec-005 spike: a variable binding scanned off a live node came back as a variable **id**, but `createFigmaNode`/`applyTokenRefs` rebind by token **name** — so a rebuild dropped every binding.

## What changed
- **`scan-token-refs.ts`** (new, 63 lines) — the pure id→name join: bound field → `tokenRefs` slot (`fill`/`textColor`/`stroke`/`radius`/`gap`, and `padding` only when all four sides are bound to the same variable). Sync + pure → unit-testable against a plain `Map`.
- **`scan-node.ts`** — `readTokenNameMap()` reads the file's local variables **once** per scan (async), so `nodeToSpec(node, tokenNames?)` stays synchronous and injectable as exec-js. Raw ids stay in `figmaScanBindings` alongside the recovered `tokenRefs`.
- **`cli/commands/scan-node.ts`** — prelude awaits the map and hands it to the walker (verified against the real esbuild bundle + the `opExecJs` async wrapper).
- **`executor-variables.ts`** — a `tokenRef` naming a variable this file has no local Variable for now **warns** (`pushImportWarning`) and keeps the literal value, instead of returning silently.

## Round-trip result (honest)
Bindings **survive**: `spec1 === spec2` asserted for fill, stroke, radius, gap, uniform padding, and a TEXT `textColor` on a child. Mutation-checked — stubbing the join fails 3 binding tests, so the assertion is real.

Two edges **remain**, asserted as explicit non-fixed-points rather than hidden:
1. **library / remote variables** — `getLocalVariablesAsync` doesn't list them, so no name is recoverable; the binding is reported as a raw id in `figmaScanBindings` and a rebuild drops it. (Reattaching would need `importVariableByKeyAsync` + the library key — out of P1 scope.)
2. **per-side (non-uniform) padding bindings** — `tokenRefs` models uniform padding only, so there's no slot to carry them back.

Instance references (gap 2) untouched — that's P2.

## Verify
4 BARE gates green · figma-agent suite 223/223 · figma-agent typecheck + build green.