### PR TITLE
feat: mirror-verify — the one-command round-trip gate (spec 005 P5)

### DIFF
--- a/figma-agent/cli/src/commands/mirror-verify.ts
+++ b/figma-agent/cli/src/commands/mirror-verify.ts
@@ -1,0 +1,149 @@
+// `figma-agent mirror-verify <nodeId>` — the ONE-COMMAND gate of the spec-005
+// mirror (P5). It closes the loop the two halves only imply separately:
+//
+//   scan-node  →  specA  →  IMPORT_PAYLOAD (rebuild)  →  scan-node  →  specB
+//                              structuralDiff(specA, specB)
+//
+// `equal: true` means this node's representation is REVERSIBLE on the real canvas
+// — the claim the fixed-point test only makes against a mock `figma`. `equal:
+// false` names the fields that were lost, by path; the mirror never claims a
+// round-trip it cannot show (Art II: a standard needs an emitter AND a linter).
+//
+// The rebuild is scratch: it is removed again unless `--keep` is passed, so the
+// gate never litters the owner's canvas.
+//
+// KNOWN, DELIBERATE LIMITATION — variable bindings (spec-005 P1):
+// the payload carries EMPTY tokens, and the import path binds tokenRefs ONLY
+// through the map `createVariablesFromTokens(payload.tokens)` returns (see
+// plugin/src/main/main.ts importPayload → executor-variables.applyTokenRefs). It
+// does NOT look up a same-named variable that already exists in the file. So on a
+// token-bound node, the rebuild keeps the literal values, drops the bindings, and
+// this command HONESTLY reports `tokenRefs.*` / `figmaScanBindings.*` diffs plus
+// the import's own "no variable named X" warnings (surfaced as `warnings`).
+// Non-empty tokens are NOT the fix: `createVariablesFromTokens` resolves by VALUE
+// inside its own collection, so it would mint duplicate variables in the owner's
+// file — a verification gate must not mutate what it verifies. Closing this needs
+// a resolve-existing-by-name step in the import path, which is a spec-005 P5
+// decision, not a thing this command may invent.
+import { COMMAND_TIMEOUTS } from '../../../shared/protocol.ts';
+import type { CommandArgs } from '../figma-agent.ts';
+import { CliError } from '../transport/protocol-helpers.ts';
+import { runCommand } from '../transport/broker-client.ts';
+import { structuralDiff, type StructuralDiffEntry } from '../util/structural-diff.ts';
+import {
+  resolveScanTimeout, scanNodeSpec, type Runner, type ScannedSpec,
+} from './scan-node.ts';
+
+/** No tokens: see the header note — a gate must not mint variables in the file. */
+const EMPTY_TOKENS = { colors: [], typography: [], spacing: [], radii: [], shadows: [] };
+
+export interface MirrorVerifyResult {
+  nodeId: string;
+  rebuiltId: string;
+  equal: boolean;
+  diffCount: number;
+  diffs: StructuralDiffEntry[];
+  keptRebuild: boolean;
+  /** The rebuild's own import warnings (bindings skipped, main lost, …). */
+  warnings: string[];
+  /** Spec fields dropped before the diff — see normalizeForDiff. */
+  normalized: string[];
+}
+
+/**
+ * Fields dropped before comparing. The walker emits NO node id at all (see
+ * plugin/src/main/scan-node.ts — the spec is identity-free by construction), so
+ * nothing needs stripping for ids; `componentId` IS kept, because it names the
+ * MAIN component, which the rebuild resolves to the same node.
+ *
+ * Only the ROOT's absolute `x`/`y` go: importPayload places the rebuilt root at
+ * the viewport centre (main.ts step 4), so the coordinates are a property of WHEN
+ * it ran, not of the node. Nested `x`/`y` (absolutely-positioned children) are
+ * parent-relative and therefore structural — they stay in the diff.
+ */
+export const NORMALIZED_FIELDS = ['x (root)', 'y (root)'];
+
+export function normalizeForDiff(spec: ScannedSpec): ScannedSpec {
+  const { x: _x, y: _y, ...rest } = spec;
+  return rest;
+}
+
+interface ImportReply { id?: string; name?: string; warnings?: string[] }
+
+export interface MirrorVerifyOpts {
+  parentId?: string;
+  keep: boolean;
+  timeoutMs: number;
+}
+
+export async function execute(
+  nodeId: string,
+  opts: MirrorVerifyOpts,
+  run: Runner = runCommand,
+): Promise<MirrorVerifyResult> {
+  // 1. Scan the original — the same walker `scan-node` uses, not a copy.
+  const specA = await scanNodeSpec(nodeId, opts.timeoutMs, run);
+
+  // 2. Rebuild it from that spec alone. IMPORT_PAYLOAD is registered in the wire
+  //    protocol and the UI relay forwards every non-HTML_TO_FIGMA command to the
+  //    main thread unchanged, so a CLI call lands on the same handler the
+  //    html-to-figma path uses.
+  const imported = (await run('IMPORT_PAYLOAD', {
+    payload: {
+      version: 1,
+      name: typeof specA.name === 'string' ? specA.name : 'mirror-verify',
+      width: typeof specA.width === 'number' ? specA.width : 0,
+      height: typeof specA.height === 'number' ? specA.height : 0,
+      tokens: EMPTY_TOKENS,
+      rootNode: specA,
+    },
+    parentId: opts.parentId,
+  }, { timeoutMs: COMMAND_TIMEOUTS.IMPORT_PAYLOAD })) as ImportReply | null;
+
+  const rebuiltId = imported?.id;
+  if (!rebuiltId) throw new CliError('E_PLUGIN_ERROR', 'IMPORT_PAYLOAD returned no rebuilt node id');
+
+  // 3. Scan the rebuild, then clean up — even if that second scan throws, so a
+  //    failed verification never leaves scratch on the owner's canvas.
+  let specB: ScannedSpec;
+  try {
+    specB = await scanNodeSpec(rebuiltId, opts.timeoutMs, run);
+  } finally {
+    if (!opts.keep) await removeNode(rebuiltId, opts.timeoutMs, run);
+  }
+
+  const { equal, diffs } = structuralDiff(normalizeForDiff(specA), normalizeForDiff(specB));
+  return {
+    nodeId,
+    rebuiltId,
+    equal,
+    diffCount: diffs.length,
+    diffs,
+    keptRebuild: opts.keep,
+    warnings: imported?.warnings ?? [],
+    normalized: NORMALIZED_FIELDS,
+  };
+}
+
+/** Best-effort scratch removal — a cleanup failure must not mask the verdict. */
+async function removeNode(id: string, timeoutMs: number, run: Runner): Promise<void> {
+  const code = `const n = await figma.getNodeByIdAsync(${JSON.stringify(id)});
+if (n && 'remove' in n) n.remove();
+return { removed: !!n };`;
+  try {
+    await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + 2_000 });
+  } catch {
+    // The verdict is already computed; a stranded scratch node is the owner's to
+    // delete and is named in the result as `rebuiltId`.
+  }
+}
+
+export async function run(args: CommandArgs): Promise<unknown> {
+  const nodeId = args.positionals[0];
+  if (!nodeId) throw new CliError('E_INVALID_ARGS', 'mirror-verify requires a <nodeId>');
+  return execute(nodeId, {
+    parentId: args.str('parent'),
+    keep: args.bool('keep'),
+    timeoutMs: resolveScanTimeout(args.num('timeout')),
+  });
+}

