### PR TITLE
fix: pair set-shaped arrays by name in the mirror diff (spec 005 P16 edge A)

### DIFF
--- a/figma-agent/cli/src/util/structural-diff-keyed.ts
+++ b/figma-agent/cli/src/util/structural-diff-keyed.ts
@@ -1,0 +1,75 @@
+// The mirror linter's ALIGNMENT layer (spec-005 P16) — how structural-diff decides
+// that two arrays are two views of the SAME set, and pairs their members up by name
+// instead of by position.
+//
+// THE BUG THIS CLOSES. `innerOverrides` and `figmaScanInnerOverrides` are SETS that
+// happen to be serialised as sorted arrays: an instance's inner overrides, keyed by
+// childKey, and the field names those overrides touch. Compared by INDEX, one missing
+// member shifts every later member by one and each shift is reported as a diff —
+// so the live gate on node 25579:749755 reported 43 diffs for 5 real ones, and the
+// real ones were unreadable underneath a cascade of "[6].childKey: A vs B" noise
+// that named two entirely different children.
+//
+// THE RULE — and it is what makes this safe to put in a schema-agnostic linter:
+// alignment only changes HOW a difference is REPORTED, never WHETHER there is one.
+// Both predicates below demand a STRICTLY ASCENDING key sequence on BOTH sides, and
+// under that precondition:
+//   - a sorted, duplicate-free array is the unique canonical form of its key set, so
+//     `keys(a) === keys(b)` elementwise IFF `set(a) === set(b)`;
+//   - therefore when the key sets match, keyed pairing IS index pairing, member for
+//     member — the identical comparison;
+//   - and when they do not, both schemes report unequal. Keyed just says WHICH member
+//     is missing rather than smearing the shift across the tail.
+// So `equal` is provably unchanged for every input. An array that is not strictly
+// ascending (an ordered one — `children`, `fills`, `effects`) fails the guard and
+// keeps positional comparison, which is the semantics it needs: for those, position
+// IS the identity.
+
+/** A plain object — same stance as structural-diff (walks JSON, not the type). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** True when `keys` is strictly ascending — which also proves it duplicate-free. */
+function strictlyAscending(keys: string[]): boolean {
+  for (let i = 1; i < keys.length; i++) if (!(keys[i - 1] < keys[i])) return false;
+  return true;
+}
+
+/**
+ * An array of `{childKey, …}` entries in strictly-ascending childKey order — the
+ * shape `readInnerOverrides` emits (it builds from a Map and sorts by childKey, so a
+ * real scan always qualifies).
+ *
+ * Recognised by SHAPE, not by field name at a known path: the linter stays
+ * schema-agnostic, and any future keyed collection the walker adds is aligned the day
+ * it appears.
+ */
+export function innerOverrideKeys(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const keys: string[] = [];
+  for (const e of v) {
+    if (!isPlainObject(e) || typeof e.childKey !== 'string') return undefined;
+    keys.push(e.childKey);
+  }
+  return strictlyAscending(keys) ? keys : undefined;
+}
+
+/**
+ * An array of strings in strictly-ascending order — a SET the walker serialised
+ * sorted (`figmaScanInnerOverrides`, `figmaScanUnbindable`, …).
+ *
+ * A string array whose order is meaningful is not ascending in general, so it falls
+ * through to positional comparison; and in the case where it happens to be, the proof
+ * in the header says the verdict is the same either way.
+ */
+export function stringSetMembers(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  for (const e of v) if (typeof e !== 'string') return undefined;
+  return strictlyAscending(v as string[]) ? (v as string[]) : undefined;
+}
+
+/** Every key present on either side, in one deterministic (sorted) order. */
+export function unionKeys(a: string[], b: string[]): string[] {
+  return [...new Set([...a, ...b])].sort();
+}

--- a/figma-agent/cli/src/util/structural-diff.ts
+++ b/figma-agent/cli/src/util/structural-diff.ts
@@ -16,6 +16,15 @@
 //    `{fills: undefined}` are the same spec.
 //  - Object keys are visited SORTED, so the diff list is deterministic (the same
 //    two specs always produce byte-identical output — Art VI).
