### PR TITLE
feat: rebuild-from-spec reattaches token bindings by name (spec 005 P6)

### DIFF
--- a/figma-agent/plugin/code.js
+++ b/figma-agent/plugin/code.js
@@ -464,6 +464,30 @@
     return { id: node.id, field, variable: variable.name };
   }
 
+  // plugin/src/main/executor-token-var-resolve.ts
+  function tokensAreEmpty(tokens) {
+    return !(tokens.colors?.length || tokens.spacing?.length || tokens.radii?.length);
+  }
+  async function readLocalVariableMap() {
+    const byName = /* @__PURE__ */ new Map();
+    try {
+      for (const v of await figma.variables.getLocalVariablesAsync()) {
+        if (!byName.has(v.name)) byName.set(v.name, v);
+      }
+    } catch (err) {
+      pushImportWarning(`local variable lookup failed \u2014 tokenRefs left unbound: ${String(err)}`);
+    }
+    return byName;
+  }
+  async function resolveTokenVars(tokens) {
+    const resolved = await readLocalVariableMap();
+    if (tokensAreEmpty(tokens)) return resolved;
+    for (const [name, variable] of await createVariablesFromTokens(tokens)) {
+      resolved.set(name, variable);
+    }
+    return resolved;
+  }
+
   // plugin/src/main/executor-text.ts
   async function createTextNode(exportNode, tokenVars) {
     const textNode = figma.createText();
@@ -560,8 +584,8 @@
       } catch {
       }
     }
-    if (exportNode.tokenRefs && tokenVars && tokenVars.size > 0) {
-      applyTokenRefs(textNode, exportNode.tokenRefs, tokenVars);
+    if (exportNode.tokenRefs) {
+      applyTokenRefs(textNode, exportNode.tokenRefs, tokenVars ?? /* @__PURE__ */ new Map());
     }
     return textNode;
   }
@@ -610,8 +634,8 @@
     if (exportNode.opacity !== void 0 && exportNode.opacity > 0) {
       rect.opacity = exportNode.opacity;
     }
-    if (exportNode.tokenRefs && tokenVars && tokenVars.size > 0) {
-      applyTokenRefs(rect, exportNode.tokenRefs, tokenVars);
+    if (exportNode.tokenRefs) {
+      applyTokenRefs(rect, exportNode.tokenRefs, tokenVars ?? /* @__PURE__ */ new Map());
     }
     return rect;
   }
@@ -1159,8 +1183,8 @@
     } catch {
     }
     frame.clipsContent = !!exportNode.clipsContent;