--- a/figma-agent/cli/src/commands/scan-node.ts
+++ b/figma-agent/cli/src/commands/scan-node.ts
@@ -5,6 +5,9 @@
 // hand-copied string), bundled at BUILD time into SCAN_NODE_WALKER_BUNDLE — so it
 // stays drift-free with the unit-tested walker AND the command runs on a dist-only
 // install, where neither plugin/src nor esbuild exists. See scripts/build.mjs.
+//
+// `scanNodeSpec` is exported so the OTHER half of the mirror (mirror-verify) scans
+// through the exact same walker + timeout policy instead of copying this code.
 import {
   COMMAND_TIMEOUTS,
   EXEC_JS_MAX_TIMEOUT_MS,
@@ -16,22 +19,42 @@ import { runCommand } from '../transport/broker-client.ts';
 
 const WIRE_MARGIN_MS = 2_000;
 
-export async function run(args: CommandArgs): Promise<unknown> {
-  const nodeId = args.positionals[0];
-  if (!nodeId) throw new CliError('E_INVALID_ARGS', 'scan-node requires a <nodeId>');
+/** Transport seam — the real `runCommand` in production, a recorder in tests. */
+export type Runner = (cmd: string, params: unknown, opts?: { timeoutMs?: number }) => Promise<unknown>;
 
-  // getNodeByIdAsync, not getNodeById: the plugin manifest declares
-  // `documentAccess: "dynamic-page"`, under which the sync getter throws outright —
-  // so the sync call could never resolve a node on a real canvas.
-  // The id→name token map is read ONCE (async) and handed to the sync walker, so
-  // variable bindings come back as reversible tokenRefs (spec-005 P1).
+/** The walker's output, opaque to the CLI: plain JSON, compared structurally. */
+export type ScannedSpec = Record<string, unknown>;
+
+/** Clamp a requested timeout into the EXEC_JS policy (default → cap). */
+export function resolveScanTimeout(requested?: number): number {
+  return Math.min(requested ?? COMMAND_TIMEOUTS.EXEC_JS ?? 30_000, EXEC_JS_MAX_TIMEOUT_MS);
+}
+
+/**
+ * Scan ONE node into a FigmaExportNode spec, through the bundled walker.
+ *
+ * getNodeByIdAsync, not getNodeById: the plugin manifest declares
+ * `documentAccess: "dynamic-page"`, under which the sync getter throws outright —
+ * so the sync call could never resolve a node on a real canvas.
+ * The id→name token map is read ONCE (async) and handed to the sync walker, so
+ * variable bindings come back as reversible tokenRefs (spec-005 P1).
+ */
+export async function scanNodeSpec(
+  nodeId: string,
+  timeoutMs: number,
+  run: Runner = runCommand,
+): Promise<ScannedSpec> {
   const code = `${SCAN_NODE_WALKER_BUNDLE}
 const node = await figma.getNodeByIdAsync(${JSON.stringify(nodeId)});
 if (!node) throw new Error('node not found: ' + ${JSON.stringify(nodeId)});
 const tokenNames = await __scan.readTokenNameMap();
 return __scan.nodeToSpec(node, tokenNames);`;
+  const spec = await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS });
+  return spec as ScannedSpec;
+}
 