+//  - An array is compared POSITIONALLY unless it is provably a SET serialised in
+//    sorted order, in which case its members are paired by NAME (spec-005 P16 — see
+//    structural-diff-keyed for the shape rules and the proof that this cannot change
+//    the verdict, only the report). Without it one missing member of `innerOverrides`
+//    shifted the whole tail and turned 5 real diffs into 43.
+
+import {
+  innerOverrideKeys, stringSetMembers, unionKeys,
+} from './structural-diff-keyed.ts';
 
 /** One field that did not survive the round-trip. */
 export interface StructuralDiffEntry {
@@ -47,6 +56,49 @@ function numbersEqual(a: number, b: number): boolean {
   return Math.abs(a - b) <= FLOAT_EPSILON;
 }
 
+/**
+ * Pair two arrays by NAME when both are provably sets in sorted order; returns false
+ * (comparison untouched) otherwise, so the caller falls through to positional.
+ *
+ * No `length` entry is emitted here on purpose: a member that is missing is already
+ * reported AT ITS OWN KEY, which says strictly more than a count does. The two
+ * together would be the cascade this rule exists to remove, just shorter.
+ */
+function walkAsSet(a: unknown[], b: unknown[], path: string, out: StructuralDiffEntry[]): boolean {
+  const keysA = innerOverrideKeys(a);
+  const keysB = innerOverrideKeys(b);
+  if (keysA && keysB) {
+    const byKey = (arr: unknown[], keys: string[]) =>
+      new Map(keys.map((k, i) => [k, arr[i]]));
+    const ma = byKey(a, keysA);
+    const mb = byKey(b, keysB);
+    for (const key of unionKeys(keysA, keysB)) {
+      walk(ma.get(key), mb.get(key), `${path}[childKey=${key}]`, out);
+    }
+    return true;
+  }
+
+  const setA = stringSetMembers(a);
+  const setB = stringSetMembers(b);
+  if (setA && setB) {
+    const inA = new Set(setA);
+    const inB = new Set(setB);
+    for (const member of unionKeys(setA, setB)) {
+      // Membership is the only thing a string set can differ in — the member IS its
+      // own value, so a present/absent pair is the whole story.
+      if (inA.has(member) !== inB.has(member)) {
+        out.push({
+          path: `${path}[${member}]`,
+          left: inA.has(member) ? member : undefined,
+          right: inB.has(member) ? member : undefined,
+        });
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 function walk(a: unknown, b: unknown, path: string, out: StructuralDiffEntry[]): void {
   if (a === undefined && b === undefined) return;
 
@@ -56,6 +108,7 @@ function walk(a: unknown, b: unknown, path: string, out: StructuralDiffEntry[]):
   }
 
   if (Array.isArray(a) && Array.isArray(b)) {
+    if (walkAsSet(a, b, path, out)) return;
     if (a.length !== b.length) {
       out.push({ path: joinPath(path, 'length'), left: a.length, right: b.length });
     }

--- a/figma-agent/tests/instance-inner-fill-sizing.test.ts
+++ b/figma-agent/tests/instance-inner-fill-sizing.test.ts
@@ -180,7 +180,8 @@ describe('spec-005 P14 — the mirror normalizer', () => {
     );
     expect(equal).toBe(false);
     expect(diffs).toEqual([
-      { path: 'innerOverrides[0].figmaScanFillSize.height', left: 836, right: 700 },
+      // Addressed by childKey, not by position — see structural-diff-keyed (P16).
+      { path: 'innerOverrides[childKey=25575:353482].figmaScanFillSize.height', left: 836, right: 700 },
     ]);
   });
 
@@ -192,6 +193,6 @@ describe('spec-005 P14 — the mirror normalizer', () => {
     const { equal, diffs } = diffNormalized(a, rebuilt({ width: 1108, height: 836 }));
     expect(equal).toBe(false);
     expect(diffs.some((d) => d.path.includes('figmaScanInnerOverrides'))).toBe(true);
-    expect(diffs.some((d) => d.path === 'innerOverrides[0].fields.height')).toBe(true);
+    expect(diffs.some((d) => d.path === 'innerOverrides[childKey=25575:353482].fields.height')).toBe(true);
   });
 });

--- a/figma-agent/tests/structural-diff-keyed.test.ts
+++ b/figma-agent/tests/structural-diff-keyed.test.ts
@@ -1,0 +1,114 @@
+// spec-005 P16, Edge A — the mirror linter pairs SET-shaped arrays by NAME.
+//
+// The live gate on node 25579:749755 reported 43 diffs for 5 real ones: the rebuild
+// was missing 4 of the original's 16 `innerOverrides`, and index-pairing smeared that
+// shift across the whole tail — `innerOverrides[6].childKey: <childA> vs <childB>`,
+// comparing two entirely different children and calling it a lost round-trip.
+//
+// The claim these tests defend is narrow and total: keyed pairing changes WHICH path
+// a difference is reported at, and NEVER whether there is one. So every test here
+// comes in a pair — one that the report got sharper, one that nothing got forgiven.
+import { describe, it, expect } from 'vitest';
+import { structuralDiff } from '../cli/src/util/structural-diff.ts';
+
+const entry = (childKey: string, fields: Record<string, unknown> = {}) => ({ childKey, fields });
+
+describe('spec-005 P16 — innerOverrides pair by childKey, not by index', () => {
+  it('reports ONE diff per missing member instead of a cascade down the tail', () => {
+    // The live shape, shrunk: the rebuild lost the FIRST member, so every later
+    // member sits one index early. Index-pairing called all four of those a diff.
+    const a = { innerOverrides: [entry('a:1'), entry('b:2'), entry('c:3'), entry('d:4')] };
+    const b = { innerOverrides: [entry('b:2'), entry('c:3'), entry('d:4')] };
+    const { equal, diffs } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    expect(diffs).toEqual([
+      { path: 'innerOverrides[childKey=a:1]', left: entry('a:1'), right: undefined },
+    ]);
+  });
+
+  it('names the member the REBUILD invented, too — the loss is not one-directional', () => {
+    const a = { innerOverrides: [entry('b:2')] };
+    const b = { innerOverrides: [entry('a:1'), entry('b:2')] };
+    expect(structuralDiff(a, b).diffs).toEqual([
+      { path: 'innerOverrides[childKey=a:1]', left: undefined, right: entry('a:1') },
+    ]);
+  });
+
+  it('still descends INTO a member that is present on both sides but changed', () => {
+    // The whole point of forgiving nothing: pairing by name must not skip the compare.
+    const a = { innerOverrides: [entry('a:1'), entry('b:2', { name: 'Old' })] };
+    const b = { innerOverrides: [entry('a:1'), entry('b:2', { name: 'New' })] };
+    expect(structuralDiff(a, b).diffs).toEqual([
+      { path: 'innerOverrides[childKey=b:2].fields.name', left: 'Old', right: 'New' },
+    ]);
+  });
+
+  it('reports equal for the same members — and pairing is what makes that true', () => {
+    const members = [entry('a:1', { width: 10 }), entry('b:2', { name: 'X' })];
+    const res = structuralDiff({ innerOverrides: members }, { innerOverrides: structuredClone(members) });
+    expect(res).toEqual({ equal: true, diffs: [] });
+  });
+
+  it('falls back to POSITIONAL when the keys are not strictly ascending', () => {
+    // The guard that makes this provably verdict-preserving: an unsorted array is not
+    // a set the walker serialised, so it keeps the semantics it had. Whatever the
+    // paths, the verdict is the one index-pairing gives.
+    const a = { innerOverrides: [entry('b:2'), entry('a:1')] };
+    const b = { innerOverrides: [entry('a:1'), entry('b:2')] };
+    const { equal, diffs } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    expect(diffs.every((d) => /innerOverrides\[\d+\]/.test(d.path))).toBe(true);
+  });
+
+  it('leaves an ORDERED array of objects alone — children keep comparing by position', () => {
+    // No childKey → not a keyed set. `children` is the tree; index IS identity there,
+    // and a reordered tree is a real loss the gate must keep reporting.
+    const a = { children: [{ type: 'TEXT', name: 'A' }, { type: 'TEXT', name: 'B' }] };
+    const b = { children: [{ type: 'TEXT', name: 'B' }, { type: 'TEXT', name: 'A' }] };
+    const { equal, diffs } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    expect(diffs).toEqual([
+      { path: 'children[0].name', left: 'A', right: 'B' },
+      { path: 'children[1].name', left: 'B', right: 'A' },
+    ]);
+  });
+});
+
+describe('spec-005 P16 — a sorted string array is a SET, compared by membership', () => {
+  it('names the ONE missing field name instead of shifting the tail', () => {
+    // The live figmaScanInnerOverrides: the rebuild registered no `effects` override,
+    // and index-pairing turned that single absence into 7 diffs.
+    const a = { figmaScanInnerOverrides: ['effects', 'fills', 'name', 'visible'] };
+    const b = { figmaScanInnerOverrides: ['fills', 'name', 'visible'] };
+    const { equal, diffs } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    expect(diffs).toEqual([
+      { path: 'figmaScanInnerOverrides[effects]', left: 'effects', right: undefined },
+    ]);
+  });
+
+  it('reports a member the rebuild added that the original never had', () => {
+    const a = { figmaScanInnerOverrides: ['fills'] };
+    const b = { figmaScanInnerOverrides: ['fills', 'visible'] };
+    expect(structuralDiff(a, b).diffs).toEqual([
+      { path: 'figmaScanInnerOverrides[visible]', left: undefined, right: 'visible' },
+    ]);
+  });
+
+  it('reports equal for identical sets', () => {
+    const set = ['effects', 'fills', 'name'];
+    expect(structuralDiff({ f: set }, { f: [...set] })).toEqual({ equal: true, diffs: [] });
+  });
+
+  it('keeps an ORDERED string array positional — a font stack is not a set', () => {
+    const a = { fontStack: ['Inter', 'Arial'] };
+    const b = { fontStack: ['Arial', 'Inter'] };
+    const { equal, diffs } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    // Not ascending on the left → positional, so the reorder still reads as a diff.
+    expect(diffs).toEqual([
+      { path: 'fontStack[0]', left: 'Inter', right: 'Arial' },
+      { path: 'fontStack[1]', left: 'Arial', right: 'Inter' },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

`structuralDiff` now pairs SET-shaped arrays by NAME instead of by index.

`innerOverrides` (keyed by `childKey`) and `figmaScanInnerOverrides` (field names) are sets the walker serialises sorted. Compared positionally, one member the rebuild did not register shifted the whole tail and every shift was reported as a lost round-trip.

Live on node **25579:749755**: **43 diffs → 8**, twice. All 12 shared childKeys were byte-identical — the entire remainder was cascade. The noise also actively misled: `innerOverrides[6].childKey: <childA> vs <childB>` compared two different children purely because they sat at the same index.

## Why it cannot regress the gate

Both predicates demand a **strictly-ascending key sequence on both sides**. Under that precondition a sorted duplicate-free array is the unique canonical form of its key set, so:

- key sets match → keyed pairing *is* index pairing, member for member;
- key sets differ → both schemes report unequal.

So `equal` is provably unchanged for every input; only the reported path gets sharper. Arrays that are not strictly ascending (`children`, `fills`, `effects`) keep positional comparison — there, position IS identity. Tests cover both directions.

## Verify

- 4 BARE gates green (typecheck, lint, build, test 1890).
- figma-agent: typecheck + build + test **384** (374 + 10 new).
- Live DS regress, all `equal:true`: `25575:353653`, `25579:376846`, `25575:353516`. `353653` needed a second run — the known font-load race (`textAutoResize failed`, warning attached), not a regression.
- `plugin/code.js` unchanged: this is CLI-side only, the walker is untouched.

## Edge B is NOT in this PR — its premise broke on live evidence

See the report on the task. Two findings block it:

1. **The two specs cannot prove value-identity.** The residual is 4–6 *missing* `innerOverrides` entries. Figma does not flag those children on the rebuild, so the rebuild's spec carries **no record of them at all** — there is no right-hand value to compare against. An honest Edge B needs a two-sided **witness** (a walker/protocol change), not a CLI normalize.
2. **A bound paint's literal is mode-dependent.** Probe on the twin: child `…;5198:1124` has the *identical* binding (`VariableID:5140:17717`) on both sides, but resolves to `r=0` on the original and `r=0.0392` on the rebuild — the rebuild sits in a different variable-mode context. A literal-equality rule would call that real loss. It is not.

Live probe of all 6 residual children: **every reproducible value byte-identical on both sides; only `overriddenFields` differs** (original has the was-SET flag, rebuild has none) — confirming the P16 class, and confirming that the honest fix is a witness, not a blind forgive.