-    if (exportNode.tokenRefs && tokenVars && tokenVars.size > 0) {
-      applyTokenRefs(frame, exportNode.tokenRefs, tokenVars);
+    if (exportNode.tokenRefs) {
+      applyTokenRefs(frame, exportNode.tokenRefs, tokenVars ?? /* @__PURE__ */ new Map());
     }
     if (exportNode.children) {
       for (const childExport of exportNode.children) {
@@ -1898,7 +1922,7 @@
     const colorStyles = await createColorStyles(tokens.colors ?? []);
     await createTextStyles(tokens.typography ?? []);
     await createEffectStyles(tokens.shadows ?? []);
-    const tokenVars = await createVariablesFromTokens(tokens);
+    const tokenVars = await resolveTokenVars(tokens);
     const root = await createFigmaNode(payload.rootNode, colorStyles, tokenVars);
     if (!root) throw new Error("payload rootNode produced no Figma node");
     let replaceTarget = null;

--- a/figma-agent/plugin/src/main/executor-frame.ts
+++ b/figma-agent/plugin/src/main/executor-frame.ts
@@ -266,9 +266,11 @@ export async function createFrameNode(
   frame.clipsContent = !!exportNode.clipsContent;
 
   // Token bindings (P3 leg B) — after fills/strokes/radius/spacing/padding
-  // are set so paint-copy binding rebinds the actual applied paints
-  if (exportNode.tokenRefs && tokenVars && tokenVars.size > 0) {
-    applyTokenRefs(frame, exportNode.tokenRefs, tokenVars);
+  // are set so paint-copy binding rebinds the actual applied paints.
+  // Gated on tokenRefs ALONE (spec-005 P6): an empty map must still reach
+  // applyTokenRefs so an unresolvable ref warns instead of vanishing.
+  if (exportNode.tokenRefs) {
+    applyTokenRefs(frame, exportNode.tokenRefs, tokenVars ?? new Map());
   }
 
   // Children

--- a/figma-agent/plugin/src/main/executor-shapes.ts
+++ b/figma-agent/plugin/src/main/executor-shapes.ts
@@ -67,9 +67,10 @@ export async function createRectangleNode(
     rect.opacity = exportNode.opacity;
   }
 
-  // Token bindings (carried follow-up): fill/stroke/radius refs on decorations
-  if (exportNode.tokenRefs && tokenVars && tokenVars.size > 0) {
-    applyTokenRefs(rect, exportNode.tokenRefs, tokenVars);
+  // Token bindings (carried follow-up): fill/stroke/radius refs on decorations.
+  // Gated on tokenRefs ALONE — see executor-frame's build (spec-005 P6).
+  if (exportNode.tokenRefs) {
+    applyTokenRefs(rect, exportNode.tokenRefs, tokenVars ?? new Map());
   }
 
   return rect;

--- a/figma-agent/plugin/src/main/executor-text.ts
+++ b/figma-agent/plugin/src/main/executor-text.ts
@@ -126,9 +126,10 @@ export async function createTextNode(exportNode: FigmaExportNode, tokenVars?: Ma
     }
   }
 
-  // Token bindings (P3 leg B): textColor → fills variable
-  if (exportNode.tokenRefs && tokenVars && tokenVars.size > 0) {
-    applyTokenRefs(textNode, exportNode.tokenRefs, tokenVars);
+  // Token bindings (P3 leg B): textColor → fills variable.
+  // Gated on tokenRefs ALONE — see executor-frame's build (spec-005 P6).
+  if (exportNode.tokenRefs) {
+    applyTokenRefs(textNode, exportNode.tokenRefs, tokenVars ?? new Map());
   }
 
   return textNode;

--- a/figma-agent/plugin/src/main/executor-token-var-resolve.ts
+++ b/figma-agent/plugin/src/main/executor-token-var-resolve.ts
@@ -1,0 +1,73 @@
+// spec-005 P6 — the emitter half of the mirror's binding contract.
+//
+// THE GAP THIS CLOSES: a scanned spec records its bindings as token NAMES
+// (scan-token-refs.bindingsToTokenRefs). Rebuilding that spec is the reverse
+// trip — but the only name→Variable map the build path had was the one
+// `createVariablesFromTokens` derives from `payload.tokens`. A rebuild FROM A
+// SPEC ALONE carries no tokens, so that map came back empty and every tokenRef
+// silently lost its binding. The round-trip looked like a fixed point only
+// because the harness handed the builder the tokens by hand.
+//
+// The fix is to resolve a tokenRef against the variables the FILE already has,
+// looked up by name — the exact inverse of the id→name join the scanner does.
+//
+// WHY NOT REUSE createVariablesFromTokens: its de-dup (findReusableVariable)
+// matches by VALUE, so feeding it synthesised tokens to force a map would mint
+// duplicate variables in the owner's file whenever a value drifted. This module
+// never creates a variable; it only ever binds to one that already exists.
+
+import type { FigmaExportTokens } from '../../../shared/figma-payload-types';
+import { createVariablesFromTokens } from './executor-variables';
+import { pushImportWarning } from './executor-styles';
+
+/** True when the payload carries no token of any kind (the rebuild-from-spec case). */
+function tokensAreEmpty(tokens: FigmaExportTokens): boolean {
+  return !(tokens.colors?.length || tokens.spacing?.length || tokens.radii?.length);
+}
+
+/**
+ * name → Variable for every LOCAL variable in the file, read in ONE async call.
+ *
+ * First occurrence wins on a duplicate name (Figma permits the same name across
+ * collections): the scanner's id→name map is many-to-one in the same direction,
+ * so neither side can do better than pick deterministically.
+ *
+ * Library / remote variables are NOT listed by getLocalVariablesAsync — a
+ * tokenRef naming one stays unresolvable here and surfaces as an import warning
+ * at bind time (applyTokenRefs), which is the same known edge spec-005 P1
+ * documented on the scan side.
+ */
+export async function readLocalVariableMap(): Promise<Map<string, Variable>> {
+  const byName = new Map<string, Variable>();
+  try {
+    for (const v of await figma.variables.getLocalVariablesAsync()) {
+      if (!byName.has(v.name)) byName.set(v.name, v);
+    }
+  } catch (err) {
+    // A file we cannot enumerate binds nothing; it must not abort the import.
+    pushImportWarning(`local variable lookup failed — tokenRefs left unbound: ${String(err)}`);
+  }
+  return byName;
+}
+
+/**
+ * The build path's name → Variable map: the file's existing local variables,
+ * overlaid with whatever `payload.tokens` produced.
+ *
+ * Precedence is payload-over-local ON PURPOSE — a payload that ships tokens is
+ * authoritative about what those names mean, so this stays byte-identical to the
+ * pre-P6 behaviour for every caller that passes tokens. The local map is a
+ * FALLBACK: it can only fill names the payload never spoke for.
+ *
+ * With empty tokens we skip createVariablesFromTokens entirely rather than let it
+ * mint an empty "EaseDesign Tokens" collection as a side effect of a rebuild that
+ * asked for no tokens at all.
+ */
+export async function resolveTokenVars(tokens: FigmaExportTokens): Promise<Map<string, Variable>> {
+  const resolved = await readLocalVariableMap();
+  if (tokensAreEmpty(tokens)) return resolved;
+  for (const [name, variable] of await createVariablesFromTokens(tokens)) {
+    resolved.set(name, variable);
+  }
+  return resolved;
+}

--- a/figma-agent/plugin/src/main/main.ts
+++ b/figma-agent/plugin/src/main/main.ts
@@ -16,7 +16,8 @@ import {
   createColorStyles, createTextStyles, createEffectStyles,
   resetImportWarnings, getImportWarnings, withCode,
 } from './executor-styles';
-import { createVariablesFromTokens, opCreateVariable, opBindVariable } from './executor-variables';
+import { opCreateVariable, opBindVariable } from './executor-variables';
+import { resolveTokenVars } from './executor-token-var-resolve';
 import { createFigmaNode } from './executor-frame';
 import { serializeDesignSystem } from './serialize-node';
 import { auditDs } from './executor-audit';
@@ -221,12 +222,14 @@ async function importPayload(params: Params): Promise<{ id: string; name: string
   resetImportWarnings();
 
   // 1. Local styles + variables from tokens (variables are de-duped on re-import);
-  //    tokenVars (name → Variable) feeds tokenRefs binding during node build (P3 leg B)
+  //    tokenVars (name → Variable) feeds tokenRefs binding during node build (P3 leg B).
+  //    spec-005 P6: the map now also carries the file's EXISTING local variables, so a
+  //    rebuild from a spec alone (no payload.tokens) reattaches its bindings by name.
   const tokens = payload.tokens ?? { colors: [], typography: [], spacing: [], radii: [], shadows: [] };
   const colorStyles = await createColorStyles(tokens.colors ?? []);
   await createTextStyles(tokens.typography ?? []);
   await createEffectStyles(tokens.shadows ?? []);
-  const tokenVars = await createVariablesFromTokens(tokens);
+  const tokenVars = await resolveTokenVars(tokens);
 
   // 2. Build the node tree (tokenRefs bound inline via tokenVars)
   const root = await createFigmaNode(payload.rootNode, colorStyles, tokenVars);

--- a/figma-agent/tests/helpers/mock-figma.ts
+++ b/figma-agent/tests/helpers/mock-figma.ts
@@ -123,11 +123,65 @@ function setBoundVariableForPaint(paint: Record<string, unknown>, _field: 'color
   return { ...paint, boundVariables: { color: { type: 'VARIABLE_ALIAS', id: variable.id } } };
 }
 
+/** A local Variable, as the plugin API models one: identity + a value per mode. */
+export interface FakeVariable {
+  id: string;
+  name: string;
+  resolvedType?: string;
+  variableCollectionId?: string;
+  valuesByMode?: Record<string, unknown>;
+  setValueForMode?(modeId: string, value: unknown): void;
+}
+
 /** The file's LOCAL variables, as getLocalVariablesAsync reports them. A binding
- * to an id absent from this list = the library/remote-variable edge. */
-let localVariables: Array<{ id: string; name: string }> = [];
-export function setMockLocalVariables(vars: Array<{ id: string; name: string }>): void {
+ * to an id absent from this list = the library/remote-variable edge (a library
+ * variable is real and bindable in Figma, but this call never lists it). */
+let localVariables: FakeVariable[] = [];
+export function setMockLocalVariables(vars: FakeVariable[]): void {
   localVariables = vars;
+}
+
+/** A local variable that already EXISTS in the file — what a rebuild-from-spec
+ * must find by name (spec-005 P6). */
+export function makeMockVariable(name: string, resolvedType = 'COLOR'): FakeVariable {
+  return { id: `VariableID:${idSeq++}`, name, resolvedType };
+}
+
+/** The file's variable COLLECTIONS, as the token-import path finds/creates them. */
+interface FakeCollection {
+  id: string;
+  name: string;
+  modes: Array<{ modeId: string; name: string }>;
+}
+let collections: FakeCollection[] = [];
+export function setMockVariableCollections(cols: FakeCollection[]): void {
+  collections = cols;
+}
+
+function createVariableCollection(name: string): FakeCollection {
+  const col: FakeCollection = {
+    id: `VariableCollectionId:${idSeq++}`,
+    name,
+    modes: [{ modeId: `m${idSeq++}`, name: 'Mode 1' }],
+  };
+  collections.push(col);
+  return col;
+}
+
+/** figma.variables.createVariable — mints a variable INTO the file's local list. */
+function createVariable(name: string, collection: FakeCollection, resolvedType: string): FakeVariable {
+  const v: FakeVariable = {
+    id: `VariableID:${idSeq++}`,
+    name,
+    resolvedType,
+    variableCollectionId: collection.id,
+    valuesByMode: {},
+    setValueForMode(modeId: string, value: unknown) {
+      (this.valuesByMode as Record<string, unknown>)[modeId] = value;
+    },
+  };
+  localVariables.push(v);
+  return v;
 }
 
 /** The file's COMPONENT / COMPONENT_SET nodes, as the instance build-case resolves
@@ -158,12 +212,17 @@ export interface MockFigma {
   importComponentByKeyAsync(key: string): Promise<FakeNode>;
   variables: {
     setBoundVariableForPaint: typeof setBoundVariableForPaint;
-    getLocalVariablesAsync(): Promise<Array<{ id: string; name: string }>>;
+    getLocalVariablesAsync(type?: string): Promise<FakeVariable[]>;
+    getLocalVariableCollectionsAsync(): Promise<FakeCollection[]>;
+    createVariableCollection(name: string): FakeCollection;
+    createVariable(name: string, collection: FakeCollection, type: string): FakeVariable;
   };
 }
 
 /** Install a fresh mock on globalThis.figma; returns it. Call once per test file. */
 export function installMockFigma(): MockFigma {
+  localVariables = [];
+  collections = [];
   const mk = (type: string): FakeNode => {
     const n = new FakeNode(type);
     if (type === 'TEXT') n.name = 'Text';
@@ -185,7 +244,13 @@ export function installMockFigma(): MockFigma {
     },
     variables: {
       setBoundVariableForPaint,
-      getLocalVariablesAsync: async () => localVariables,
+      // Figma filters by resolved type when asked; an untyped fixture variable
+      // answers only the untyped query.
+      getLocalVariablesAsync: async (type?: string) =>
+        (type ? localVariables.filter((v) => v.resolvedType === type) : localVariables),
+      getLocalVariableCollectionsAsync: async () => collections,
+      createVariableCollection,
+      createVariable,
     },
   };
   (globalThis as unknown as { figma: MockFigma }).figma = figma;

--- a/figma-agent/tests/scan-node-fixed-point.test.ts
+++ b/figma-agent/tests/scan-node-fixed-point.test.ts
@@ -48,6 +48,7 @@ beforeAll(() => { installMockFigma(); });
 // executor modules only touch `figma` inside function bodies.
 const { createFigmaNode } = await import('../plugin/src/main/executor-frame.ts');
 const { nodeToSpec, readTokenNameMap } = await import('../plugin/src/main/scan-node.ts');
+const { resolveTokenVars } = await import('../plugin/src/main/executor-token-var-resolve.ts');
 
 type Vars = Map<string, { id: string; name: string }>;
 
@@ -232,6 +233,26 @@ describe('fixed point — variable bindings survive via the token NAME (spec-005
     const map = await readTokenNameMap();
     expect(map.get('VariableID:1')).toBe('color/brand');
     setMockLocalVariables([]);
+  });
+
+  /**
+   * spec-005 P6 — the assertion the suite above CANNOT make, and the reason it was
+   * too weak: `roundTrips` hands the rebuild its token map, but the mirror rebuilds
+   * from a sidecar spec that carries NO tokens. This test withholds them and lets the
+   * production resolver find the file's own variables by name — the real rebuild path.
+   * Without the P6 fix the second pass binds nothing and the fixed point collapses.
+   */
+  it('STAYS a fixed point when the rebuild is handed NO tokens (spec-005 P6)', async () => {
+    const spec1 = await build(btn, vars);
+
+    setMockLocalVariables([...vars.values()]); // the variables the file already has
+    const resolved = await resolveTokenVars({ colors: [], typography: [], spacing: [], radii: [], shadows: [] });
+    const spec2 = await build(spec1, resolved as unknown as Vars, namesOf(vars));
+    setMockLocalVariables([]);
+
+    expect(spec2.tokenRefs).toEqual(spec1.tokenRefs);
+    expect(spec2.figmaScanBindings).toEqual(spec1.figmaScanBindings);
+    expectFixedPoint(spec1, spec2);
   });
 });
 

--- a/figma-agent/tests/token-var-reattach.test.ts
+++ b/figma-agent/tests/token-var-reattach.test.ts
@@ -1,0 +1,236 @@
+// spec-005 P6 — the OFFLINE proof that a rebuild FROM A SPEC ALONE reattaches its
+// token bindings.
+//
+// WHY THIS SUITE EXISTS: scan-node-fixed-point's `roundTrips` hands the builder the
+// token collection by hand ("Both passes see the SAME token collection"). That is a
+// fair question to ask, but it is NOT the question the mirror asks. The mirror
+// rebuilds a component from its sidecar spec — a payload with NO tokens — and the
+// build path's only name→Variable map came from those very tokens. So P1's "binding
+// survives" held in the harness and dropped on a real canvas: a gap a green fixture
+// suite could not see, exactly the class of miss the repo's own rule warns about.
+//
+// Every test here therefore withholds payload.tokens and asserts against the file's
+// EXISTING local variables — the state a real rebuild actually runs in.
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import {
+  installMockFigma, setMockLocalVariables, setMockVariableCollections,
+  makeMockVariable, type FakeVariable,
+} from './helpers/mock-figma.ts';
+import type { FigmaExportNode, FigmaExportTokens } from '../shared/figma-payload-types.ts';
+
+beforeAll(() => { installMockFigma(); });
+
+const { createFigmaNode } = await import('../plugin/src/main/executor-frame.ts');
+const { resolveTokenVars, readLocalVariableMap } = await import('../plugin/src/main/executor-token-var-resolve.ts');
+const { getImportWarnings, resetImportWarnings } = await import('../plugin/src/main/executor-styles.ts');
+
+const NO_TOKENS: FigmaExportTokens = { colors: [], typography: [], spacing: [], radii: [], shadows: [] };
+
+/** The alias the mock records on a bound scalar field. */
+const aliasOf = (bound: unknown): string | undefined => (bound as { id?: string } | undefined)?.id;
+/** The alias a paint-copy binding stamps on the first paint's color. */
+const paintAliasOf = (node: Record<string, unknown>, field: string): string | undefined => {
+  const paints = node[field] as Array<{ boundVariables?: { color?: { id: string } } }> | undefined;
+  return paints?.[0]?.boundVariables?.color?.id;
+};
+
+/** Build a spec the way the mirror does: through the REAL builder, tokens withheld. */
+async function rebuildFromSpecAlone(spec: FigmaExportNode): Promise<Record<string, unknown>> {
+  const tokenVars = await resolveTokenVars(NO_TOKENS);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const node = await createFigmaNode(spec as any, new Map(), tokenVars as any);
+  if (!node) throw new Error('builder returned null');
+  return node as unknown as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  resetImportWarnings();
+  setMockLocalVariables([]);
+  setMockVariableCollections([]);
+});
+
+describe('readLocalVariableMap — the name→Variable join', () => {
+  it('keys the file\'s local variables by name', async () => {
+    const primary = makeMockVariable('color.primary');
+    const gap = makeMockVariable('space.md', 'FLOAT');
+    setMockLocalVariables([primary, gap]);
+
+    const map = await readLocalVariableMap();
+
+    expect(map.get('color.primary')).toBe(primary);
+    expect(map.get('space.md')).toBe(gap);
+    expect(map.size).toBe(2);
+  });
+
+  it('keeps the FIRST of a duplicated name (deterministic, as Figma permits dupes)', async () => {
+    const first = makeMockVariable('color.primary');
+    const second = makeMockVariable('color.primary');
+    setMockLocalVariables([first, second]);
+
+    expect((await readLocalVariableMap()).get('color.primary')).toBe(first);
+  });
+
+  it('never mints a variable — the file\'s local list is untouched', async () => {
+    const before: FakeVariable[] = [makeMockVariable('color.primary')];
+    setMockLocalVariables(before);
+
+    await resolveTokenVars(NO_TOKENS);
+
+    expect(await figma.variables.getLocalVariablesAsync()).toHaveLength(1);
+  });
+});
+
+describe('rebuild from spec alone — bindings REATTACH by name (the P6 gap)', () => {
+  it('binds a FRAME fill tokenRef to the existing variable, with NO payload tokens', async () => {
+    const primary = makeMockVariable('color.primary');
+    setMockLocalVariables([primary]);
+
+    const frame = await rebuildFromSpecAlone({
+      type: 'FRAME', name: 'Card', width: 100, height: 50,
+      fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0, a: 1 } }],
+      tokenRefs: { fill: 'color.primary' },
+    });
+
+    // The binding the pre-P6 gate dropped on the floor.
+    expect(paintAliasOf(frame, 'fills')).toBe(primary.id);
+    expect(getImportWarnings()).toEqual([]);
+  });
+
+  it('binds scalar refs (radius → cornerRadius, gap → itemSpacing)', async () => {
+    const radius = makeMockVariable('radius.lg', 'FLOAT');
+    const gap = makeMockVariable('space.md', 'FLOAT');
+    setMockLocalVariables([radius, gap]);
+
+    const frame = await rebuildFromSpecAlone({
+      type: 'FRAME', name: 'Card', width: 100, height: 50,
+      layoutMode: 'VERTICAL', itemSpacing: 12, cornerRadius: 8,
+      tokenRefs: { radius: 'radius.lg', gap: 'space.md' },
+    });
+
+    const bound = frame.boundVariables as Record<string, unknown>;
+    expect(aliasOf(bound.cornerRadius)).toBe(radius.id);
+    expect(aliasOf(bound.itemSpacing)).toBe(gap.id);
+  });
+
+  it('binds a uniform padding ref to all four sides', async () => {
+    const pad = makeMockVariable('space.lg', 'FLOAT');
+    setMockLocalVariables([pad]);
+
+    const frame = await rebuildFromSpecAlone({
+      type: 'FRAME', name: 'Card', width: 100, height: 50,
+      layoutMode: 'VERTICAL', paddingTop: 16, paddingRight: 16, paddingBottom: 16, paddingLeft: 16,
+      tokenRefs: { padding: 'space.lg' },
+    });
+
+    const bound = frame.boundVariables as Record<string, unknown>;
+    for (const side of ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft']) {
+      expect(aliasOf(bound[side])).toBe(pad.id);
+    }
+  });
+
+  it('binds a TEXT child\'s textColor ref (the builder recurses with the same map)', async () => {
+    const ink = makeMockVariable('color.ink');
+    setMockLocalVariables([ink]);
+
+    const frame = await rebuildFromSpecAlone({
+      type: 'FRAME', name: 'Card', width: 100, height: 50, layoutMode: 'VERTICAL',
+      children: [{
+        type: 'TEXT', name: 'Title', characters: 'Hello', fontSize: 16,
+        textColor: { r: 1, g: 1, b: 1, a: 1 },
+        tokenRefs: { textColor: 'color.ink' },
+      }],
+    });
+
+    const text = (frame.children as Array<Record<string, unknown>>)[0];
+    expect(paintAliasOf(text, 'fills')).toBe(ink.id);
+  });
+
+  it('binds a RECTANGLE\'s fill ref', async () => {
+    const accent = makeMockVariable('color.accent');
+    setMockLocalVariables([accent]);
+
+    const rect = await rebuildFromSpecAlone({
+      type: 'RECTANGLE', name: 'Swatch', width: 24, height: 24,
+      fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0, a: 1 } }],
+      tokenRefs: { fill: 'color.accent' },
+    });
+
+    expect(paintAliasOf(rect, 'fills')).toBe(accent.id);
+  });
+});
+
+describe('unresolvable ref — honest, not silent (the library/remote edge)', () => {
+  it('warns and keeps the literal fill when NO variable carries the name', async () => {
+    setMockLocalVariables([makeMockVariable('color.other')]);
+
+    const frame = await rebuildFromSpecAlone({
+      type: 'FRAME', name: 'Card', width: 100, height: 50,
+      fills: [{ type: 'SOLID', color: { r: 0.5, g: 0, b: 0, a: 1 } }],
+      tokenRefs: { fill: 'color.fromLibrary' },
+    });
+
+    expect(paintAliasOf(frame, 'fills')).toBeUndefined();
+    // The literal survives — a missed binding degrades, never destroys.
+    // (A Figma paint carries RGB in `color` and alpha in `opacity`.)
+    expect((frame.fills as Array<{ color: unknown }>)[0].color).toEqual({ r: 0.5, g: 0, b: 0 });
+    expect(getImportWarnings().join('\n')).toContain('color.fromLibrary');
+  });
+
+  it('warns rather than crashing when the file has NO variables at all', async () => {
+    setMockLocalVariables([]);
+
+    const frame = await rebuildFromSpecAlone({
+      type: 'FRAME', name: 'Card', width: 100, height: 50,
+      tokenRefs: { fill: 'color.primary' },
+    });
+
+    expect(frame.name).toBe('Card'); // built fine
+    expect(getImportWarnings().join('\n')).toContain('color.primary');
+  });
+});
+
+describe('the pre-P6 flow is untouched (payload tokens stay authoritative)', () => {
+  const TOKENS: FigmaExportTokens = {
+    colors: [{ name: 'color.primary', color: { r: 1, g: 0, b: 0, a: 1 } }],
+    typography: [], spacing: [], radii: [], shadows: [],
+  };
+
+  it('a payload token WINS over a same-named local variable', async () => {
+    const stale = makeMockVariable('color.primary');
+    setMockLocalVariables([stale]);
+
+    const tokenVars = await resolveTokenVars(TOKENS);
+
+    // createVariablesFromTokens minted a variable for the payload's value; the
+    // fallback must not shadow it.
+    expect(tokenVars.get('color.primary')).not.toBe(stale);
+    expect(tokenVars.get('color.primary')?.name).toBe('color.primary');
+  });
+
+  it('a payload token still binds when the file had no variable (P3 leg B intact)', async () => {
+    setMockLocalVariables([]);
+    const tokenVars = await resolveTokenVars(TOKENS);
+
+    const node = await createFigmaNode(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {
+        type: 'FRAME', name: 'Card', width: 100, height: 50,
+        fills: [{ type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 1 } }],
+        tokenRefs: { fill: 'color.primary' },
+      } as any,
+      new Map(),
+      tokenVars as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    );
+
+    expect(paintAliasOf(node as unknown as Record<string, unknown>, 'fills'))
+      .toBe(tokenVars.get('color.primary')?.id);
+  });
+
+  it('empty tokens mint NO collection (a rebuild asks for none)', async () => {
+    setMockLocalVariables([]);
+    await resolveTokenVars(NO_TOKENS);
+
+    expect(await figma.variables.getLocalVariableCollectionsAsync()).toEqual([]);
+  });
+});


