### PR TITLE
feat: instances survive round-trip as ref + overrides (spec 005 P2)

### DIFF
--- a/figma-agent/plugin/code.js
+++ b/figma-agent/plugin/code.js
@@ -226,6 +226,22 @@
     const a = full.length >= 8 ? parseInt(full.slice(6, 8), 16) / 255 : 1;
     return { r: (int >> 16 & 255) / 255, g: (int >> 8 & 255) / 255, b: (int & 255) / 255, a };
   }
+  function exportFillToPaint(fill) {
+    if ((fill.type === "GRADIENT_LINEAR" || fill.type === "GRADIENT_RADIAL" || fill.type === "GRADIENT_ANGULAR") && fill.gradientStops && fill.gradientTransform) {
+      return {
+        type: fill.type,
+        gradientStops: fill.gradientStops.map((stop) => ({
+          color: { ...rgbToFigma(stop.color), a: stop.color.a },
+          position: stop.position
+        })),
+        gradientTransform: fill.gradientTransform
+      };
+    }
+    if (fill.color) {
+      return { type: "SOLID", color: rgbToFigma(fill.color), opacity: fill.color.a };
+    }
+    return null;
+  }
   function mapExportEffects(effects) {
     return effects.map((e) => {
       if (e.type === "LAYER_BLUR" || e.type === "BACKGROUND_BLUR") {
@@ -689,6 +705,106 @@
     }
   }
 
+  // plugin/src/main/executor-instance.ts
+  async function resolveMainComponent(spec) {
+    if (spec.componentKey) {
+      try {
+        return await figma.importComponentByKeyAsync(spec.componentKey);
+      } catch {
+      }
+    }
+    if (spec.componentId) {
+      try {
+        const local = await figma.getNodeByIdAsync(spec.componentId);
+        if (local && local.type === "COMPONENT") return local;
+        if (local && local.type === "COMPONENT_SET") return local.defaultVariant;
+      } catch {
+      }
+    }
+    return null;
+  }
+  function applyComponentProperties(instance, spec) {
+    if (!spec.componentProperties || Object.keys(spec.componentProperties).length === 0) return;
+    try {
+      instance.setProperties(spec.componentProperties);
+    } catch (err) {
+      pushImportWarning(`instance "${spec.name}": setProperties failed \u2014 built with main defaults (${String(err)})`);
+    }
+  }
+  function fillsDiffer(current, wanted) {
+    if (typeof current === "symbol") return true;
+    return JSON.stringify(current) !== JSON.stringify(wanted);
+  }
+  function applyNodeOverrides(instance, spec) {
+    if (spec.name && instance.name !== spec.name) {
+      try {
+        instance.name = spec.name;
+      } catch {
+      }
+    }
+    if (spec.width && spec.height && (Math.abs(instance.width - spec.width) > 0.01 || Math.abs(instance.height - spec.height) > 0.01)) {
+      try {
+        instance.resize(spec.width, spec.height);
+      } catch (err) {
+        pushImportWarning(`instance "${spec.name}": resize failed (${String(err)})`);
+      }
+    }
+    if (spec.fills && spec.fills.length) {
+      const paints = spec.fills.map(exportFillToPaint).filter((p) => p !== null);
+      if (paints.length && fillsDiffer(instance.fills, paints)) {
+        try {
+          instance.fills = paints;
+        } catch {
+        }
+      }
+    }
+    if (spec.cornerRadius !== void 0 && instance.cornerRadius !== spec.cornerRadius) {
+      try {
+        instance.cornerRadius = spec.cornerRadius;
+      } catch {
+      }
+    } else if (spec.cornerRadii) {
+      try {
+        instance.topLeftRadius = spec.cornerRadii.tl;
+        instance.topRightRadius = spec.cornerRadii.tr;
+        instance.bottomRightRadius = spec.cornerRadii.br;
+        instance.bottomLeftRadius = spec.cornerRadii.bl;
+      } catch {
+      }
+    }
+    if (spec.opacity !== void 0 && spec.opacity > 0 && instance.opacity !== spec.opacity) {
+      try {
+        instance.opacity = spec.opacity;
+      } catch {
+      }
+    }
+    if (spec.effects && spec.effects.length) {
+      try {
+        instance.effects = mapExportEffects(spec.effects);
+      } catch {
+      }
+    }
+  }
+  async function createInstanceNode(spec, frameFallback) {
+    const main = await resolveMainComponent(spec);
+    if (!main) {
+      pushImportWarning(
+        `instance "${spec.name}": main component not found (key=${spec.componentKey ?? "\u2014"}, id=${spec.componentId ?? "\u2014"}) \u2014 rebuilt as a plain frame, component link lost`
+      );
+      return frameFallback(spec);
+    }
+    let instance;
+    try {
+      instance = main.createInstance();
+    } catch (err) {
+      pushImportWarning(`instance "${spec.name}": createInstance failed \u2014 rebuilt as a plain frame (${String(err)})`);
+      return frameFallback(spec);
+    }
+    applyComponentProperties(instance, spec);
+    applyNodeOverrides(instance, spec);
+    return instance;
+  }
+
   // plugin/src/main/background-fill.ts
   function backgroundSizeToScaleMode(bgSize) {
     const s = (bgSize || "").trim().toLowerCase();
@@ -845,6 +961,9 @@
       case "RECTANGLE":
         node = await createRectangleNode(exportNode, colorStyles, tokenVars);
         break;
+      case "INSTANCE":
+        node = await createInstanceNode(exportNode, (spec) => createFrameNode(spec, colorStyles, tokenVars));
+        break;
       case "FRAME":
       case "GROUP":
       default:
@@ -978,28 +1097,14 @@
       const figmaFills = [];
       let usedPaintStyle = false;
       for (const fill of exportNode.fills ?? []) {
-        if ((fill.type === "GRADIENT_LINEAR" || fill.type === "GRADIENT_RADIAL" || fill.type === "GRADIENT_ANGULAR") && fill.gradientStops && fill.gradientTransform) {
-          figmaFills.push({
-            type: fill.type,
-            gradientStops: fill.gradientStops.map((stop) => ({
-              color: { ...rgbToFigma(stop.color), a: stop.color.a },
-              position: stop.position
-            })),
-            gradientTransform: fill.gradientTransform
-          });
-        } else if (fill.color) {
-          const hex = figmaColorToHex(fill.color);
-          const paintStyle = colorStyles.get(hex);
-          if (paintStyle && !hasBgImage) {
-            await frame.setFillStyleIdAsync(paintStyle.id);
-            usedPaintStyle = true;
-          } else {
-            figmaFills.push({
-              type: "SOLID",
-              color: rgbToFigma(fill.color),
-              opacity: fill.color.a
-            });
-          }
+        const paint = exportFillToPaint(fill);
+        if (!paint) continue;
+        const paintStyle = paint.type === "SOLID" ? colorStyles.get(figmaColorToHex(fill.color)) : void 0;
+        if (paintStyle && !hasBgImage) {
+          await frame.setFillStyleIdAsync(paintStyle.id);
+          usedPaintStyle = true;
+        } else {
+          figmaFills.push(paint);
         }
       }
       if (hasBgImage) {

--- a/figma-agent/plugin/src/main/executor-frame.ts
+++ b/figma-agent/plugin/src/main/executor-frame.ts
@@ -8,7 +8,8 @@
 import type { FigmaExportNode } from '../../../shared/figma-payload-types';
 import { createTextNode } from './executor-text';
 import { createRectangleNode, createImageNode, createSvgNode, createImageNodeWithFetch, resolveImagePaint } from './executor-shapes';
-import { rgbToFigma, figmaColorToHex, mapExportEffects, pushImportWarning } from './executor-styles';
+import { rgbToFigma, figmaColorToHex, exportFillToPaint, mapExportEffects, pushImportWarning } from './executor-styles';
+import { createInstanceNode } from './executor-instance';
 import { applyTokenRefs } from './executor-variables';
 import { backgroundSizeToScaleMode } from './background-fill';
 import { applyMotionTracks } from './executor-motion';
@@ -30,6 +31,11 @@ export async function createFigmaNode(
       break;
     case 'RECTANGLE':
       node = await createRectangleNode(exportNode, colorStyles, tokenVars); break;
+    case 'INSTANCE':
+      // spec-005 P2: rebuild from the main component + overrides; an unresolvable
+      // main degrades to the pre-P2 behaviour (a plain frame) with a warning.
+      node = await createInstanceNode(exportNode, (spec) => createFrameNode(spec, colorStyles, tokenVars));
+      break;
     case 'FRAME':
     case 'GROUP':
     default:
@@ -186,32 +192,17 @@ export async function createFrameNode(
     const figmaFills: Paint[] = [];
     let usedPaintStyle = false;
     for (const fill of exportNode.fills ?? []) {
-      if ((fill.type === 'GRADIENT_LINEAR' || fill.type === 'GRADIENT_RADIAL' || fill.type === 'GRADIENT_ANGULAR')
-        && fill.gradientStops && fill.gradientTransform) {
-        figmaFills.push({
-          type: fill.type,
-          gradientStops: fill.gradientStops.map((stop) => ({
-            color: { ...rgbToFigma(stop.color), a: stop.color.a },
-            position: stop.position,
-          })),
-          gradientTransform: fill.gradientTransform as Transform,
-        } as GradientPaint);
-      } else if (fill.color) {
-        const hex = figmaColorToHex(fill.color);
-        const paintStyle = colorStyles.get(hex);
-        // Skip the paint-style shortcut when a bg-image must sit on top — the
-        // image + solid have to coexist in the fills array (setFillStyleIdAsync
-        // would replace them entirely).
-        if (paintStyle && !hasBgImage) {
-          await frame.setFillStyleIdAsync(paintStyle.id);
-          usedPaintStyle = true;
-        } else {
-          figmaFills.push({
-            type: 'SOLID',
-            color: rgbToFigma(fill.color),
-            opacity: fill.color.a,
-          });
-        }
+      const paint = exportFillToPaint(fill);
+      if (!paint) continue;
+      const paintStyle = paint.type === 'SOLID' ? colorStyles.get(figmaColorToHex(fill.color)) : undefined;
+      // Skip the paint-style shortcut when a bg-image must sit on top — the
+      // image + solid have to coexist in the fills array (setFillStyleIdAsync
+      // would replace them entirely).
+      if (paintStyle && !hasBgImage) {
+        await frame.setFillStyleIdAsync(paintStyle.id);
+        usedPaintStyle = true;
+      } else {
+        figmaFills.push(paint);
       }
     }
     // CSS background-image paints ABOVE background-color (Figma: last fill on top).

--- a/figma-agent/plugin/src/main/executor-instance.ts
+++ b/figma-agent/plugin/src/main/executor-instance.ts
@@ -1,0 +1,127 @@
+// spec-005 P2 — the INSTANCE build-case: the forward twin of scan-node-instance.
+//
+// An instance is rebuilt as REF + OVERRIDES, never from a copied inner tree:
+// resolve the main component (portable `componentKey` first, same-file
+// `componentId` as fallback), `createInstance()` it, apply the component/variant
+// properties, then re-apply ONLY the node-level fields whose value differs from
+// what the main already gives — writing a field back that the main already
+// produces would create a spurious override in the user's file.
+//
+// Nothing here throws: an unresolvable main degrades to the plain frame the build
+// path would have produced before P2, with a warning (visible loss, not silent).
+
+import type { FigmaExportNode } from '../../../shared/figma-payload-types';
+import { exportFillToPaint, mapExportEffects, pushImportWarning } from './executor-styles';
+
+/** Builds the degrade-to-frame placeholder — injected to avoid an import cycle. */
+export type FrameFallback = (spec: FigmaExportNode) => Promise<SceneNode | null>;
+
+/** Resolve the spec's main component: library/published key first, local id second. */
+async function resolveMainComponent(spec: FigmaExportNode): Promise<ComponentNode | null> {
+  if (spec.componentKey) {
+    try {
+      return await figma.importComponentByKeyAsync(spec.componentKey);
+    } catch { /* not a published/reachable key → try the local id */ }
+  }
+  if (spec.componentId) {
+    try {
+      const local = await figma.getNodeByIdAsync(spec.componentId);
+      if (local && local.type === 'COMPONENT') return local;
+      if (local && local.type === 'COMPONENT_SET') return local.defaultVariant;
+    } catch { /* id from another file / stale → unresolvable */ }
+  }
+  return null;
+}
+
+/** Variant selection + component-property values (a no-op when the spec has none). */
+function applyComponentProperties(instance: InstanceNode, spec: FigmaExportNode): void {
+  if (!spec.componentProperties || Object.keys(spec.componentProperties).length === 0) return;
+  try {
+    instance.setProperties(spec.componentProperties);
+  } catch (err) {
+    // A property the main no longer exposes (renamed variant, deleted prop) —
+    // the instance still builds, on the main's defaults.
+    pushImportWarning(`instance "${spec.name}": setProperties failed — built with main defaults (${String(err)})`);
+  }
+}
+
+/** True when the spec's fills differ from the paints the main already produced. */
+function fillsDiffer(current: readonly Paint[] | symbol, wanted: Paint[]): boolean {
+  if (typeof current === 'symbol') return true; // figma.mixed → cannot compare
+  return JSON.stringify(current) !== JSON.stringify(wanted);
+}
+
+/**
+ * Re-apply the node-level overrides the payload models — size, fills, corner
+ * radius, opacity — each ONLY when it differs from the main's own value. Every
+ * write is guarded: an instance field can be locked by its main component.
+ */
+function applyNodeOverrides(instance: InstanceNode, spec: FigmaExportNode): void {
+  if (spec.name && instance.name !== spec.name) {
+    try { instance.name = spec.name; } catch { /* name locked */ }
+  }
+
+  if (spec.width && spec.height
+    && (Math.abs(instance.width - spec.width) > 0.01 || Math.abs(instance.height - spec.height) > 0.01)) {
+    try { instance.resize(spec.width, spec.height); } catch (err) {
+      pushImportWarning(`instance "${spec.name}": resize failed (${String(err)})`);
+    }
+  }
+
+  if (spec.fills && spec.fills.length) {
+    const paints = spec.fills.map(exportFillToPaint).filter((p): p is Paint => p !== null);
+    if (paints.length && fillsDiffer(instance.fills, paints)) {
+      try { instance.fills = paints; } catch { /* fills locked by the main */ }
+    }
+  }
+
+  if (spec.cornerRadius !== undefined && instance.cornerRadius !== spec.cornerRadius) {
+    try { instance.cornerRadius = spec.cornerRadius; } catch { /* radius locked */ }
+  } else if (spec.cornerRadii) {
+    try {
+      instance.topLeftRadius = spec.cornerRadii.tl;
+      instance.topRightRadius = spec.cornerRadii.tr;
+      instance.bottomRightRadius = spec.cornerRadii.br;
+      instance.bottomLeftRadius = spec.cornerRadii.bl;
+    } catch { /* radius locked */ }
+  }
+
+  if (spec.opacity !== undefined && spec.opacity > 0 && instance.opacity !== spec.opacity) {
+    try { instance.opacity = spec.opacity; } catch { /* opacity locked */ }
+  }
+
+  if (spec.effects && spec.effects.length) {
+    try { instance.effects = mapExportEffects(spec.effects); } catch { /* effects locked */ }
+  }
+}
+
+/**
+ * Payload INSTANCE node → a live instance of its main component.
+ * Falls back to `frameFallback` (a plain frame) when the main cannot be resolved —
+ * the spec's own visuals still land, but the component link is lost and reported.
+ */
+export async function createInstanceNode(
+  spec: FigmaExportNode,
+  frameFallback: FrameFallback,
+): Promise<SceneNode | null> {
+  const main = await resolveMainComponent(spec);
+  if (!main) {
+    pushImportWarning(
+      `instance "${spec.name}": main component not found (key=${spec.componentKey ?? '—'}, `
+      + `id=${spec.componentId ?? '—'}) — rebuilt as a plain frame, component link lost`,
+    );
+    return frameFallback(spec);
+  }
+
+  let instance: InstanceNode;
+  try {
+    instance = main.createInstance();
+  } catch (err) {
+    pushImportWarning(`instance "${spec.name}": createInstance failed — rebuilt as a plain frame (${String(err)})`);
+    return frameFallback(spec);
+  }
+
+  applyComponentProperties(instance, spec); // properties FIRST — a variant swap resets visuals
+  applyNodeOverrides(instance, spec);
+  return instance;
+}

--- a/figma-agent/plugin/src/main/executor-styles.ts
+++ b/figma-agent/plugin/src/main/executor-styles.ts
@@ -4,7 +4,7 @@
 // figmaColorToHex (858-864). Also hosts the cross-executor helpers:
 // error-code tagging and the per-import warnings collector.
 
-import type { FigmaColor, FigmaExportEffect, FigmaExportTokens } from '../../../shared/figma-payload-types';
+import type { FigmaColor, FigmaExportEffect, FigmaExportFill, FigmaExportTokens } from '../../../shared/figma-payload-types';
 import { loadBestFont } from './executor-fonts';
 
 // Folder prefix for generated local styles (EaseUI original used 'EaseUI/').
@@ -42,6 +42,30 @@ export function hexToFigmaColor(hex: string): FigmaColor {
   const int = parseInt(full.slice(0, 6), 16) || 0;
   const a = full.length >= 8 ? parseInt(full.slice(6, 8), 16) / 255 : 1;
   return { r: ((int >> 16) & 255) / 255, g: ((int >> 8) & 255) / 255, b: (int & 255) / 255, a };
+}
+
+/**
+ * One payload fill → one Figma Paint. The SHARED conversion behind every fill
+ * writer (frame build, instance overrides): a gradient with stops+transform maps
+ * to a GradientPaint, anything else carrying a colour maps to SOLID (alpha lives
+ * in paint.opacity, the convention the reverse-walker reads back).
+ */
+export function exportFillToPaint(fill: FigmaExportFill): Paint | null {
+  if ((fill.type === 'GRADIENT_LINEAR' || fill.type === 'GRADIENT_RADIAL' || fill.type === 'GRADIENT_ANGULAR')
+    && fill.gradientStops && fill.gradientTransform) {
+    return {
+      type: fill.type,
+      gradientStops: fill.gradientStops.map((stop) => ({
+        color: { ...rgbToFigma(stop.color), a: stop.color.a },
+        position: stop.position,
+      })),
+      gradientTransform: fill.gradientTransform as Transform,
+    } as GradientPaint;
+  }
+  if (fill.color) {
+    return { type: 'SOLID', color: rgbToFigma(fill.color), opacity: fill.color.a };
+  }
+  return null;
 }
 
 /** Map payload effects → Figma effects (shared by rect + frame executors). */

--- a/figma-agent/plugin/src/main/scan-node-instance.ts
+++ b/figma-agent/plugin/src/main/scan-node-instance.ts
@@ -1,0 +1,98 @@
+// Reverse-walker: the non-visual material — variable bindings (spec-005 P1) and
+// the instance/component reference (spec-005 P2, this module's reason to exist).
+//
+// INSTANCE MODEL — ref + overrides, NOT a copy of the inner tree:
+// an instance's composition belongs to its MAIN component, so the reversible
+// representation is (componentKey|componentId) + componentProperties, and the
+// builder rebuilds it with `main.createInstance()`. Recursing the inner tree would
+// capture the main's structure and rebuild it as a detached frame — exactly the
+// degradation P2 exists to remove. What the ref+overrides model cannot carry is
+// recorded in `figmaScanInnerOverrides` so the loss stays visible.
+
+import type { FigmaExportNode } from '../../../shared/figma-payload-types';
+import type { ScannedNode } from './scan-node-types';
+import { aliasId, safe } from './scan-node-utils';
+import { bindingsToTokenRefs } from './scan-token-refs';
+
+/** field→variable-id for every bound field the walker can see (node + paints). */
+function readBindings(n: Record<string, unknown>): Record<string, string> {
+  const rec: Record<string, string> = {};
+  // Scalar fields (cornerRadius, itemSpacing, padding…) live on node.boundVariables.
+  const bound = safe(() => n.boundVariables as Record<string, unknown>);
+  if (bound && typeof bound === 'object') {
+    for (const [field, val] of Object.entries(bound)) {
+      const id = aliasId(val);
+      if (id) rec[field] = id;
+    }
+  }
+  // Paint fields (fills/strokes) record the alias on the PAINT, not the node.
+  for (const field of ['fills', 'strokes'] as const) {
+    const paints = safe(() => n[field] as Array<Record<string, unknown>>);
+    if (!Array.isArray(paints)) continue;
+    for (const p of paints) {
+      const id = aliasId((p.boundVariables as { color?: unknown } | undefined)?.color);
+      if (id) { rec[field] = id; break; }
+    }
+  }
+  return rec;
+}
+
+/**
+ * Fields overridden on the instance's INNER children (deduped + sorted).
+ * `InstanceNode.overrides` reports one entry per overridden node; entries for the
+ * instance node ITSELF are excluded — those are node-level overrides the payload
+ * models and the builder re-applies. What remains is the un-survivable class.
+ */
+function readInnerOverrideFields(n: Record<string, unknown>, selfId: string): string[] {
+  const overrides = safe(() => n.overrides as Array<{ id?: string; overriddenFields?: string[] }>);
+  if (!Array.isArray(overrides)) return [];
+  const fields = new Set<string>();
+  for (const o of overrides) {
+    if (!o || o.id === selfId) continue;
+    for (const f of o.overriddenFields ?? []) fields.add(f);
+  }
+  return [...fields].sort();
+}
+
+/** The instance reference + property overrides — everything a rebuild needs. */
+export function readInstance(n: Record<string, unknown>, out: ScannedNode, selfId: string): void {
+  // `mainComponent` is the sync getter (the async twin can't be used: the walker is
+  // injected as a sync EXEC_JS function). Null for a main outside the loaded page.
+  const main = safe(() => n.mainComponent as { id?: string; key?: string; name?: string } | null);
+  if (main) {
+    if (typeof main.key === 'string' && main.key) out.componentKey = main.key;
+    if (typeof main.id === 'string' && main.id) out.componentId = main.id;
+    if (typeof main.name === 'string' && main.name) out.componentName = main.name;
+  }
+  const props = safe(() => n.componentProperties as Record<string, { value?: unknown }>);
+  if (props && typeof props === 'object') {
+    const rec: Record<string, string | boolean> = {};
+    for (const [k, entry] of Object.entries(props)) {
+      const v = entry?.value;
+      // string | boolean only — a variable-bound property value (VariableAlias)
+      // has no reversible slot and is left out (documented edge, see the header).
+      if (typeof v === 'string' || typeof v === 'boolean') rec[k] = v;
+    }
+    if (Object.keys(rec).length) out.componentProperties = rec;
+  }
+  const inner = readInnerOverrideFields(n, selfId);
+  if (inner.length) out.figmaScanInnerOverrides = inner;
+}
+
+/** Capture bindings (→ tokenRefs when resolvable) + un-modelled component types. */
+export function readExtensions(
+  n: Record<string, unknown>,
+  out: ScannedNode,
+  tokenNames: Map<string, string> | undefined,
+): void {
+  const rec = readBindings(n);
+  if (Object.keys(rec).length) {
+    out.figmaScanBindings = rec;
+    const refs = bindingsToTokenRefs(rec, out.type as FigmaExportNode['type'], tokenNames);
+    if (refs) out.tokenRefs = refs;
+  }
+  const type = n.type as string;
+  // COMPONENT / COMPONENT_SET have no payload representation (they ARE definitions,
+  // not instances of one) → they still degrade to FRAME; record the source type.
+  if (type === 'COMPONENT' || type === 'COMPONENT_SET') out.figmaScanSourceType = type;
+}

--- a/figma-agent/plugin/src/main/scan-node-layout.ts
+++ b/figma-agent/plugin/src/main/scan-node-layout.ts
@@ -1,0 +1,40 @@
+// Reverse-walker: auto-layout + self-sizing readers — the symmetric inverse of
+// executor-frame.applyAutoLayout and applyChildSizingHints.
+// Extracted from scan-node.ts (Art IX).
+
+import type { FigmaExportNode } from '../../../shared/figma-payload-types';
+import type { ScannedNode } from './scan-node-types';
+import { safe } from './scan-node-utils';
+
+/** Auto-layout + sizing block — the symmetric core of applyAutoLayout/child-sizing. */
+export function readLayout(n: Record<string, unknown>, out: ScannedNode): void {
+  const mode = n.layoutMode as string | undefined;
+  if (mode && mode !== 'NONE') {
+    out.layoutMode = mode as FigmaExportNode['layoutMode'];
+    if (typeof n.itemSpacing === 'number') out.itemSpacing = n.itemSpacing;
+    for (const k of ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'] as const) {
+      if (typeof n[k] === 'number') out[k] = n[k] as number;
+    }
+    if (n.primaryAxisSizingMode) out.primaryAxisSizingMode = n.primaryAxisSizingMode as 'AUTO' | 'FIXED';
+    if (n.counterAxisSizingMode) out.counterAxisSizingMode = n.counterAxisSizingMode as 'AUTO' | 'FIXED';
+    if (n.primaryAxisAlignItems) out.primaryAxisAlignItems = n.primaryAxisAlignItems as FigmaExportNode['primaryAxisAlignItems'];
+    if (n.counterAxisAlignItems) out.counterAxisAlignItems = n.counterAxisAlignItems as FigmaExportNode['counterAxisAlignItems'];
+    if (n.layoutWrap === 'WRAP') out.layoutWrap = 'WRAP';
+    if (typeof n.counterAxisSpacing === 'number') out.counterAxisSpacing = n.counterAxisSpacing;
+    if (n.counterAxisAlignContent === 'SPACE_BETWEEN') out.counterAxisAlignContent = 'SPACE_BETWEEN';
+    if (mode === 'GRID') {
+      for (const k of ['gridColumnCount', 'gridRowCount', 'gridRowGap', 'gridColumnGap'] as const) {
+        if (typeof n[k] === 'number') out[k] = n[k] as number;
+      }
+    }
+  }
+}
+
+/** Self-sizing — set by the PARENT's child-sizing loop; readable on ANY child (incl. TEXT). */
+export function readSelfSizing(n: Record<string, unknown>, out: ScannedNode): void {
+  const h = safe(() => n.layoutSizingHorizontal as string);
+  const v = safe(() => n.layoutSizingVertical as string);
+  if (h === 'FILL' || h === 'FIXED' || h === 'HUG') out.layoutSizingHorizontal = h;
+  if (v === 'FILL' || v === 'FIXED' || v === 'HUG') out.layoutSizingVertical = v;
+  if (typeof n.layoutGrow === 'number' && n.layoutGrow > 0) out.layoutGrow = n.layoutGrow;
+}

--- a/figma-agent/plugin/src/main/scan-node-paint.ts
+++ b/figma-agent/plugin/src/main/scan-node-paint.ts
@@ -1,0 +1,48 @@
+// Reverse-walker: Figma Paint / Effect → the payload's fill & effect shapes.
+// The symmetric inverse of executor-frame's fill mapping and
+// executor-styles.mapExportEffects. Extracted from scan-node.ts (Art IX).
+
+import type { FigmaExportEffect, FigmaExportFill } from '../../../shared/figma-payload-types';
+
+/** One Figma Paint → FigmaExportFill (SOLID alpha lives in paint.opacity → color.a). */
+export function paintToFill(p: Paint): FigmaExportFill | null {
+  if (p.type === 'SOLID') {
+    const a = typeof p.opacity === 'number' ? p.opacity : 1;
+    return { type: 'SOLID', color: { r: p.color.r, g: p.color.g, b: p.color.b, a } };
+  }
+  if (p.type === 'GRADIENT_LINEAR' || p.type === 'GRADIENT_RADIAL' || p.type === 'GRADIENT_ANGULAR') {
+    const g = p as GradientPaint;
+    return {
+      type: p.type,
+      gradientStops: g.gradientStops.map((s) => ({
+        color: { r: s.color.r, g: s.color.g, b: s.color.b, a: s.color.a },
+        position: s.position,
+      })),
+      gradientTransform: g.gradientTransform as unknown as [number, number, number][],
+    };
+  }
+  return null; // IMAGE / VIDEO paints not modelled by this spike
+}
+
+/** Figma Effect → FigmaExportEffect (inverse of executor-styles.mapExportEffects). */
+export function effectToExport(e: Effect): FigmaExportEffect | null {
+  if (e.type === 'LAYER_BLUR' || e.type === 'BACKGROUND_BLUR') {
+    return { type: e.type, radius: e.radius };
+  }
+  const s = e as DropShadowEffect;
+  const c = s.color;
+  return {
+    type: e.type as FigmaExportEffect['type'],
+    offset: { x: s.offset.x, y: s.offset.y },
+    radius: s.radius,
+    spread: s.spread ?? 0,
+    color: { r: c.r, g: c.g, b: c.b, a: c.a },
+  };
+}
+
+/** A node's fills/strokes array → payload fills; undefined when nothing modelled. */
+export const asFills = (v: unknown): FigmaExportFill[] | undefined => {
+  if (!Array.isArray(v) || v.length === 0) return undefined;
+  const out = (v as Paint[]).map(paintToFill).filter((f): f is FigmaExportFill => f !== null);
+  return out.length ? out : undefined;
+};

--- a/figma-agent/plugin/src/main/scan-node-text.ts
+++ b/figma-agent/plugin/src/main/scan-node-text.ts
@@ -1,0 +1,44 @@
+// Reverse-walker: TEXT-only readers — the inverse of executor-text.createTextNode.
+// Extracted from scan-node.ts (Art IX).
+
+import type { FigmaColor, FigmaExportNode } from '../../../shared/figma-payload-types';
+import type { ScannedNode } from './scan-node-types';
+import { asFills } from './scan-node-paint';
+import { safe } from './scan-node-utils';
+
+// Inverse of executor-fonts.getFontStyleVariants: a Figma style name → numeric
+// weight. Only recovers the weight the build path could have emitted; unknown
+// styles leave fontWeight unset (documented reversibility limit).
+export function styleToWeight(style: string): number | undefined {
+  const s = style.toLowerCase().replace(/\s|italic/g, '');
+  const map: Record<string, number> = {
+    thin: 100, hairline: 100, extralight: 200, ultralight: 200, light: 300,
+    regular: 400, normal: 400, book: 400, medium: 500, semibold: 600, demibold: 600,
+    bold: 700, extrabold: 800, ultrabold: 800, black: 900, heavy: 900,
+  };
+  return map[s];
+}
+
+/** Text-only fields — inverse of executor-text.createTextNode. */
+export function readText(n: Record<string, unknown>, out: ScannedNode): void {
+  if (typeof n.characters === 'string') out.characters = n.characters;
+  const font = safe(() => n.fontName as FontName);
+  if (font && typeof font === 'object' && 'family' in font) {
+    out.fontFamily = font.family;
+    if (font.style.toLowerCase().includes('italic')) out.fontStyle = 'italic';
+    const w = styleToWeight(font.style);
+    if (w !== undefined) out.fontWeight = w;
+  }
+  if (typeof n.fontSize === 'number') out.fontSize = n.fontSize;
+  const lh = safe(() => n.lineHeight as LineHeight);
+  if (lh && typeof lh === 'object' && lh.unit === 'PIXELS') out.lineHeight = lh.value;
+  const ls = safe(() => n.letterSpacing as LetterSpacing);
+  if (ls && typeof ls === 'object' && ls.unit === 'PIXELS') out.letterSpacing = ls.value;
+  if (n.textAlignHorizontal) out.textAlignHorizontal = n.textAlignHorizontal as FigmaExportNode['textAlignHorizontal'];
+  if (n.textAutoResize) out.textAutoResize = n.textAutoResize as FigmaExportNode['textAutoResize'];
+  if (n.textDecoration && n.textDecoration !== 'NONE') out.textDecoration = n.textDecoration as FigmaExportNode['textDecoration'];
+  if (n.textCase && n.textCase !== 'ORIGINAL') out.textCase = n.textCase as FigmaExportNode['textCase'];
+  // TEXT colour lives in fills[0]; surface it as textColor (build-path convention).
+  const fills = asFills(n.fills);
+  if (fills && fills[0]?.type === 'SOLID' && fills[0].color) out.textColor = fills[0].color as FigmaColor;
+}

--- a/figma-agent/plugin/src/main/scan-node-types.ts
+++ b/figma-agent/plugin/src/main/scan-node-types.ts
@@ -1,0 +1,23 @@
+// Shared types for the reverse-walker (scan-node*.ts). Kept in their own module so
+// the sub-walkers (layout / text / paint / instance) can type their `out` parameter
+// without importing scan-node.ts back (circular import).
+
+import type { FigmaExportNode } from '../../../shared/figma-payload-types';
+
+/** Material captured beyond the reversible FigmaExportNode fields. */
+export interface ScanExtensions {
+  // Raw field → variable id, ALWAYS recorded. Ids that resolve against the token
+  // map also become `tokenRefs` (reversible); ids that don't (library/remote
+  // variables) stay here only — the loss stays visible instead of silent.
+  figmaScanBindings?: Record<string, string>;
+  // The raw node.type when the schema cannot model it: COMPONENT / COMPONENT_SET
+  // still degrade to FRAME (their definition is the file's, not a payload's).
+  // INSTANCE is NO LONGER here — it is a first-class type since spec-005 P2.
+  figmaScanSourceType?: string;
+  // Fields overridden on the instance's INNER children (deduped names). The mirror
+  // models an instance as ref + node-level overrides only, so these do NOT survive
+  // a rebuild — recorded to keep that loss visible (spec-005 P2 documented edge).
+  figmaScanInnerOverrides?: string[];
+}
+
+export type ScannedNode = FigmaExportNode & ScanExtensions;

--- a/figma-agent/plugin/src/main/scan-node-utils.ts
+++ b/figma-agent/plugin/src/main/scan-node-utils.ts
@@ -1,0 +1,23 @@
+// Small readers shared by every reverse-walker module (scan-node*.ts).
+// Pure, sync, never throwing — the walker runs in the Figma plugin sandbox and a
+// single missing/mixed field must never abort a scan.
+
+/** Round to 2 decimals (Figma reports sub-pixel sizes; the spec stores stable ones). */
+export const r2 = (n: number): number => Math.round(n * 100) / 100;
+
+/** Read a possibly-mixed / throwing field; returns undefined on symbol/throw. */
+export function safe<T>(read: () => T): T | undefined {
+  try {
+    const v = read();
+    if (typeof v === 'symbol') return undefined; // figma.mixed
+    return v;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read a variable-alias id off a boundVariables entry (array field or scalar field). */
+export function aliasId(val: unknown): string | undefined {
+  const alias = Array.isArray(val) ? val[0] : val;
+  return (alias as { id?: string } | undefined)?.id;
+}

--- a/figma-agent/plugin/src/main/scan-node.ts
+++ b/figma-agent/plugin/src/main/scan-node.ts
@@ -1,178 +1,40 @@
-// Reverse-walker (spec 005 SPIKE): live SceneNode subtree → FigmaExportNode.
+// Reverse-walker (spec 005): live SceneNode subtree → FigmaExportNode.
 // The SYMMETRIC inverse of the build path — where build-frame.ts walks DOM+CSS
 // into a FigmaExportNode and executor-frame.createFigmaNode replays that spec onto
 // the canvas, `nodeToSpec` reads the ACTUAL node fields the executor writes back
 // into a FigmaExportNode, so `node → spec → node` can be proven a fixed point.
 //
-// Pure + self-contained (only TYPE imports, erased at runtime) so the CLI
-// `scan-node` command can inject `nodeToSpec.toString()` as an EXEC_JS script and
-// the fixed-point harness can unit-test it against mock nodes. Runs in the Figma
-// plugin sandbox (browser platform, no node APIs) — never throws on a missing field.
+// Sub-walkers live in scan-node-{layout,text,paint,instance,utils}.ts (Art IX);
+// this module owns only the type mapping and the recursion. Everything stays pure
+// and sync so the CLI `scan-node` command can esbuild-bundle it into an EXEC_JS
+// script. Runs in the Figma plugin sandbox (browser platform, no node APIs) and
+// never throws on a missing field.
 //
-// SCOPE — variable bindings ARE reversible since spec-005 P1: `nodeToSpec` takes the
-// file's id→name token map (see readTokenNameMap) and rebuilds `tokenRefs`, which the
-// build path already reattaches by name. Still only *captured as an extension*, with
-// no reversible slot: instance/component references (mainComponent) and nested-variant
-// composition — FigmaExportNode has no instance type and createFigmaNode no instance
-// build-case, so an INSTANCE cannot survive a round-trip (spec-005 P2's job).
+// SCOPE — reversible since spec-005 P1: variable bindings (`nodeToSpec` takes the
+// file's id→name token map, see readTokenNameMap, and rebuilds `tokenRefs`, which
+// the build path reattaches by name). Reversible since P2: INSTANCE nodes, as
+// ref + overrides (see scan-node-instance.ts). Still captured as extensions only,
+// with no reversible slot: COMPONENT / COMPONENT_SET definitions, library variable
+// bindings, and an instance's INNER (per-child) overrides.
 
-import type {
-  FigmaColor, FigmaExportEffect, FigmaExportFill, FigmaExportNode,
-} from '../../../shared/figma-payload-types';
-import { bindingsToTokenRefs } from './scan-token-refs';
+import type { FigmaExportEffect, FigmaExportNode } from '../../../shared/figma-payload-types';
+import type { ScannedNode } from './scan-node-types';
+import { readExtensions, readInstance } from './scan-node-instance';
+import { readLayout, readSelfSizing } from './scan-node-layout';
+import { asFills, effectToExport } from './scan-node-paint';
+import { readText } from './scan-node-text';
+import { r2, safe } from './scan-node-utils';
 
-/** Material captured beyond the reversible FigmaExportNode fields. */
-export interface ScanExtensions {
-  // Raw field → variable id, ALWAYS recorded. Ids that resolve against the token
-  // map also become `tokenRefs` (reversible); ids that don't (library/remote
-  // variables) stay here only — the loss stays visible instead of silent.
-  figmaScanBindings?: Record<string, string>;
-  // This node is an INSTANCE / COMPONENT — records the source. FigmaExportNode has
-  // no instance type and createFigmaNode has no instance build-case → link is lost.
-  figmaScanSourceType?: string;      // the raw node.type (INSTANCE / COMPONENT / …)
-  figmaScanMainComponent?: string;   // mainComponent.id for an INSTANCE
-}
+export type { ScanExtensions, ScannedNode } from './scan-node-types';
 
-export type ScannedNode = FigmaExportNode & ScanExtensions;
-
-const r2 = (n: number): number => Math.round(n * 100) / 100;
-
-/** Figma node.type → FigmaExportNode.type (the only 5 the schema models). */
+/** Figma node.type → FigmaExportNode.type (the only ones the schema models). */
 function mapType(t: string): FigmaExportNode['type'] {
   if (t === 'TEXT') return 'TEXT';
   if (t === 'GROUP') return 'GROUP';
+  if (t === 'INSTANCE') return 'INSTANCE';
   if (t === 'RECTANGLE' || t === 'ELLIPSE' || t === 'VECTOR'
     || t === 'LINE' || t === 'STAR' || t === 'POLYGON') return 'RECTANGLE';
-  return 'FRAME'; // FRAME / COMPONENT / COMPONENT_SET / INSTANCE / SECTION
-}
-
-/** Read a possibly-mixed / throwing field; returns undefined on symbol/throw. */
-function safe<T>(read: () => T): T | undefined {
-  try {
-    const v = read();
-    if (typeof v === 'symbol') return undefined; // figma.mixed
-    return v;
-  } catch {
-    return undefined;
-  }
-}
-
-/** One Figma Paint → FigmaExportFill (SOLID alpha lives in paint.opacity → color.a). */
-function paintToFill(p: Paint): FigmaExportFill | null {
-  if (p.type === 'SOLID') {
-    const a = typeof p.opacity === 'number' ? p.opacity : 1;
-    return { type: 'SOLID', color: { r: p.color.r, g: p.color.g, b: p.color.b, a } };
-  }
-  if (p.type === 'GRADIENT_LINEAR' || p.type === 'GRADIENT_RADIAL' || p.type === 'GRADIENT_ANGULAR') {
-    const g = p as GradientPaint;
-    return {
-      type: p.type,
-      gradientStops: g.gradientStops.map((s) => ({
-        color: { r: s.color.r, g: s.color.g, b: s.color.b, a: s.color.a },
-        position: s.position,
-      })),
-      gradientTransform: g.gradientTransform as unknown as [number, number, number][],
-    };
-  }
-  return null; // IMAGE / VIDEO paints not modelled by this spike
-}
-
-/** Figma Effect → FigmaExportEffect (inverse of executor-styles.mapExportEffects). */
-function effectToExport(e: Effect): FigmaExportEffect | null {
-  if (e.type === 'LAYER_BLUR' || e.type === 'BACKGROUND_BLUR') {
-    return { type: e.type, radius: e.radius };
-  }
-  const s = e as DropShadowEffect;
-  const c = s.color;
-  return {
-    type: e.type as FigmaExportEffect['type'],
-    offset: { x: s.offset.x, y: s.offset.y },
-    radius: s.radius,
-    spread: s.spread ?? 0,
-    color: { r: c.r, g: c.g, b: c.b, a: c.a },
-  };
-}
-
-const asFills = (v: unknown): FigmaExportFill[] | undefined => {
-  if (!Array.isArray(v) || v.length === 0) return undefined;
-  const out = (v as Paint[]).map(paintToFill).filter((f): f is FigmaExportFill => f !== null);
-  return out.length ? out : undefined;
-};
-
-/** Auto-layout + sizing block — the symmetric core of applyAutoLayout/child-sizing. */
-function readLayout(n: Record<string, unknown>, out: ScannedNode): void {
-  const mode = n.layoutMode as string | undefined;
-  if (mode && mode !== 'NONE') {
-    out.layoutMode = mode as FigmaExportNode['layoutMode'];
-    if (typeof n.itemSpacing === 'number') out.itemSpacing = n.itemSpacing;
-    for (const k of ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'] as const) {
-      if (typeof n[k] === 'number') out[k] = n[k] as number;
-    }
-    if (n.primaryAxisSizingMode) out.primaryAxisSizingMode = n.primaryAxisSizingMode as 'AUTO' | 'FIXED';
-    if (n.counterAxisSizingMode) out.counterAxisSizingMode = n.counterAxisSizingMode as 'AUTO' | 'FIXED';
-    if (n.primaryAxisAlignItems) out.primaryAxisAlignItems = n.primaryAxisAlignItems as FigmaExportNode['primaryAxisAlignItems'];
-    if (n.counterAxisAlignItems) out.counterAxisAlignItems = n.counterAxisAlignItems as FigmaExportNode['counterAxisAlignItems'];
-    if (n.layoutWrap === 'WRAP') out.layoutWrap = 'WRAP';
-    if (typeof n.counterAxisSpacing === 'number') out.counterAxisSpacing = n.counterAxisSpacing;
-    if (n.counterAxisAlignContent === 'SPACE_BETWEEN') out.counterAxisAlignContent = 'SPACE_BETWEEN';
-    if (mode === 'GRID') {
-      for (const k of ['gridColumnCount', 'gridRowCount', 'gridRowGap', 'gridColumnGap'] as const) {
-        if (typeof n[k] === 'number') out[k] = n[k] as number;
-      }
-    }
-  }
-}
-
-/** Self-sizing — set by the PARENT's child-sizing loop; readable on ANY child (incl. TEXT). */
-function readSelfSizing(n: Record<string, unknown>, out: ScannedNode): void {
-  const h = safe(() => n.layoutSizingHorizontal as string);
-  const v = safe(() => n.layoutSizingVertical as string);
-  if (h === 'FILL' || h === 'FIXED' || h === 'HUG') out.layoutSizingHorizontal = h;
-  if (v === 'FILL' || v === 'FIXED' || v === 'HUG') out.layoutSizingVertical = v;
-  if (typeof n.layoutGrow === 'number' && n.layoutGrow > 0) out.layoutGrow = n.layoutGrow;
-}
-
-// Inverse of executor-fonts.getFontStyleVariants: a Figma style name → numeric
-// weight. Only recovers the weight the build path could have emitted; unknown
-// styles leave fontWeight unset (documented reversibility limit).
-function styleToWeight(style: string): number | undefined {
-  const s = style.toLowerCase().replace(/\s|italic/g, '');
-  const map: Record<string, number> = {
-    thin: 100, hairline: 100, extralight: 200, ultralight: 200, light: 300,
-    regular: 400, normal: 400, book: 400, medium: 500, semibold: 600, demibold: 600,
-    bold: 700, extrabold: 800, ultrabold: 800, black: 900, heavy: 900,
-  };
-  return map[s];
-}
-
-/** Text-only fields — inverse of executor-text.createTextNode. */
-function readText(n: Record<string, unknown>, out: ScannedNode): void {
-  if (typeof n.characters === 'string') out.characters = n.characters;
-  const font = safe(() => n.fontName as FontName);
-  if (font && typeof font === 'object' && 'family' in font) {
-    out.fontFamily = font.family;
-    if (font.style.toLowerCase().includes('italic')) out.fontStyle = 'italic';
-    const w = styleToWeight(font.style);
-    if (w !== undefined) out.fontWeight = w;
-  }
-  if (typeof n.fontSize === 'number') out.fontSize = n.fontSize;
-  const lh = safe(() => n.lineHeight as LineHeight);
-  if (lh && typeof lh === 'object' && lh.unit === 'PIXELS') out.lineHeight = lh.value;
-  const ls = safe(() => n.letterSpacing as LetterSpacing);
-  if (ls && typeof ls === 'object' && ls.unit === 'PIXELS') out.letterSpacing = ls.value;
-  if (n.textAlignHorizontal) out.textAlignHorizontal = n.textAlignHorizontal as FigmaExportNode['textAlignHorizontal'];
-  if (n.textAutoResize) out.textAutoResize = n.textAutoResize as FigmaExportNode['textAutoResize'];
-  if (n.textDecoration && n.textDecoration !== 'NONE') out.textDecoration = n.textDecoration as FigmaExportNode['textDecoration'];
-  if (n.textCase && n.textCase !== 'ORIGINAL') out.textCase = n.textCase as FigmaExportNode['textCase'];
-  // TEXT colour lives in fills[0]; surface it as textColor (build-path convention).
-  const fills = asFills(n.fills);
-  if (fills && fills[0]?.type === 'SOLID' && fills[0].color) out.textColor = fills[0].color as FigmaColor;
-}
-
-/** Read a variable-alias id off a boundVariables entry (array field or scalar field). */
-function aliasId(val: unknown): string | undefined {
-  const alias = Array.isArray(val) ? val[0] : val;
-  return (alias as { id?: string } | undefined)?.id;
+  return 'FRAME'; // FRAME / COMPONENT / COMPONENT_SET / SECTION
 }
 
 /**
@@ -192,40 +54,36 @@ export async function readTokenNameMap(): Promise<Map<string, string>> {
   return map;
 }
 
-/** Capture bindings (→ tokenRefs when resolvable) + the instance ref (gap 2). */
-function readExtensions(
-  n: Record<string, unknown>,
-  out: ScannedNode,
-  tokenNames: Map<string, string> | undefined,
-): void {
-  const rec: Record<string, string> = {};
-  // Scalar fields (cornerRadius, itemSpacing, padding…) live on node.boundVariables.
-  const bound = safe(() => n.boundVariables as Record<string, unknown>);
-  if (bound && typeof bound === 'object') {
-    for (const [field, val] of Object.entries(bound)) {
-      const id = aliasId(val);
-      if (id) rec[field] = id;
-    }
+/** Fills, corner radius, strokes, constraints, clipping — the frame-ish visuals. */
+function readFrameVisuals(n: Record<string, unknown>, out: ScannedNode): void {
+  out.fills = asFills(n.fills);
+  if (out.fills === undefined) delete out.fills;
+
+  // Corner radius: uniform number, else per-corner (getter throws figma.mixed).
+  const cr = safe(() => n.cornerRadius as number);
+  if (typeof cr === 'number' && cr > 0) {
+    out.cornerRadius = cr;
+  } else {
+    const tl = safe(() => n.topLeftRadius as number) ?? 0;
+    const tr = safe(() => n.topRightRadius as number) ?? 0;
+    const br = safe(() => n.bottomRightRadius as number) ?? 0;
+    const bl = safe(() => n.bottomLeftRadius as number) ?? 0;
+    if (tl || tr || br || bl) out.cornerRadii = { tl, tr, br, bl };
   }
-  // Paint fields (fills/strokes) record the alias on the PAINT, not the node.
-  for (const field of ['fills', 'strokes'] as const) {
-    const paints = safe(() => n[field] as Array<Record<string, unknown>>);
-    if (!Array.isArray(paints)) continue;
-    for (const p of paints) {
-      const id = aliasId((p.boundVariables as { color?: unknown } | undefined)?.color);
-      if (id) { rec[field] = id; break; }
-    }
+
+  const strokes = asFills(n.strokes);
+  if (strokes) {
+    out.strokes = strokes;
+    if (typeof n.strokeWeight === 'number') out.strokeWeight = n.strokeWeight;
+    if (n.strokeAlign) out.strokeAlign = n.strokeAlign as FigmaExportNode['strokeAlign'];
   }
-  if (Object.keys(rec).length) {
-    out.figmaScanBindings = rec;
-    const refs = bindingsToTokenRefs(rec, out.type, tokenNames);
-    if (refs) out.tokenRefs = refs;
+
+  for (const k of ['maxWidth', 'minWidth', 'maxHeight', 'minHeight'] as const) {
+    if (typeof n[k] === 'number') out[k] = n[k] as number;
   }
-  const type = n.type as string;
-  if (type === 'INSTANCE' || type === 'COMPONENT' || type === 'COMPONENT_SET') {
-    out.figmaScanSourceType = type;
-    const main = safe(() => (n.mainComponent as { id?: string } | null)?.id);
-    if (main) out.figmaScanMainComponent = main;
+  if (n.clipsContent === true) out.clipsContent = true;
+  if (n.blendMode && n.blendMode !== 'PASS_THROUGH' && n.blendMode !== 'NORMAL') {
+    out.blendMode = n.blendMode as string;
   }
 }
 
@@ -233,8 +91,9 @@ function readExtensions(
  * Walk one live SceneNode subtree → FigmaExportNode (+ scan extensions).
  * `tokenNames` (from readTokenNameMap) turns variable ids into reversible
  * tokenRefs; omit it and bindings degrade to raw ids only.
- * INSTANCE composition is NOT recursed (audit rule L106) — its inner tree is the
- * component's, not the instance's, and has no reversible representation here.
+ * INSTANCE composition is NOT recursed: an instance is captured as a reference to
+ * its main component plus its overrides (spec-005 P2) — the inner tree is the
+ * component's definition, and the builder rebuilds it via createInstance().
  */
 export function nodeToSpec(node: SceneNode, tokenNames?: Map<string, string>): ScannedNode {
   const n = node as unknown as Record<string, unknown>;
@@ -252,35 +111,7 @@ export function nodeToSpec(node: SceneNode, tokenNames?: Map<string, string>): S
     readText(n, out);
   } else {
     readLayout(n, out);
-    out.fills = asFills(n.fills);
-    if (out.fills === undefined) delete out.fills;
-
-    // Corner radius: uniform number, else per-corner (getter throws figma.mixed).
-    const cr = safe(() => n.cornerRadius as number);
-    if (typeof cr === 'number' && cr > 0) {
-      out.cornerRadius = cr;
-    } else {
-      const tl = safe(() => n.topLeftRadius as number) ?? 0;
-      const tr = safe(() => n.topRightRadius as number) ?? 0;
-      const br = safe(() => n.bottomRightRadius as number) ?? 0;
-      const bl = safe(() => n.bottomLeftRadius as number) ?? 0;
-      if (tl || tr || br || bl) out.cornerRadii = { tl, tr, br, bl };
-    }
-
-    const strokes = asFills(n.strokes);
-    if (strokes) {
-      out.strokes = strokes;
-      if (typeof n.strokeWeight === 'number') out.strokeWeight = n.strokeWeight;
-      if (n.strokeAlign) out.strokeAlign = n.strokeAlign as FigmaExportNode['strokeAlign'];
-    }
-
-    for (const k of ['maxWidth', 'minWidth', 'maxHeight', 'minHeight'] as const) {
-      if (typeof n[k] === 'number') out[k] = n[k] as number;
-    }
-    if (n.clipsContent === true) out.clipsContent = true;
-    if (n.blendMode && n.blendMode !== 'PASS_THROUGH' && n.blendMode !== 'NORMAL') {
-      out.blendMode = n.blendMode as string;
-    }
+    readFrameVisuals(n, out);
   }
 
   // Shared visual fields (frame + text): effects, opacity, rotation.
@@ -293,6 +124,7 @@ export function nodeToSpec(node: SceneNode, tokenNames?: Map<string, string>): S
   if (typeof n.rotation === 'number' && Math.abs(n.rotation) > 0.001) out.rotation = n.rotation;
 
   readExtensions(n, out, tokenNames);
+  if (type === 'INSTANCE') readInstance(n, out, node.id);
 
   // Children — recurse, EXCEPT into an instance (composition is the component's).
   if (type !== 'INSTANCE' && 'children' in node) {

--- a/figma-agent/shared/figma-payload-types.ts
+++ b/figma-agent/shared/figma-payload-types.ts
@@ -26,7 +26,7 @@ export interface FigmaExportEffect {
 }
 
 export interface FigmaExportNode {
-  type: 'FRAME' | 'TEXT' | 'RECTANGLE' | 'IMAGE' | 'GROUP';
+  type: 'FRAME' | 'TEXT' | 'RECTANGLE' | 'IMAGE' | 'GROUP' | 'INSTANCE';
   name: string;
 
   // Dimensions
@@ -130,6 +130,24 @@ export interface FigmaExportNode {
     gap?: string;       // spacing[].name  (itemSpacing)
     padding?: string;   // spacing[].name  (all four sides when uniform)
   };
+
+  // Instance reference (spec 005 P2) — only meaningful when `type === 'INSTANCE'`.
+  // An instance is modelled as REF + OVERRIDES, never as a copy of its inner tree:
+  // the composition belongs to the main component, so a rebuild instantiates the
+  // main and re-applies only what this instance overrides. `componentKey` is the
+  // portable identity (published/library components, importComponentByKeyAsync);
+  // `componentId` is the same-file fallback (local node id). At least one is needed
+  // to rebuild — with neither resolvable the builder degrades to a plain frame and
+  // warns (no silent loss).
+  componentKey?: string;
+  componentId?: string;
+  componentName?: string; // trace only — never used to resolve the main component
+  // Variant selection + component-property values, as `InstanceNode.setProperties`
+  // consumes them (keys are Figma's property names, e.g. "State" or "Label#12:3").
+  // Values are string (VARIANT / TEXT / INSTANCE_SWAP-key) or boolean (BOOLEAN) —
+  // the only kinds the Plugin API accepts; a bound VariableAlias value has no
+  // reversible slot here and is skipped by the walker.
+  componentProperties?: Record<string, string | boolean>;
 
   // Nesting
   children?: FigmaExportNode[];

--- a/figma-agent/tests/helpers/mock-figma.ts
+++ b/figma-agent/tests/helpers/mock-figma.ts
@@ -10,8 +10,12 @@
 //      walker must fall back to per-corner reads.
 //   3. variable bindings are recorded on node.boundVariables (scalar fields) and on
 //      the PAINT's boundVariables (fills/strokes) — the split the walker must scan.
+//   4. an INSTANCE mirrors its main component (createInstance clones it) and
+//      setProperties throws on a property the main does not expose — the two
+//      behaviours the spec-005 P2 instance round-trip stands on.
 // It does NOT emulate Figma's layout re-flow (a child's FILL coercing the parent's
-// sizing mode). That is exactly the class of loss the LIVE half must confirm.
+// sizing mode), nor `InstanceNode.overrides` bookkeeping (tests set it by hand).
+// Those are exactly the classes of loss the LIVE half (P5) must confirm.
 
 let idSeq = 0;
 export const FIGMA_MIXED = Symbol('figma.mixed');
@@ -48,6 +52,37 @@ export class FakeNode {
 
   setBoundVariable(field: string, variable: { id: string }): void {
     this.boundVariables[field] = { type: 'VARIABLE_ALIAS', id: variable.id };
+  }
+
+  /** Own data props (incl. the private corner/sizing fields) + children, deep-copied. */
+  private cloneAs(type: string): FakeNode {
+    const copy = new FakeNode(type);
+    for (const [k, v] of Object.entries(this)) {
+      if (k === 'id' || k === 'type' || k === 'parent' || k === 'children') continue;
+      copy[k] = v && typeof v === 'object' ? JSON.parse(JSON.stringify(v)) : v;
+    }
+    for (const c of this.children) copy.appendChild(c.cloneAs(c.type));
+    return copy;
+  }
+
+  /** ComponentNode.createInstance — an instance MIRRORS its main until overridden. */
+  createInstance(): FakeNode {
+    const inst = this.cloneAs('INSTANCE');
+    delete inst.key; // only a main component is publishable
+    inst.mainComponent = { id: this.id, key: this.key, name: this.name };
+    return inst;
+  }
+
+  /** InstanceNode.setProperties — throws on a property the main doesn't expose. */
+  setProperties(props: Record<string, string | boolean>): void {
+    const defs = this.componentPropertyDefinitions as Record<string, unknown> | undefined;
+    const current = (this.componentProperties as Record<string, { value: unknown }>) ?? {};
+    const next: Record<string, { type: string; value: unknown }> = { ...(current as never) };
+    for (const [k, v] of Object.entries(props)) {
+      if (defs && !(k in defs)) throw new Error(`property "${k}" not found on the main component`);
+      next[k] = { type: 'VARIANT', value: v };
+    }
+    this.componentProperties = next;
   }
 
   private get inAutoLayout(): boolean {
@@ -95,13 +130,32 @@ export function setMockLocalVariables(vars: Array<{ id: string; name: string }>)
   localVariables = vars;
 }
 
+/** The file's COMPONENT / COMPONENT_SET nodes, as the instance build-case resolves
+ * them: by publishable `key` (importComponentByKeyAsync) or node id
+ * (getNodeByIdAsync). A ref that matches neither = the unresolvable-main edge. */
+let components: FakeNode[] = [];
+export function setMockComponents(comps: FakeNode[]): void {
+  components = comps;
+}
+
+/** A COMPONENT the instance build-case can resolve + instantiate. */
+export function makeMockComponent(name: string, key?: string): FakeNode {
+  const comp = new FakeNode('COMPONENT');
+  comp.name = name;
+  if (key) comp.key = key;
+  return comp;
+}
+
 export interface MockFigma {
   mixed: symbol;
   createFrame(): FakeNode;
   createText(): FakeNode;
   createRectangle(): FakeNode;
+  createComponent(): FakeNode;
   loadFontAsync(font: FontName): Promise<void>;
   listAvailableFontsAsync(): Promise<Array<{ fontName: FontName }>>;
+  getNodeByIdAsync(id: string): Promise<FakeNode | null>;
+  importComponentByKeyAsync(key: string): Promise<FakeNode>;
   variables: {
     setBoundVariableForPaint: typeof setBoundVariableForPaint;
     getLocalVariablesAsync(): Promise<Array<{ id: string; name: string }>>;
@@ -120,8 +174,15 @@ export function installMockFigma(): MockFigma {
     createFrame: () => mk('FRAME'),
     createText: () => mk('TEXT'),
     createRectangle: () => mk('RECTANGLE'),
+    createComponent: () => mk('COMPONENT'),
     loadFontAsync: async () => { /* every font "exists" */ },
     listAvailableFontsAsync: async () => [],
+    getNodeByIdAsync: async (id: string) => components.find((c) => c.id === id) ?? null,
+    importComponentByKeyAsync: async (key: string) => {
+      const found = components.find((c) => c.key === key);
+      if (!found) throw new Error(`component key not found: ${key}`); // the library-miss edge
+      return found;
+    },
     variables: {
       setBoundVariableForPaint,
       getLocalVariablesAsync: async () => localVariables,

--- a/figma-agent/tests/scan-node-fixed-point.test.ts
+++ b/figma-agent/tests/scan-node-fixed-point.test.ts
@@ -16,17 +16,27 @@
 //     joins each bound variable id against the file's id→name map and re-emits
 //     tokenRefs, which the build path rebinds by name (fill/textColor/stroke/radius/
 //     gap/uniform padding).
+//     Since spec-005 P2, INSTANCE nodes are also a fixed point — as ref + overrides:
+//     the main-component link (componentKey/componentId), the variant + component
+//     PROPERTY values, and the node-level overrides the payload models (size, fills,
+//     radius, opacity) all come back. The inner composition is deliberately NOT
+//     captured — it belongs to the main, which the rebuild instantiates.
 //   DO NOT SURVIVE (documented gaps):
 //     - library / remote variable bindings: the id is not in the file's LOCAL
 //       variables, so no token name is recoverable → the binding is reported as a raw
 //       id in figmaScanBindings (visible, not silent) and a rebuild drops it.
 //     - per-side (non-uniform) padding bindings: tokenRefs models uniform padding
 //       only → no slot to carry them back.
-//     - instance / component references: FigmaExportNode has no instance type and
-//       createFigmaNode has no instance build-case → an INSTANCE degrades to a plain
-//       FRAME and its inner composition is not recursed. (spec-005 P2)
-import { describe, it, expect, beforeAll } from 'vitest';
-import { installMockFigma, setMockLocalVariables, FakeNode } from './helpers/mock-figma.ts';
+//     - an instance's INNER (per-child) ad-hoc overrides — e.g. a text edited inside
+//       the instance without a component property: ref+overrides has no slot for them.
+//       Reported in figmaScanInnerOverrides (visible), dropped by a rebuild. (P2 edge)
+//     - an instance whose main resolves to NOTHING (unpublished library component,
+//       main in another file): degrades to a plain frame + an import warning. (P2 edge)
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import {
+  installMockFigma, setMockLocalVariables, setMockComponents, makeMockComponent, FakeNode,
+} from './helpers/mock-figma.ts';
+import { getImportWarnings, resetImportWarnings } from '../plugin/src/main/executor-styles.ts';
 import type { FigmaExportNode } from '../shared/figma-payload-types.ts';
 import type { ScannedNode } from '../plugin/src/main/scan-node.ts';
 
@@ -248,28 +258,156 @@ describe('reversibility GAP that REMAINS — per-side (non-uniform) padding bind
   });
 });
 
-describe('reversibility GAP — instance / component references do not survive', () => {
-  it('degrades an INSTANCE to a FRAME and does not recurse its composition', async () => {
-    const inst = new FakeNode('INSTANCE');
-    inst.name = 'Button/Primary';
-    inst.resize(120, 40);
-    inst.layoutMode = 'HORIZONTAL';
-    inst.itemSpacing = 8;
-    inst.primaryAxisSizingMode = 'AUTO';
-    inst.mainComponent = { id: 'C:99' };
-    const label = new FakeNode('TEXT');
-    label.characters = 'Click';
-    inst.appendChild(label);
+// ── spec-005 P2: instances ────────────────────────────────────────────────
+// The main component every instance test instantiates. It carries the visuals an
+// instance MIRRORS (so a rebuild that resolves the main gets them for free) and a
+// State variant property.
+function mainButton(): FakeNode {
+  const comp = makeMockComponent('Button/Primary', 'KEY-BTN');
+  comp.resize(120, 40);
+  comp.layoutMode = 'HORIZONTAL';
+  comp.itemSpacing = 8;
+  comp.primaryAxisSizingMode = 'AUTO';
+  comp.counterAxisSizingMode = 'AUTO';
+  comp.fills = [{ type: 'SOLID', color: { r: 0.5, g: 0.2, b: 0.9 }, opacity: 1 }];
+  comp.cornerRadius = 8;
+  comp.componentPropertyDefinitions = { State: { type: 'VARIANT', defaultValue: 'Default' } };
+  comp.componentProperties = { State: { type: 'VARIANT', value: 'Default' } };
+  const label = new FakeNode('TEXT');
+  label.name = 'Label';
+  label.characters = 'Click';
+  comp.appendChild(label);
+  return comp;
+}
+
+describe('fixed point — INSTANCE survives as ref + overrides (spec-005 P2)', () => {
+  let main: FakeNode;
+  beforeEach(() => {
+    main = mainButton();
+    setMockComponents([main]);
+    resetImportWarnings();
+  });
+
+  const instSpec = (over: Partial<FigmaExportNode> = {}): FigmaExportNode => ({
+    type: 'INSTANCE', name: 'Button/Primary', componentKey: 'KEY-BTN',
+    componentProperties: { State: 'Hover' }, ...over,
+  });
+
+  it('rebuilds a real INSTANCE (not a frame) and keeps the main-component link', async () => {
+    const spec1 = await build(instSpec());
+    expect(spec1.type).toBe('INSTANCE');
+    expect(spec1.componentKey).toBe('KEY-BTN');
+    expect(spec1.componentId).toBe(main.id);
+    expect(spec1.componentName).toBe('Button/Primary');
+    // Inner composition is NOT captured — it is the main's, and createInstance rebuilds it.
+    expect(spec1.children).toBeUndefined();
+  });
+
+  it('keeps the variant / component property values', async () => {
+    const [spec1, spec2] = await roundTrips(instSpec());
+    expect(spec1.componentProperties).toEqual({ State: 'Hover' });
+    expect(spec2.componentProperties).toEqual({ State: 'Hover' });
+  });
+
+  it('IS a fixed point (spec1 === spec2)', async () => {
+    const [spec1, spec2] = await roundTrips(instSpec());
+    expect(spec2).toEqual(spec1);
+  });
+
+  it('mirrors the main visuals without re-writing them as overrides', async () => {
+    const spec1 = await build(instSpec());
+    // Read back off the instance: they came from the main via createInstance.
+    expect(spec1).toMatchObject({ width: 120, height: 40, layoutMode: 'HORIZONTAL', itemSpacing: 8, cornerRadius: 8 });
+    expect(spec1.fills?.[0]).toMatchObject({ type: 'SOLID', color: { r: 0.5, g: 0.2, b: 0.9, a: 1 } });
+  });
+
+  it('round-trips node-level overrides that DIFFER from the main (fill, size, radius)', async () => {
+    const overridden = instSpec({
+      width: 200, height: 48, cornerRadius: 24,
+      fills: [{ type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 1 } }],
+    });
+    const [spec1, spec2] = await roundTrips(overridden);
+    expect(spec1).toMatchObject({ type: 'INSTANCE', width: 200, height: 48, cornerRadius: 24 });
+    expect(spec1.fills?.[0]?.color).toMatchObject({ r: 1, g: 0, b: 0 });
+    expect(spec2).toEqual(spec1);
+  });
+
+  it('resolves the main by componentId when no key is published', async () => {
+    const local = mainButton();
+    delete local.key; // an unpublished local component has no key
+    setMockComponents([local]);
+    const spec1 = await build({ type: 'INSTANCE', name: 'Local', componentId: local.id });
+    expect(spec1.type).toBe('INSTANCE');
+    expect(spec1.componentId).toBe(local.id);
+    expect(spec1.componentKey).toBeUndefined();
+  });
+
+  it('survives as a CHILD of an auto-layout frame (the real registry shape)', async () => {
+    const card: FigmaExportNode = {
+      type: 'FRAME', name: 'Card', width: 320, height: 120, layoutMode: 'VERTICAL',
+      itemSpacing: 12, primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'FIXED',
+      children: [
+        { type: 'TEXT', name: 'Title', characters: 'Hi', fontSize: 16, textAutoResize: 'WIDTH_AND_HEIGHT' },
+        instSpec(),
+      ],
+    };
+    const [spec1, spec2] = await roundTrips(card);
+    expect(spec1.children?.[1]).toMatchObject({
+      type: 'INSTANCE', componentKey: 'KEY-BTN', componentProperties: { State: 'Hover' },
+    });
+    expect(spec2).toEqual(spec1);
+  });
+});
+
+describe('instance EDGE — a property the main does not expose', () => {
+  beforeEach(() => { setMockComponents([mainButton()]); resetImportWarnings(); });
+
+  it('still builds the instance, on the main defaults, and warns (no silent loss)', async () => {
+    const spec1 = await build({
+      type: 'INSTANCE', name: 'Button/Primary', componentKey: 'KEY-BTN',
+      componentProperties: { Size: 'Large' }, // renamed/removed on the main
+    });
+    expect(spec1.type).toBe('INSTANCE');
+    expect(spec1.componentProperties).toEqual({ State: 'Default' }); // the main's default
+    expect(getImportWarnings().join('\n')).toContain('setProperties failed');
+  });
+});
+
+describe('instance GAP that REMAINS — main component not resolvable', () => {
+  beforeEach(() => { setMockComponents([]); resetImportWarnings(); });
+
+  it('degrades to a plain frame + warns; the component link is lost (visible, not silent)', async () => {
+    const spec1 = await build({
+      type: 'INSTANCE', name: 'Ghost', width: 100, height: 40, componentKey: 'KEY-GONE',
+      fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0, a: 1 } }],
+    });
+    expect(spec1.type).toBe('FRAME');            // degraded — the pre-P2 behaviour
+    expect(spec1.componentKey).toBeUndefined();  // the link did not survive
+    expect(spec1).toMatchObject({ name: 'Ghost', width: 100, height: 40 }); // visuals still land
+    expect(getImportWarnings().join('\n')).toContain('component link lost');
+  });
+});
+
+describe('instance GAP that REMAINS — INNER (per-child) ad-hoc overrides', () => {
+  it('reports them in figmaScanInnerOverrides; a rebuild drops them', async () => {
+    const main = mainButton();
+    setMockComponents([main]);
+    const inst = main.createInstance();
+    // Figma reports one entry per overridden node; the entry for the instance ITSELF
+    // is node-level (modelled + re-applied) — only the CHILD entries are the gap.
+    inst.overrides = [
+      { id: inst.id, overriddenFields: ['fills'] },
+      { id: `${inst.id};child`, overriddenFields: ['characters', 'fontSize'] },
+    ];
 
     const spec1 = nodeToSpec(inst as unknown as SceneNode);
-    expect(spec1.type).toBe('FRAME');                 // no INSTANCE type in the schema
-    expect(spec1.figmaScanSourceType).toBe('INSTANCE'); // detected, but only as metadata
-    expect(spec1.figmaScanMainComponent).toBe('C:99');
-    expect(spec1.children).toBeUndefined();            // composition NOT recursed (audit rule)
+    expect(spec1.figmaScanInnerOverrides).toEqual(['characters', 'fontSize']); // deduped + sorted
+    expect(spec1.figmaScanBindings).toBeUndefined();
 
-    // Rebuild → a plain frame; the instance identity is gone.
+    // Rebuild: the instance comes back, its inner edits do not.
     const spec2 = await build(spec1);
-    expect(spec2.figmaScanSourceType).toBeUndefined();
-    expect(spec2.type).toBe('FRAME');
+    expect(spec2.type).toBe('INSTANCE');
+    expect(spec2.figmaScanInnerOverrides).toBeUndefined();
+    expect(spec2).not.toEqual(spec1); // NOT a fixed point — the loss is reported, not faked
   });
 });


### PR DESCRIPTION
Closes gap 2 of spec 005: an INSTANCE no longer degrades to a plain FRAME on rebuild.

## Model — instance = ref + overrides (executor decision)
An instance is captured as a **reference to its main component + what it overrides**, never as a copy of its inner tree. The composition belongs to the main; recursing it and rebuilding would produce a detached frame — exactly the degradation P2 exists to remove. The rebuild does `main.createInstance()` and re-applies only the deltas.

## What survives (asserted, mutation-verified)
- main-component link: `componentKey` (portable/library) + `componentId` (same-file fallback)
- variant / component **property values** (`setProperties`)
- node-level overrides the payload models: size, fills, corner radius, opacity, effects
- an instance nested as a child of an auto-layout frame (the real registry shape)
- `spec1 === spec2` fixed point for all of the above; P1 token bindings still green

## What does NOT survive (explicit degrade, no silent loss)
| Edge | Behaviour |
|---|---|
| main unresolvable (unpublished/other file) | plain frame + `component link lost` import warning |
| property the main no longer exposes | instance builds on main defaults + `setProperties failed` warning |
| inner per-child ad-hoc overrides (e.g. text edited inside the instance) | reported in `figmaScanInnerOverrides`, dropped by rebuild — asserted as NOT a fixed point |
| library/remote variable bindings, per-side padding bindings | unchanged P1 edges |

## Also
- **Art IX**: `scan-node.ts` 304 → 136 lines, split into `scan-node-{types,utils,paint,layout,text,instance}.ts`. Pure refactor; verified the CLI `scan-node` EXEC_JS bundle is still self-contained after the split.
- shared `exportFillToPaint` extracted — one fill→Paint conversion behind both the frame build and instance overrides (rather than a second copy in the new module).
- schema fix caught by typecheck: component property values are `string | boolean` (the Plugin API rejects `number`).

## Verify
4 gates BARE green (typecheck / lint / build / test 1843 pass) · figma-agent 232/232 · fixed-point test 23/23. Mutation-checked: breaking main-resolution fails 8 tests, dropping property capture fails 3.

Live round-trip on a real Figma component remains P5 — the mock proves the mechanism, not the contract.