-  const requested = args.num('timeout') ?? COMMAND_TIMEOUTS.EXEC_JS ?? 30_000;
-  const timeoutMs = Math.min(requested, EXEC_JS_MAX_TIMEOUT_MS);
-  return runCommand('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS });
+export async function run(args: CommandArgs): Promise<unknown> {
+  const nodeId = args.positionals[0];
+  if (!nodeId) throw new CliError('E_INVALID_ARGS', 'scan-node requires a <nodeId>');
+  return scanNodeSpec(nodeId, resolveScanTimeout(args.num('timeout')));
 }

--- a/figma-agent/cli/src/figma-agent.ts
+++ b/figma-agent/cli/src/figma-agent.ts
@@ -15,6 +15,7 @@ import * as execJs from './commands/exec-js.ts';
 import * as exportPng from './commands/export-png.ts';
 import * as getSelection from './commands/get-selection.ts';
 import * as htmlToFigma from './commands/html-to-figma.ts';
+import * as mirrorVerify from './commands/mirror-verify.ts';
 import * as scanDesignSystem from './commands/scan-design-system.ts';
 import * as scanNode from './commands/scan-node.ts';
 import * as scanConventions from './commands/scan-conventions.ts';
@@ -35,6 +36,7 @@ const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<unknown>
   'get-selection': getSelection,
   'scan-design-system': scanDesignSystem,
   'scan-node': scanNode,
+  'mirror-verify': mirrorVerify,
   'scan-conventions': scanConventions,
   'audit-ds': auditDs,
   'create-frame': createFrame,
@@ -62,6 +64,7 @@ Commands:
   get-selection        Serialize the current selection [--depth 1]
   scan-design-system   Components/variables/styles registry [--out file.json --timeout ms]
   scan-node            [SPIKE] Reverse-walk one node → FigmaExportNode spec <nodeId> [--timeout ms]
+  mirror-verify        Prove one node round-trips: scan → rebuild → scan → diff <nodeId> [--parent id --keep --timeout ms]
   scan-conventions     Convention-DNA walk over sections → usage-dna.json [<sectionId...> --out file.json --budget 14000 --timeout ms]
   audit-ds             DS-hygiene audit of the open file's component library [--out file.json --sections "01 A,02 B" --facts raw.json --from-facts raw.json --timeout ms]
   create-frame         --name n --w 400 --h 300 [--parent id --x 0 --y 0]

--- a/figma-agent/cli/src/util/structural-diff.ts
+++ b/figma-agent/cli/src/util/structural-diff.ts
@@ -1,0 +1,86 @@
+// The mirror's LINTER (Art II): a deep, path-reporting comparison of two
+// FigmaExportNode specs. `mirror-verify` asks "did scan → rebuild → scan land on
+// the same spec?" — a boolean answer is useless when it says NO, so this reports
+// exactly WHICH field lost the round-trip, as a JSON path (e.g.
+// `children[0].fills[0].color.a`).
+//
+// Deliberately schema-agnostic: it walks the JSON, not the FigmaExportNode type.
+// A field added to the walker is compared the day it appears, with no edit here.
+//
+// Conventions, all of them load-bearing for a HONEST verdict:
+//  - Numbers compare with an epsilon (FLOAT_EPSILON) — the build path round-trips
+//    colours through paint.opacity ↔ color.a and radii through float fields, so a
+//    strict === would report noise as loss. Same tolerance the fixed-point test
+//    asserts with toBeCloseTo(_, 5).
+//  - `undefined` === absent. The walker `delete`s empty fields, so `{}` and
+//    `{fills: undefined}` are the same spec.
+//  - Object keys are visited SORTED, so the diff list is deterministic (the same
+//    two specs always produce byte-identical output — Art VI).
+
+/** One field that did not survive the round-trip. */
+export interface StructuralDiffEntry {
+  /** JSON path from the spec root, e.g. `children[0].fills[0].color.a`. */
+  path: string;
+  left: unknown;
+  right: unknown;
+}
+
+export interface StructuralDiffResult {
+  equal: boolean;
+  diffs: StructuralDiffEntry[];
+}
+
+/** Float tolerance — matches the fixed-point test's `toBeCloseTo(x, 5)`. */
+export const FLOAT_EPSILON = 1e-5;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** `path` + a key, honouring the root case (no leading dot). */
+function joinPath(path: string, key: string): string {
+  return path ? `${path}.${key}` : key;
+}
+
+function numbersEqual(a: number, b: number): boolean {
+  if (Number.isNaN(a) && Number.isNaN(b)) return true;
+  return Math.abs(a - b) <= FLOAT_EPSILON;
+}
+
+function walk(a: unknown, b: unknown, path: string, out: StructuralDiffEntry[]): void {
+  if (a === undefined && b === undefined) return;
+
+  if (typeof a === 'number' && typeof b === 'number') {
+    if (!numbersEqual(a, b)) out.push({ path, left: a, right: b });
+    return;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      out.push({ path: joinPath(path, 'length'), left: a.length, right: b.length });
+    }
+    const n = Math.max(a.length, b.length);
+    for (let i = 0; i < n; i++) walk(a[i], b[i], `${path}[${i}]`, out);
+    return;
+  }
+
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+    for (const key of keys) walk(a[key], b[key], joinPath(path, key), out);
+    return;
+  }
+
+  // Primitives, null, and every type mismatch (array↔object, object↔primitive,
+  // present↔absent) land here: one comparison, one entry.
+  if (a !== b) out.push({ path, left: a, right: b });
+}
+
+/**
+ * Deep-compare two specs. `equal` is true iff no field differs; `diffs` lists
+ * every field that does, in a deterministic order.
+ */
+export function structuralDiff(a: unknown, b: unknown): StructuralDiffResult {
+  const diffs: StructuralDiffEntry[] = [];
+  walk(a, b, '', diffs);
+  return { equal: diffs.length === 0, diffs };
+}