### PR DESCRIPTION
The emitter half of the mirror's binding contract — the counterpart to what `mirror-verify` lints (Art II). Closes the Art III gap the P5 harness exposed.

## The gap

A scanned spec records its bindings as token **names** (`scan-token-refs.bindingsToTokenRefs`). But the build path's only name→Variable map came from `payload.tokens`, via `createVariablesFromTokens`. A rebuild **from a sidecar spec alone** carries no tokens ⇒ that map came back empty ⇒ `applyTokenRefs` was gated off ⇒ every tokenRef silently lost its binding.

P1's "binding survives" was true only inside the harness: `scan-node-fixed-point`'s `roundTrips` hands the builder the token collection by hand. A green fixture suite could not see this — exactly the class of miss `CLAUDE.md` warns about ("every phase budgets one run on real data").

Verified while implementing: the gate was at **three** call sites (frame, shapes, text), not just `executor-frame`.

## The fix

- **`executor-token-var-resolve.ts`** (new) — reads the file's local variables **once** and keys them by name, the inverse of the scanner's id→name join. `resolveTokenVars` overlays payload tokens on top of that map.
- **Precedence is payload-over-local on purpose**: a caller shipping tokens is byte-identical to pre-P6; the name lookup can only fill names the payload never spoke for.
- **Never mints a variable.** `createVariablesFromTokens` de-dups by *value*, so feeding it synthesised tokens to force a map would breed duplicate variables in the owner's file whenever a value drifted. The fallback only ever binds to what already exists.
- **Gate relaxed to `tokenRefs` alone** at all three sites — an empty map now still reaches `applyTokenRefs`, whose existing miss branch warns. An unresolvable ref (library/remote variable) degrades honestly instead of vanishing; the literal value stays.

## Proof (offline, and it has teeth)

`tests/token-var-reattach.test.ts` withholds `payload.tokens` and asserts against variables the file already has — the state a real rebuild runs in. Repointed at the pre-P6 behaviour, **all five reattach tests fail**; with the fix they pass.

`scan-node-fixed-point` gains the assertion it structurally could not make before: the round trip stays a fixed point when the rebuild is handed **no tokens**, resolving through the production path rather than a hand-fed map.

## Verify

- 4 BARE gates green (root: typecheck, lint, build, test 1890)
- figma-agent: typecheck + build green, suite **281 → 295**
- `plugin/code.js` rebuilt and committed (fix lives in `plugin/src`)

Not merged — for review.