### PR TITLE
feat: figma node sidecar storage per component (spec 005 P3)

### DIFF
--- a/schemas/component-registry.schema.json
+++ b/schemas/component-registry.schema.json
@@ -67,6 +67,11 @@
         "deprecated": {
           "type": "boolean",
           "description": "Soft-deprecation flag (spec 004). Absent or false = active; true = deprecated (the audit reads this). Distinct from lifecycle 'status'."
+        },
+        "figmaNode": {
+          "type": "string",
+          "pattern": "^(?!/)(?!.*(^|/)\\.\\.(/|$))[^\\\\:]+\\.figma\\.json$",
+          "description": "Pointer to this component's Figma node sidecar (spec 005), relative to the design dir — e.g. 'components/button-primary.figma.json'. Holds the buildable FigmaExportNode spec; the tree is never inlined here. Absent = no mirror captured yet. Must stay inside the design dir: no absolute path, no '..' traversal. Orthogonal to 'markup', which stays one-way design→code."
         }
       },
       "required": ["name", "category", "markup", "tokensUsed"],

--- a/src/core/figma-node-reader.ts
+++ b/src/core/figma-node-reader.ts
@@ -1,0 +1,197 @@
+/**
+ * Figma-node sidecar storage (spec 005 P3) — one `<design>/components/<slug>.figma.json`
+ * file per component, holding the buildable `FigmaExportNode` spec captured from Figma.
+ * The registry record keeps a *pointer* (`ComponentRecord.figmaNode`), never the tree
+ * inline, so the shared registry JSON stays small and a component's spec diffs on its own.
+ *
+ * Direction of truth (spec 005): the Figma-native node spec is the reversible half;
+ * `markup` (HTML/JSX) stays one-way design→code and is NOT touched by this module.
+ *
+ * Storage only — no reconcile wiring (that is P4), no live Figma call. This is the IO
+ * boundary for sidecars; `figmaNodeRelPath` / `validateFigmaNodeSidecar` are pure.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { toSafeFilename } from "./html-export.js";
+import { FIGMA_NODE_SUFFIX, RegistryError, validateFigmaNodePointer } from "./registry-store.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * One captured Figma node spec — the sidecar payload.
+ *
+ * The full field list is `FigmaExportNode` in `figma-agent/shared/figma-payload-types.ts`
+ * and is owned there (`nodeToSpec` produces it, `createFigmaNode` consumes it). As
+ * `figma-reconcile.ts` does for `ChangeFrame`, the kernel does NOT import that type:
+ * figma-agent is a separate package/bundle and the FILE is the contract, not the type.
+ * Storage only needs the discriminant, so the payload stays open and passes through
+ * rather than being re-declared here, where a ~100-field mirror would silently drift.
+ */
+export type FigmaNodeSpec = {
+  type: string;
+  name: string;
+  [key: string]: unknown;
+};
+
+/**
+ * On-disk sidecar envelope. `version` follows the registry file convention (every
+ * ease-design data file carries one) so the payload migrates independently of the
+ * registry schema; `name` makes an orphaned sidecar self-identifying.
+ */
+export interface FigmaNodeSidecar {
+  version: string;
+  name: string;
+  node: FigmaNodeSpec;
+}
+
+/** Result of a sidecar write. */
+export interface FigmaNodeWriteResult {
+  /** Pointer to store on the record, relative to the design dir. */
+  relPath: string;
+  path: string;
+  /** False = content guard found identical bytes and skipped the rewrite. */
+  written: boolean;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const SIDECAR_VERSION = "0.1.0";
+/** Sidecar sub-directory under the project design dir. */
+const SIDECAR_DIR = "components";
+/** Node types the sidecar accepts — must stay in sync with FigmaExportNode["type"]. */
+const VALID_NODE_TYPES = new Set<string>(["FRAME", "TEXT", "RECTANGLE", "IMAGE", "GROUP", "INSTANCE"]);
+
+// ─── Pure: pointer + payload validation ───────────────────────────────────────
+
+/**
+ * Derive the sidecar pointer for a component name: `components/<slug>.figma.json`.
+ *
+ * The slug reuses `toSafeFilename` (the existing kebab-case filename util), so
+ * `Button/Primary` → `components/button-primary.figma.json`. Registry names are
+ * `Category/Variant` in letters only, so slugs collide only for names differing by case
+ * alone — which the registry already treats as two distinct records.
+ */
+export function figmaNodeRelPath(name: string): string {
+  return `${SIDECAR_DIR}/${toSafeFilename(name)}${FIGMA_NODE_SUFFIX}`;
+}
+
+/**
+ * Validate an unknown value as a sidecar envelope.
+ *
+ * Shallow by design (see {@link FigmaNodeSpec}): assert the envelope + the node's
+ * discriminant, pass the tree through.
+ *
+ * @throws RegistryError("BAD_SIDECAR") on any violation.
+ */
+export function validateFigmaNodeSidecar(value: unknown, source: string): FigmaNodeSidecar {
+  const bad = (msg: string): never => {
+    throw new RegistryError("BAD_SIDECAR", `${msg}: '${source}'`);
+  };
+  const isObject = (x: unknown): x is Record<string, unknown> =>
+    x !== null && typeof x === "object" && !Array.isArray(x);
+
+  if (!isObject(value)) return bad("figma node sidecar root must be an object");
+  if (typeof value["version"] !== "string" || value["version"].length === 0) {
+    return bad("sidecar missing required 'version' string");
+  }
+  if (typeof value["name"] !== "string" || value["name"].length === 0) {
+    return bad("sidecar missing required 'name' string");
+  }
+
+  const node = value["node"];
+  if (!isObject(node)) return bad("sidecar 'node' must be an object");
+  if (typeof node["type"] !== "string" || !VALID_NODE_TYPES.has(node["type"])) {
+    return bad(
+      `sidecar node.type '${String(node["type"])}' must be one of: ${[...VALID_NODE_TYPES].join(", ")}`,
+    );
+  }
+  if (typeof node["name"] !== "string") return bad("sidecar node.name is required and must be a string");
+
+  return { version: value["version"], name: value["name"], node: node as FigmaNodeSpec };
+}
+
+// ─── I/O boundary ─────────────────────────────────────────────────────────────
+
+/** Serialize a sidecar deterministically (stable key order via the literal). */
+function serialize(name: string, node: FigmaNodeSpec): string {
+  const sidecar: FigmaNodeSidecar = { version: SIDECAR_VERSION, name, node };
+  return JSON.stringify(sidecar, null, 2) + "\n";
+}
+
+/**
+ * Write a component's node spec to its sidecar under `<designDir>/components/`.
+ *
+ * Content guard: the serialized bytes are compared against what is already on disk and
+ * the write is skipped when identical, so a component whose structure did not change
+ * produces no sidecar churn (spec 005 plan, sidecar-sprawl mitigation). Byte-equality is
+ * the exact form of that guard — no hash collisions to reason about.
+ *
+ * @throws RegistryError("WRITE_ERROR") on failure.
+ */
+export function writeFigmaNode(
+  designDir: string,
+  name: string,
+  node: FigmaNodeSpec,
+): FigmaNodeWriteResult {
+  const relPath = figmaNodeRelPath(name);
+  const path = resolve(join(designDir, relPath));
+  const content = serialize(name, node);
+
+  let existing: string | undefined;
+  try {
+    existing = readFileSync(path, "utf8");
+  } catch {
+    existing = undefined; // absent or unreadable → fall through to write
+  }
+  if (existing === content) {
+    return { relPath, path, written: false };
+  }
+
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, "utf8");
+  } catch (e) {
+    throw new RegistryError(
+      "WRITE_ERROR",
+      `cannot write figma node sidecar '${path}': ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  return { relPath, path, written: true };
+}
+
+/**
+ * Read + validate a component's node spec from its sidecar pointer.
+ *
+ * @param designDir Project design dir the pointer is relative to.
+ * @param relPath   `ComponentRecord.figmaNode` value.
+ * @throws RegistryError: BAD_ARG (bad pointer), FILE_NOT_FOUND, READ_ERROR, BAD_SIDECAR.
+ */
+export function readFigmaNode(designDir: string, relPath: string): FigmaNodeSpec {
+  const safeRel = validateFigmaNodePointer(relPath);
+  const path = resolve(join(designDir, safeRel));
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (e) {
+    const isNotFound =
+      e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT";
+    if (isNotFound) {
+      throw new RegistryError("FILE_NOT_FOUND", `figma node sidecar not found: '${path}'`);
+    }
+    throw new RegistryError(
+      "READ_ERROR",
+      `cannot read figma node sidecar '${path}': ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new RegistryError("BAD_SIDECAR", `figma node sidecar is not valid JSON: '${path}'`);
+  }
+
+  return validateFigmaNodeSidecar(parsed, path).node;
+}