--- a/figma-agent/tests/mirror-verify.test.ts
+++ b/figma-agent/tests/mirror-verify.test.ts
@@ -1,0 +1,141 @@
+// `mirror-verify` orchestration (spec-005 P5) — OFFLINE, through the same
+// injected-Runner seam scan-design-system/scan-conventions use. It does not mock
+// the broker or the plugin: it asserts the command's own contract — the wire
+// sequence (scan → IMPORT_PAYLOAD → scan → cleanup), the empty-tokens payload,
+// the scratch removal, and the shape of the JSON envelope. The verdict itself is
+// structuralDiff's, unit-tested in structural-diff.test.ts; the round-trip truth
+// is the fixed-point test's. Only a LIVE run on a real canvas proves all three at
+// once — that is the owner-in-the-loop step this command exists to make one line.
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../cli/src/arg-parse.ts';
+import { COMMAND_TIMEOUTS } from '../shared/protocol.ts';
+import { execute, normalizeForDiff } from '../cli/src/commands/mirror-verify.ts';
+
+interface Call { cmd: string; params: unknown; opts?: { timeoutMs?: number } }
+
+const CARD = {
+  type: 'FRAME', name: 'Card', width: 320, height: 200,
+  layoutMode: 'VERTICAL', itemSpacing: 12,
+  fills: [{ type: 'SOLID', color: { r: 0.1, g: 0.1, b: 0.12, a: 1 } }],
+  children: [{ type: 'TEXT', name: 'Title', characters: 'Hello', fontSize: 20 }],
+};
+
+/**
+ * A runner standing in for the plugin: answers each EXEC_JS scan with the spec
+ * queued for it, and IMPORT_PAYLOAD with a rebuilt id. `specs` is consumed in
+ * order (specA, then specB).
+ */
+function fakePlugin(specs: unknown[], calls: Call[], warnings: string[] = []) {
+  const queue = [...specs];
+  return async (cmd: string, params: unknown, opts?: { timeoutMs?: number }) => {
+    calls.push({ cmd, params, opts });
+    if (cmd === 'IMPORT_PAYLOAD') return { id: '99:1', name: 'Card', warnings };
+    const code = String((params as { code: string }).code);
+    if (code.includes('.remove()')) return { removed: true };
+    return queue.shift();
+  };
+}
+
+const OPTS = { keep: false, timeoutMs: 30_000 };
+
+describe('mirror-verify — the round-trip wire sequence', () => {
+  it('scans, rebuilds, re-scans, then removes the scratch node', async () => {
+    const calls: Call[] = [];
+    await execute('1:2', OPTS, fakePlugin([CARD, CARD], calls));
+    expect(calls.map((c) => c.cmd)).toEqual(['EXEC_JS', 'IMPORT_PAYLOAD', 'EXEC_JS', 'EXEC_JS']);
+    // The two scans target the ORIGINAL then the REBUILT node…
+    expect(String((calls[0].params as { code: string }).code)).toContain('"1:2"');
+    expect(String((calls[2].params as { code: string }).code)).toContain('"99:1"');
+    // …and the last call removes the rebuild, not the original.
+    const cleanup = String((calls[3].params as { code: string }).code);
+    expect(cleanup).toContain('"99:1"');
+    expect(cleanup).toContain('remove()');
+  });
+
+  it('rebuilds from specA with EMPTY tokens (a gate must not mint variables)', async () => {
+    const calls: Call[] = [];
+    await execute('1:2', OPTS, fakePlugin([CARD, CARD], calls));
+    const p = calls[1].params as { payload: Record<string, unknown>; parentId?: string };
+    expect(p.payload.rootNode).toEqual(CARD);
+    expect(p.payload.tokens).toEqual({ colors: [], typography: [], spacing: [], radii: [], shadows: [] });
+    expect(p.payload).toMatchObject({ version: 1, name: 'Card', width: 320, height: 200 });
+    expect(calls[1].opts?.timeoutMs).toBe(COMMAND_TIMEOUTS.IMPORT_PAYLOAD);
+  });
+
+  it('threads --parent into the rebuild', async () => {
+    const calls: Call[] = [];
+    await execute('1:2', { ...OPTS, parentId: '7:7' }, fakePlugin([CARD, CARD], calls));
+    expect((calls[1].params as { parentId?: string }).parentId).toBe('7:7');
+  });
+
+  it('--keep leaves the rebuild on the canvas (no removal call)', async () => {
+    const calls: Call[] = [];
+    const res = await execute('1:2', { ...OPTS, keep: true }, fakePlugin([CARD, CARD], calls));
+    expect(calls.map((c) => c.cmd)).toEqual(['EXEC_JS', 'IMPORT_PAYLOAD', 'EXEC_JS']);
+    expect(res.keptRebuild).toBe(true);
+  });
+
+  it('still removes the scratch node when the SECOND scan fails', async () => {
+    const calls: Call[] = [];
+    const runner = async (cmd: string, params: unknown, opts?: { timeoutMs?: number }) => {
+      calls.push({ cmd, params, opts });
+      if (cmd === 'IMPORT_PAYLOAD') return { id: '99:1' };
+      const code = String((params as { code: string }).code);
+      if (code.includes('"99:1"') && !code.includes('.remove()')) throw new Error('scan blew up');
+      if (code.includes('.remove()')) return { removed: true };
+      return CARD;
+    };
+    await expect(execute('1:2', OPTS, runner)).rejects.toThrow('scan blew up');
+    expect(calls.at(-1)?.cmd).toBe('EXEC_JS');
+    expect(String((calls.at(-1)?.params as { code: string }).code)).toContain('remove()');
+  });
+});
+
+describe('mirror-verify — the verdict envelope', () => {
+  it('reports equal + zero diffs when the node round-trips', async () => {
+    const res = await execute('1:2', OPTS, fakePlugin([CARD, structuredClone(CARD)], []));
+    expect(res).toMatchObject({ nodeId: '1:2', rebuiltId: '99:1', equal: true, diffCount: 0, keptRebuild: false });
+    expect(res.diffs).toEqual([]);
+  });
+
+  it('reports the LOST field by path when it does not', async () => {
+    const rebuilt = structuredClone(CARD);
+    rebuilt.children[0].characters = 'Hi';
+    const res = await execute('1:2', OPTS, fakePlugin([CARD, rebuilt], []));
+    expect(res.equal).toBe(false);
+    expect(res.diffCount).toBe(1);
+    expect(res.diffs[0]).toEqual({ path: 'children[0].characters', left: 'Hello', right: 'Hi' });
+  });
+
+  it('surfaces the rebuild import warnings (e.g. a skipped token binding)', async () => {
+    const warn = ['token bind fills→color/brand skipped on "Card": no variable named "color/brand"'];
+    const res = await execute('1:2', OPTS, fakePlugin([CARD, CARD], [], warn));
+    expect(res.warnings).toEqual(warn);
+  });
+
+  it('fails loudly when the rebuild returns no id', async () => {
+    const runner = async (cmd: string) => (cmd === 'IMPORT_PAYLOAD' ? {} : CARD);
+    await expect(execute('1:2', OPTS, runner)).rejects.toThrow('no rebuilt node id');
+  });
+});
+
+describe('mirror-verify — normalisation + args', () => {
+  it('drops the ROOT x/y (the rebuild lands at the viewport centre, not the original coords)', () => {
+    expect(normalizeForDiff({ type: 'FRAME', name: 'Card', x: 10, y: 20 })).toEqual({ type: 'FRAME', name: 'Card' });
+  });
+
+  it('keeps NESTED x/y — a child\'s coords are parent-relative, hence structural', async () => {
+    const withKid = { ...CARD, x: 10, y: 20, children: [{ type: 'FRAME', name: 'Abs', x: 4, y: 4 }] };
+    const moved = { ...CARD, x: 999, y: 999, children: [{ type: 'FRAME', name: 'Abs', x: 4, y: 8 }] };
+    const res = await execute('1:2', OPTS, fakePlugin([withKid, moved], []));
+    expect(res.diffs).toEqual([{ path: 'children[0].y', left: 4, right: 8 }]); // root x/y gone, child y kept
+  });
+
+  it('parses <nodeId> --parent --keep --timeout', () => {
+    const a = parseArgs(['4296:1', '--parent', '7:7', '--keep', '--timeout', '45000']);
+    expect(a.positionals[0]).toBe('4296:1');
+    expect(a.str('parent')).toBe('7:7');
+    expect(a.bool('keep')).toBe(true);
+    expect(a.num('timeout')).toBe(45000);
+  });
+});