--- a/src/core/registry-store.ts
+++ b/src/core/registry-store.ts
@@ -43,6 +43,14 @@ export interface ComponentRecord {
   /** Soft-deprecation flag (spec 004). Absent = active; `true` = deprecated (audit reads this).
    * A distinct field, NOT a `status` value — a component can be `stable` and `deprecated`. */
   deprecated?: boolean;
+  /**
+   * Pointer to this component's Figma node sidecar (spec 005 P3), relative to the design
+   * dir — e.g. `"components/button-primary.figma.json"`. A POINTER, never the node tree
+   * inline, so the shared registry file stays small. Absent = no mirror captured yet
+   * (a pre-005 record, or a component never scanned); readers must treat it as optional.
+   * Orthogonal to `markup`, which stays one-way design→code. See `figma-node-reader.ts`.
+   */
+  figmaNode?: string;
 }
 
 export interface Registry {
@@ -72,14 +80,54 @@ const REGISTRY_ROOT_KEYS = new Set(["version", "components"]);
 /** Keys permitted on a component record (mirrors schema additionalProperties:false). */
 const COMPONENT_ALLOWED_KEYS = new Set([
   "name", "category", "markup", "tokensUsed", "variants", "states", "description", "status",
-  "scope", "deprecated",
+  "scope", "deprecated", "figmaNode",
 ]);
 const VALID_STATUSES = new Set<string>(["draft", "beta", "stable"]);
 const VALID_SCOPES = new Set<string>(["local", "global"]);
 /** Default reuse scope for records that predate the `scope` field (spec 004 migration). */
 const DEFAULT_SCOPE: ComponentScope = "local";
+/** Required suffix of a `figmaNode` sidecar pointer (spec 005 P3). */
+export const FIGMA_NODE_SUFFIX = ".figma.json";
 
 // ─── Validation ───────────────────────────────────────────────────────────────
+
+/**
+ * Validate a `ComponentRecord.figmaNode` pointer: a design-dir-relative path ending in
+ * `.figma.json`.
+ *
+ * Absolute paths and `..` traversal are rejected here, at the shared layer, rather than
+ * only where a path gets resolved: a registry file is committed, shared input, so every
+ * consumer that joins this pointer to a design dir needs the same guarantee — it must not
+ * escape the design dir. `figma-node-reader.readFigmaNode` re-runs this before resolving.
+ *
+ * @returns the pointer unchanged when valid.
+ * @throws RegistryError("BAD_ARG") on a malformed pointer.
+ */
+export function validateFigmaNodePointer(relPath: unknown): string {
+  if (typeof relPath !== "string" || relPath.length === 0) {
+    throw new RegistryError("BAD_ARG", "component.figmaNode must be a non-empty string");
+  }
+  // Absolute POSIX ("/x"), Windows drive ("C:\x") and UNC ("\\srv") forms all escape.
+  if (relPath.startsWith("/") || relPath.startsWith("\\") || /^[A-Za-z]:/.test(relPath)) {
+    throw new RegistryError(
+      "BAD_ARG",
+      `component.figmaNode must be relative to the design dir, got absolute: '${relPath}'`,
+    );
+  }
+  if (relPath.split(/[/\\]/).includes("..")) {
+    throw new RegistryError(
+      "BAD_ARG",
+      `component.figmaNode must not traverse outside the design dir with '..': '${relPath}'`,
+    );
+  }
+  if (!relPath.endsWith(FIGMA_NODE_SUFFIX)) {
+    throw new RegistryError(
+      "BAD_ARG",
+      `component.figmaNode must point at a '${FIGMA_NODE_SUFFIX}' sidecar: '${relPath}'`,
+    );
+  }
+  return relPath;
+}
 
 /**
  * Validate an unknown value as a ComponentRecord against the schema constraints.
@@ -172,6 +220,11 @@ export function validateComponentRecord(rec: unknown): ComponentRecord {
     throw new RegistryError("BAD_ARG", "component.deprecated must be a boolean");
   }
 
+  // Optional: figmaNode (sidecar pointer, spec 005) — absent = no mirror captured yet.
+  if (r["figmaNode"] !== undefined) {
+    validateFigmaNodePointer(r["figmaNode"]);
+  }
+
   // additionalProperties: false — reject keys outside the schema
   for (const key of Object.keys(r)) {
     if (!COMPONENT_ALLOWED_KEYS.has(key)) {
@@ -194,6 +247,8 @@ export function validateComponentRecord(rec: unknown): ComponentRecord {
     // Migration: missing scope defaults to "local" so the returned record always carries one.
     scope: (r["scope"] as ComponentScope | undefined) ?? DEFAULT_SCOPE,
     ...(r["deprecated"] !== undefined && { deprecated: r["deprecated"] as boolean }),
+    // No migration default: a record without a sidecar simply has no pointer (P3 no-op).
+    ...(r["figmaNode"] !== undefined && { figmaNode: r["figmaNode"] as string }),
   };
 }
 

--- a/tests/figma-node-reader.test.ts
+++ b/tests/figma-node-reader.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  figmaNodeRelPath,
+  readFigmaNode,
+  validateFigmaNodeSidecar,
+  writeFigmaNode,
+  SIDECAR_VERSION,
+  type FigmaNodeSpec,
+} from "../src/core/figma-node-reader.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const dirs: string[] = [];
+function tmpDesignDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "figma-node-reader-test-"));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/** A small but non-trivial node: nested children, bindings and an INSTANCE (P1+P2 output). */
+function sampleNode(): FigmaNodeSpec {
+  return {
+    type: "FRAME",
+    name: "Button/Primary",
+    layoutMode: "HORIZONTAL",
+    itemSpacing: 8,
+    paddingTop: 12,
+    fills: [{ type: "SOLID", color: { r: 0.1, g: 0.2, b: 0.9, a: 1 } }],
+    boundVariables: { fills: [{ type: "VARIABLE_ALIAS", name: "color.primary" }] },
+    children: [
+      { type: "TEXT", name: "Label", characters: "Click", fontSize: 14 },
+      {
+        type: "INSTANCE",
+        name: "Icon/Chevron",
+        componentRef: { key: "abc123" },
+        properties: { size: "small" },
+      },
+    ],
+  };
+}
+
+// ─── figmaNodeRelPath (pure) ──────────────────────────────────────────────────
+
+describe("figmaNodeRelPath", () => {
+  it("derives components/<slug>.figma.json from a Category/Variant name", () => {
+    expect(figmaNodeRelPath("Button/Primary")).toBe("components/button-primary.figma.json");
+    expect(figmaNodeRelPath("Card/Pricing")).toBe("components/card-pricing.figma.json");
+  });
+
+  it("is deterministic — same name always yields the same pointer", () => {
+    expect(figmaNodeRelPath("Button/Primary")).toBe(figmaNodeRelPath("Button/Primary"));
+  });
+
+  it("produces a pointer the registry pointer validator accepts", async () => {
+    const { validateFigmaNodePointer } = await import("../src/core/registry-store.js");
+    expect(validateFigmaNodePointer(figmaNodeRelPath("Button/Primary"))).toBe(
+      "components/button-primary.figma.json",
+    );
+  });
+});
+
+// ─── Round-trip ───────────────────────────────────────────────────────────────
+
+describe("writeFigmaNode → readFigmaNode round-trip", () => {
+  it("reads back a written node identical to the input (deep, incl. bindings + instance)", () => {
+    const dir = tmpDesignDir();
+    const node = sampleNode();
+
+    const res = writeFigmaNode(dir, "Button/Primary", node);
+    expect(res.written).toBe(true);
+    expect(res.relPath).toBe("components/button-primary.figma.json");
+
+    const back = readFigmaNode(dir, res.relPath);
+    expect(back).toEqual(node);
+  });
+
+  it("creates the components/ sub-directory when absent", () => {
+    const dir = tmpDesignDir();
+    const res = writeFigmaNode(dir, "Card/Pricing", sampleNode());
+    expect(statSync(join(dir, "components")).isDirectory()).toBe(true);
+    expect(statSync(res.path).isFile()).toBe(true);
+  });
+
+  it("writes the envelope: version + name + node, JSON, newline-terminated", () => {
+    const dir = tmpDesignDir();
+    const res = writeFigmaNode(dir, "Button/Primary", sampleNode());
+    const raw = readFileSync(res.path, "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+    const parsed = JSON.parse(raw);
+    expect(parsed.version).toBe(SIDECAR_VERSION);
+    expect(parsed.name).toBe("Button/Primary");
+    expect(parsed.node.type).toBe("FRAME");
+  });
+
+  it("stores the node under a pointer that resolves from the design dir", () => {
+    const dir = tmpDesignDir();
+    const { relPath } = writeFigmaNode(dir, "Button/Primary", sampleNode());
+    // The pointer is exactly what a ComponentRecord.figmaNode holds — reading it back
+    // with only (designDir, pointer) is the whole P4 contract.
+    expect(() => readFigmaNode(dir, relPath)).not.toThrow();
+  });
+});
+
+// ─── Content guard ────────────────────────────────────────────────────────────
+
+describe("writeFigmaNode — content guard", () => {
+  it("does not rewrite when content is unchanged", () => {
+    const dir = tmpDesignDir();
+    const first = writeFigmaNode(dir, "Button/Primary", sampleNode());
+    expect(first.written).toBe(true);
+    const mtimeBefore = statSync(first.path).mtimeMs;
+
+    // A structurally identical re-capture must produce zero churn.
+    const second = writeFigmaNode(dir, "Button/Primary", sampleNode());
+    expect(second.written).toBe(false);
+    expect(second.relPath).toBe(first.relPath);
+    expect(statSync(first.path).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it("rewrites when the node content changed", () => {
+    const dir = tmpDesignDir();
+    writeFigmaNode(dir, "Button/Primary", sampleNode());
+
+    const changed = sampleNode();
+    changed["itemSpacing"] = 16;
+    const res = writeFigmaNode(dir, "Button/Primary", changed);
+    expect(res.written).toBe(true);
+    expect(readFigmaNode(dir, res.relPath)["itemSpacing"]).toBe(16);
+  });
+});
+
+// ─── Read failures ────────────────────────────────────────────────────────────
+
+describe("readFigmaNode — failures", () => {
+  it("throws FILE_NOT_FOUND when the sidecar is missing", () => {
+    const dir = tmpDesignDir();
+    expect(() => readFigmaNode(dir, "components/absent.figma.json")).toThrow(
+      expect.objectContaining({ code: "FILE_NOT_FOUND" }),
+    );
+  });
+
+  it("throws BAD_ARG for a pointer escaping the design dir", () => {
+    const dir = tmpDesignDir();
+    expect(() => readFigmaNode(dir, "../../etc/passwd.figma.json")).toThrow(
+      expect.objectContaining({ code: "BAD_ARG" }),
+    );
+  });
+
+  it("throws BAD_SIDECAR for malformed JSON", () => {
+    const dir = tmpDesignDir();
+    mkdirSync(join(dir, "components"), { recursive: true });
+    writeFileSync(join(dir, "components", "broken.figma.json"), "{not json", "utf8");
+    expect(() => readFigmaNode(dir, "components/broken.figma.json")).toThrow(
+      expect.objectContaining({ code: "BAD_SIDECAR" }),
+    );
+  });
+});
+
+// ─── Envelope validation (pure) ───────────────────────────────────────────────
+
+describe("validateFigmaNodeSidecar", () => {
+  const ok = { version: SIDECAR_VERSION, name: "Button/Primary", node: { type: "FRAME", name: "Root" } };
+
+  it("accepts a well-formed envelope and returns the node", () => {
+    expect(validateFigmaNodeSidecar(ok, "t").node).toEqual({ type: "FRAME", name: "Root" });
+  });
+
+  it("passes an unknown node field through untouched (payload is owned by figma-agent)", () => {
+    const withFuture = { ...ok, node: { type: "FRAME", name: "Root", someFutureField: 7 } };
+    expect(validateFigmaNodeSidecar(withFuture, "t").node["someFutureField"]).toBe(7);
+  });
+
+  it("rejects a non-object root, a missing version/name, and a missing node", () => {
+    for (const bad of [null, [], "x", {}, { version: "0.1.0" }, { version: "0.1.0", name: "A" }]) {
+      expect(() => validateFigmaNodeSidecar(bad, "t")).toThrow(
+        expect.objectContaining({ code: "BAD_SIDECAR" }),
+      );
+    }
+  });
+
+  it("rejects an unknown node.type", () => {
+    expect(() => validateFigmaNodeSidecar({ ...ok, node: { type: "WIDGET", name: "R" } }, "t")).toThrow(
+      expect.objectContaining({
+        code: "BAD_SIDECAR",
+        message: expect.stringMatching(/node\.type 'WIDGET' must be one of/),
+      }),
+    );
+  });
+
+  it("accepts every FigmaExportNode type the build path can construct", () => {
+    for (const type of ["FRAME", "TEXT", "RECTANGLE", "IMAGE", "GROUP", "INSTANCE"]) {
+      expect(validateFigmaNodeSidecar({ ...ok, node: { type, name: "R" } }, "t").node.type).toBe(type);
+    }
+  });
+});

--- a/tests/registry-store.test.ts
+++ b/tests/registry-store.test.ts
@@ -195,6 +195,69 @@ describe("validateComponentRecord", () => {
       validateComponentRecord({ ...validRecord({ scope: "global", deprecated: true }), bogus: 1 }),
     ).toThrow(expect.objectContaining({ code: "BAD_REGISTRY" }));
   });
+
+  // ─── figmaNode sidecar pointer (spec 005 P3) ─────────────────────────────
+
+  it("accepts a figmaNode pointer and preserves it on the returned record", () => {
+    const rec = validateComponentRecord(
+      validRecord({ figmaNode: "components/button-primary.figma.json" }),
+    );
+    expect(rec.figmaNode).toBe("components/button-primary.figma.json");
+  });
+
+  it("leaves figmaNode absent for a record with no sidecar (no migration default)", () => {
+    // A pre-005 record must load unchanged — no mirror captured is a valid state.
+    const rec = validateComponentRecord(validRecord());
+    expect(rec.figmaNode).toBeUndefined();
+    expect("figmaNode" in rec).toBe(false);
+  });
+
+  it("rejects a figmaNode pointer that escapes the design dir", () => {
+    for (const bad of [
+      "/etc/passwd.figma.json",
+      "../../secrets.figma.json",
+      "components/../../x.figma.json",
+      "C:\\windows\\x.figma.json",
+    ]) {
+      expect(() => validateComponentRecord(validRecord({ figmaNode: bad }))).toThrow(
+        expect.objectContaining({ code: "BAD_ARG" }),
+      );
+    }
+  });
+
+  it("rejects a figmaNode pointer that is not a .figma.json sidecar", () => {
+    expect(() => validateComponentRecord(validRecord({ figmaNode: "components/button.json" }))).toThrow(
+      expect.objectContaining({
+        code: "BAD_ARG",
+        message: expect.stringMatching(/must point at a '\.figma\.json' sidecar/),
+      }),
+    );
+  });
+
+  it("throws BAD_ARG when figmaNode is not a non-empty string", () => {
+    for (const bad of ["", 42 as never, null as never]) {
+      expect(() => validateComponentRecord(validRecord({ figmaNode: bad }))).toThrow(
+        expect.objectContaining({ code: "BAD_ARG" }),
+      );
+    }
+  });
+
+  it("keeps markup untouched alongside a figmaNode pointer (the two halves are orthogonal)", () => {
+    const rec = validateComponentRecord(
+      validRecord({ markup: "<button>Click</button>", figmaNode: "components/button-primary.figma.json" }),
+    );
+    expect(rec.markup).toBe("<button>Click</button>");
+    expect(rec.figmaNode).toBe("components/button-primary.figma.json");
+  });
+
+  it("still rejects an unknown key now that figmaNode is allowed", () => {
+    expect(() =>
+      validateComponentRecord({
+        ...validRecord({ figmaNode: "components/button-primary.figma.json" }),
+        bogus: 1,
+      }),
+    ).toThrow(expect.objectContaining({ code: "BAD_REGISTRY" }));
+  });
 });
 
 // ─── createEmptyRegistry ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Spec 005 P3 — **storage layer only**. A component's captured `FigmaExportNode` spec now lives in its own sidecar, `design/components/<slug>.figma.json`; the registry record holds a *pointer*, not the tree.

- **`src/core/figma-node-reader.ts`** (new, 197 lines) — `writeFigmaNode` / `readFigmaNode` / `figmaNodeRelPath` + envelope validation.
- **`ComponentRecord.figmaNode?`** — optional relative pointer, e.g. `components/button-primary.figma.json`. Allowed-keys + JSON schema updated in step.
- **`markup` untouched** — it stays one-way design→code; the two halves are orthogonal.

## Executor decisions

- **Kernel does not import `FigmaExportNode`.** `figma-reconcile.ts:10-13` documents the binding convention: figma-agent is a separate package/bundle, so *the file is the contract, not the type*. Storage only needs the discriminant, so the payload is a local open type (`type` + `name` + passthrough) — a ~100-field mirror in the kernel would silently drift.
- **Content guard = byte-equality**, not a hash: exact, no collisions to reason about, same no-churn outcome the plan asks for.
- **Pointer validation lives in `registry-store`**, the shared layer both consumers already import (avoids an import cycle, and gives every consumer the same no-escape guarantee rather than patching it where it surfaces).
- **Sidecar envelope** `{ version, name, node }` rather than a bare node — follows the convention that every ease-design data file carries a version, and makes an orphaned sidecar self-identifying.

## Migration / no-op

A record with no sidecar has no pointer and loads unchanged — no default is invented (unlike spec 004's `scope`, absence here is a real state: no mirror captured yet).

## Verify

4 gates BARE green + `ui knowledge check` 0 findings. Suite **1867 passed** / 4 skipped (125 files); 27 new tests cover round-trip (incl. bindings + INSTANCE), content guard, migration, traversal rejection, and unknown-key rejection.

Not wired into reconcile/apply — that is P4.