--- a/figma-agent/tests/scan-node-fixed-point.test.ts
+++ b/figma-agent/tests/scan-node-fixed-point.test.ts
@@ -36,6 +36,7 @@ import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import {
   installMockFigma, setMockLocalVariables, setMockComponents, makeMockComponent, FakeNode,
 } from './helpers/mock-figma.ts';
+import { structuralDiff } from '../cli/src/util/structural-diff.ts';
 import { getImportWarnings, resetImportWarnings } from '../plugin/src/main/executor-styles.ts';
 import type { FigmaExportNode } from '../shared/figma-payload-types.ts';
 import type { ScannedNode } from '../plugin/src/main/scan-node.ts';
@@ -72,6 +73,21 @@ async function roundTrips(spec0: FigmaExportNode, vars?: Vars): Promise<[Scanned
   return [spec1, spec2];
 }
 
+/**
+ * The fixed-point assertion, made through the SAME linter the live gate uses —
+ * `structuralDiff` (cli/src/util/structural-diff.ts), which `figma-agent
+ * mirror-verify` runs against a real canvas. Asserting both here is the point: a
+ * spec this suite calls a fixed point is one mirror-verify must also call `equal`,
+ * so the mock proof and the live proof can never drift into disagreeing. `toEqual`
+ * stays alongside as the independent second opinion.
+ */
+function expectFixedPoint(spec1: ScannedNode, spec2: ScannedNode): void {
+  const { equal, diffs } = structuralDiff(spec1, spec2);
+  expect(diffs).toEqual([]); // fails with the exact path, not just `false`
+  expect(equal).toBe(true);
+  expect(spec2).toEqual(spec1);
+}
+
 describe('fixed point — auto-layout FRAME with text children', () => {
   const card: FigmaExportNode = {
     type: 'FRAME', name: 'Card', width: 320, height: 200,
@@ -91,7 +107,7 @@ describe('fixed point — auto-layout FRAME with text children', () => {
 
   it('reaches a fixed point (spec1 === spec2)', async () => {
     const [spec1, spec2] = await roundTrips(card);
-    expect(spec2).toEqual(spec1);
+    expectFixedPoint(spec1, spec2);
   });
 
   it('preserves auto-layout topology, fills, radius, strokes', async () => {
@@ -134,7 +150,7 @@ describe('fixed point — native GRID', () => {
   };
   it('round-trips grid counts + gaps', async () => {
     const [spec1, spec2] = await roundTrips(grid);
-    expect(spec2).toEqual(spec1);
+    expectFixedPoint(spec1, spec2);
     expect(spec1).toMatchObject({
       layoutMode: 'GRID', gridColumnCount: 3, gridRowCount: 2, gridColumnGap: 16, gridRowGap: 16,
     });
@@ -150,7 +166,7 @@ describe('fixed point — per-corner radius (figma.mixed path)', () => {
   };
   it('recovers cornerRadii via the mixed-getter fallback', async () => {
     const [spec1, spec2] = await roundTrips(chip);
-    expect(spec2).toEqual(spec1);
+    expectFixedPoint(spec1, spec2);
     expect(spec1.cornerRadii).toEqual({ tl: 16, tr: 4, br: 16, bl: 4 });
     expect(spec1.cornerRadius).toBeUndefined();
   });
@@ -208,7 +224,7 @@ describe('fixed point — variable bindings survive via the token NAME (spec-005
     const [spec1, spec2] = await roundTrips(btn, vars);
     expect(spec2.tokenRefs).toEqual(spec1.tokenRefs);
     expect(spec2.figmaScanBindings).toEqual(spec1.figmaScanBindings);
-    expect(spec2).toEqual(spec1);
+    expectFixedPoint(spec1, spec2);
   });
 
   it('reads the id→name map from the file LOCAL variables (the live join source)', async () => {
@@ -240,6 +256,10 @@ describe('reversibility GAP that REMAINS — library / remote variable bindings'
     const spec2 = await build(spec1, vars, new Map());
     expect(spec2.figmaScanBindings).toBeUndefined();
     expect(spec2).not.toEqual(spec1);
+    // …and the linter the live gate runs names WHICH field was lost, by path.
+    expect(structuralDiff(spec1, spec2).diffs).toEqual([
+      { path: 'figmaScanBindings', left: { fills: 'VariableID:9' }, right: undefined },
+    ]);
   });
 });
 
@@ -311,7 +331,7 @@ describe('fixed point — INSTANCE survives as ref + overrides (spec-005 P2)', (
 
   it('IS a fixed point (spec1 === spec2)', async () => {
     const [spec1, spec2] = await roundTrips(instSpec());
-    expect(spec2).toEqual(spec1);
+    expectFixedPoint(spec1, spec2);
   });
 
   it('mirrors the main visuals without re-writing them as overrides', async () => {
@@ -329,7 +349,7 @@ describe('fixed point — INSTANCE survives as ref + overrides (spec-005 P2)', (
     const [spec1, spec2] = await roundTrips(overridden);
     expect(spec1).toMatchObject({ type: 'INSTANCE', width: 200, height: 48, cornerRadius: 24 });
     expect(spec1.fills?.[0]?.color).toMatchObject({ r: 1, g: 0, b: 0 });
-    expect(spec2).toEqual(spec1);
+    expectFixedPoint(spec1, spec2);
   });
 
   it('resolves the main by componentId when no key is published', async () => {
@@ -355,7 +375,7 @@ describe('fixed point — INSTANCE survives as ref + overrides (spec-005 P2)', (
     expect(spec1.children?.[1]).toMatchObject({
       type: 'INSTANCE', componentKey: 'KEY-BTN', componentProperties: { State: 'Hover' },
     });
-    expect(spec2).toEqual(spec1);
+    expectFixedPoint(spec1, spec2);
   });
 });
 
@@ -409,5 +429,8 @@ describe('instance GAP that REMAINS — INNER (per-child) ad-hoc overrides', () 
     expect(spec2.type).toBe('INSTANCE');
     expect(spec2.figmaScanInnerOverrides).toBeUndefined();
     expect(spec2).not.toEqual(spec1); // NOT a fixed point — the loss is reported, not faked
+    expect(structuralDiff(spec1, spec2).diffs).toEqual([
+      { path: 'figmaScanInnerOverrides', left: ['characters', 'fontSize'], right: undefined },
+    ]);
   });
 });

--- a/figma-agent/tests/structural-diff.test.ts
+++ b/figma-agent/tests/structural-diff.test.ts
@@ -1,0 +1,119 @@
+// The mirror's linter, unit-tested (spec-005 P5). structuralDiff is what turns
+// "the round-trip failed" into "children[0].fills[0].color.a failed" — so the
+// tests here are mostly about the PATH being right, not just the boolean.
+import { describe, it, expect } from 'vitest';
+import { structuralDiff, FLOAT_EPSILON } from '../cli/src/util/structural-diff.ts';
+
+describe('structuralDiff — equal specs', () => {
+  it('reports equal for two deep-identical specs', () => {
+    const spec = {
+      type: 'FRAME', name: 'Card', width: 320, layoutMode: 'VERTICAL',
+      fills: [{ type: 'SOLID', color: { r: 0.1, g: 0.1, b: 0.12, a: 1 } }],
+      children: [{ type: 'TEXT', name: 'Title', characters: 'Hello', fontSize: 20 }],
+    };
+    const res = structuralDiff(spec, structuredClone(spec));
+    expect(res).toEqual({ equal: true, diffs: [] });
+  });
+
+  it('treats an explicitly-undefined field as absent (the walker deletes empties)', () => {
+    expect(structuralDiff({ type: 'FRAME', fills: undefined }, { type: 'FRAME' }).equal).toBe(true);
+  });
+
+  it('is unaffected by key order', () => {
+    expect(structuralDiff({ a: 1, b: 2 }, { b: 2, a: 1 }).equal).toBe(true);
+  });
+});
+
+describe('structuralDiff — a single field that lost the round-trip', () => {
+  it('names the exact path of a nested scalar diff', () => {
+    const a = { type: 'FRAME', children: [{ type: 'TEXT', characters: 'Hello' }] };
+    const b = { type: 'FRAME', children: [{ type: 'TEXT', characters: 'Hi' }] };
+    expect(structuralDiff(a, b)).toEqual({
+      equal: false,
+      diffs: [{ path: 'children[0].characters', left: 'Hello', right: 'Hi' }],
+    });
+  });
+
+  it('names a path THROUGH arrays of objects (the canonical fills case)', () => {
+    const a = { fills: [{ type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 1 } }] };
+    const b = { fills: [{ type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 0.5 } }] };
+    const res = structuralDiff(a, b);
+    expect(res.equal).toBe(false);
+    expect(res.diffs).toEqual([{ path: 'fills[0].color.a', left: 1, right: 0.5 }]);
+  });
+
+  it('reports a DROPPED field as left=value, right=undefined (the binding-loss shape)', () => {
+    const a = { type: 'FRAME', tokenRefs: { fill: 'color/brand' }, cornerRadius: 8 };
+    const b = { type: 'FRAME', cornerRadius: 8 };
+    // A container that vanished WHOLE is reported once, at its own path, carrying
+    // what was lost — not fanned out into one entry per leaf. Same convention as a
+    // dropped `children` subtree below; this is the exact shape a token-bound node
+    // produces when the rebuild drops its bindings (see mirror-verify's header).
+    expect(structuralDiff(a, b).diffs).toEqual([
+      { path: 'tokenRefs', left: { fill: 'color/brand' }, right: undefined },
+    ]);
+  });
+
+  it('descends to the LEAF when the container survives but a binding inside it does not', () => {
+    const a = { tokenRefs: { fill: 'color/brand', radius: 'radius/sm' } };
+    const b = { tokenRefs: { fill: 'color/brand' } };
+    expect(structuralDiff(a, b).diffs).toEqual([
+      { path: 'tokenRefs.radius', left: 'radius/sm', right: undefined },
+    ]);
+  });
+
+  it('reports a type mismatch at the path rather than descending into it', () => {
+    expect(structuralDiff({ cornerRadius: 12 }, { cornerRadius: { tl: 12 } }).diffs).toEqual([
+      { path: 'cornerRadius', left: 12, right: { tl: 12 } },
+    ]);
+  });
+
+  it('lists every differing field, in a deterministic (sorted) order', () => {
+    const res = structuralDiff({ width: 320, height: 200, name: 'A' }, { width: 321, height: 201, name: 'A' });
+    expect(res.diffs.map((d) => d.path)).toEqual(['height', 'width']);
+  });
+});
+
+describe('structuralDiff — float epsilon', () => {
+  it('treats a sub-epsilon float delta as equal (paint.opacity ↔ color.a noise)', () => {
+    const a = { strokes: [{ color: { a: 0.1 } }] };
+    const b = { strokes: [{ color: { a: 0.1 + FLOAT_EPSILON / 2 } }] };
+    expect(structuralDiff(a, b).equal).toBe(true);
+  });
+
+  it('reports a delta ABOVE epsilon', () => {
+    const res = structuralDiff({ itemSpacing: 12 }, { itemSpacing: 12.001 });
+    expect(res.equal).toBe(false);
+    expect(res.diffs[0].path).toBe('itemSpacing');
+  });
+
+  it('does not let epsilon swallow a number ↔ string mismatch', () => {
+    expect(structuralDiff({ fontSize: 20 }, { fontSize: '20' }).equal).toBe(false);
+  });
+});
+
+describe('structuralDiff — nested children', () => {
+  it('reports a child COUNT change plus the extra child, by path', () => {
+    const a = { children: [{ name: 'One' }] };
+    const b = { children: [{ name: 'One' }, { name: 'Two' }] };
+    const res = structuralDiff(a, b);
+    expect(res.equal).toBe(false);
+    expect(res.diffs).toEqual([
+      { path: 'children.length', left: 1, right: 2 },
+      { path: 'children[1]', left: undefined, right: { name: 'Two' } },
+    ]);
+  });
+
+  it('walks arbitrarily deep nesting', () => {
+    const nest = (leaf: unknown) => ({ children: [{ children: [{ children: [leaf] }] }] });
+    const res = structuralDiff(nest({ fontSize: 14 }), nest({ fontSize: 16 }));
+    expect(res.diffs).toEqual([
+      { path: 'children[0].children[0].children[0].fontSize', left: 14, right: 16 },
+    ]);
+  });
+
+  it('reports a whole dropped subtree at its path', () => {
+    const res = structuralDiff({ name: 'Card', children: [{ name: 'Kid' }] }, { name: 'Card' });
+    expect(res.diffs).toEqual([{ path: 'children', left: [{ name: 'Kid' }], right: undefined }]);
+  });
+});

--- a/specs/005-figma-mirror/tasks.md
+++ b/specs/005-figma-mirror/tasks.md
@@ -17,5 +17,13 @@
       capture = spec 004 pending, unchanged. Plugin-down degrades explicitly (`mirrorSkipped`).
       Panel honesty closed via shared/figma-sync-summary.ts + SYNC_RESULT.landed.
       Edges deferred to P5: real overrides / nested variants; scan-node needs a repo checkout.
+- [x] dist-bundle fix — ✓ 2026-07-16 merged (PR #50, CI 5/5, figma-agent 254). Walker pre-bundled
+      into `cli/src/generated/scan-node-walker-bundle.ts` (esbuild IIFE, emitter+linter per Art II);
+      `scan-node` self-contained → dist-only install mirrors. Self-containment proven LIVE (dist copied
+      to temp, no repo → real `FigmaExportNode`). Bonus: `getNodeById`→`getNodeByIdAsync` (sync getter
+      throws under `documentAccess: dynamic-page`) — scan-node had never resolved a real node before.
 - [ ] P5 — Live round-trip GATE: real Figma component, scan→rebuild→structural-diff == fixed
-      point incl. bindings+instances (owner-in-the-loop) — stage:spec · depends P1-P4
+      point incl. bindings+instances (owner-in-the-loop) — stage:spec · depends P1-P4.
+      Harness = `mirror-verify <nodeId>` (scan → IMPORT_PAYLOAD rebuild → scan → structural-diff),
+      one command. OWNER STEP: run the freshly-built plugin in Figma (connects broker :9410), then
+      `mirror-verify <realNodeId>`. Scan-half already live-proven by the dist-bundle branch.


### PR DESCRIPTION
## What

`figma-agent mirror-verify <nodeId> [--parent id] [--keep] [--timeout ms]` — the **rebuild half** the mirror was missing. It closes the loop in one command:

    scan-node → specA → IMPORT_PAYLOAD (rebuild) → scan-node → specB → structuralDiff

Prints one JSON envelope: `{nodeId, rebuiltId, equal, diffCount, diffs, keptRebuild, warnings, normalized}`. The scratch rebuild is removed again unless `--keep` — including when the second scan throws (removal is in a `finally`), so the gate never litters the owner's canvas.

`cli/src/util/structural-diff.ts` is the mirror's **linter** (Art II): `equal: false` is useless on its own, so it names the field by path (`children[0].fills[0].color.a`), with a `1e-5` float epsilon matching the fixed-point suite's `toBeCloseTo(_, 5)`. Deterministic output (sorted keys).

`scan-node` now exports `scanNodeSpec`/`resolveScanTimeout` rather than being copied — both scans run through the one bundled walker and one timeout policy. No walker / `createFigmaNode` / reconcile logic changed.

## Two assumptions from the task brief, checked against the code

- **IMPORT_PAYLOAD is reachable directly from the CLI — TRUE.** `ui-relay.ts:191-194` forwards every command except `HTML_TO_FIGMA` to the main thread unchanged, and `main.ts:204` dispatches `IMPORT_PAYLOAD → importPayload`. No new transport needed.
- **"Empty tokens still rebind by existing variable NAME" — FALSE.** `applyTokenRefs` (executor-variables.ts:127-144) binds only through the map `createVariablesFromTokens(payload.tokens)` returns; there is no lookup of an existing same-named variable on the import path (`resolveVariable`-by-name exists, but only for the `BIND_VARIABLE` op). Empty tokens ⇒ every tokenRef is skipped with a warning and the literal value kept. The fixed-point test does not contradict this — it injects `vars` straight into `createFigmaNode` (test helper `build()`), bypassing the token path entirely.

Consequence: **a token-bound node will report `tokenRefs` / `figmaScanBindings` diffs on a live run.** That is reported, not hidden — the envelope also surfaces the import's own `no variable named "X"` warnings. Non-empty tokens are not the fix: `createVariablesFromTokens` resolves by VALUE within its own collection, so it would mint duplicate variables in the file being verified. Closing this needs a resolve-existing-by-name step in the import path — a spec-005 P5 decision, left to the owner, documented in the command header.

## Normalisation

Only the ROOT `x`/`y` are dropped before the diff (`importPayload` places the rebuilt root at the viewport centre). Nested `x`/`y` are parent-relative and therefore structural — kept. The walker emits no node id at all, so nothing is stripped for ids; `componentId` is kept (it names the main component, which the rebuild resolves to the same node).

## Tests (offline — no plugin needed)

- `tests/structural-diff.test.ts` — equal / single-field-by-path / float-epsilon / nested-children / dropped-subtree / deterministic order.
- `tests/mirror-verify.test.ts` — wire sequence, empty-tokens payload, `--parent` threading, `--keep`, cleanup-on-failure, verdict envelope, normalisation, arg parsing. Uses the repo's existing injected-`Runner` seam (as `scan-design-system`/`scan-conventions` do) — no broker mock.
- `tests/scan-node-fixed-point.test.ts` — the fixed-point assertions now go through `structuralDiff` alongside `toEqual`, so the mock proof and the live gate cannot drift apart; the two documented NOT-a-fixed-point cases now assert the exact lost path.

## Verify

figma-agent: 281 pass (was 254), typecheck + build green. Root: 1890 pass, typecheck / lint / build green.

**Live run on a real canvas is the owner's step** — it needs the plugin open in Figma Desktop.