### PR TITLE
fix: stop diffing a bound value's literal, which is only its mode projection (spec 005 P17)

### DIFF
--- a/figma-agent/cli/src/commands/mirror-verify.ts
+++ b/figma-agent/cli/src/commands/mirror-verify.ts
@@ -49,10 +49,11 @@ export interface MirrorVerifyResult {
   keptRebuild: boolean;
   /** The rebuild's own import warnings (bindings skipped, main lost, …). */
   warnings: string[];
-  /** Everything dropped before the diff, said out loud: the root's absolute
-   * position (normalizeForDiff) plus each binding Figma itself refuses to replay
-   * (util/mirror-normalize). A reader must never have to guess what `equal: true`
-   * forgave. */
+  /** Everything the verdict looked past, said out loud: the root's absolute position
+   * (normalizeForDiff), each binding Figma itself refuses to replay
+   * (util/mirror-normalize), and each bound literal that is only a mode projection
+   * (util/structural-diff-bound-projection). A reader must never have to guess what
+   * `equal: true` forgave. */
   normalized: string[];
 }
 
@@ -124,7 +125,7 @@ export async function execute(
   //    and every one of them is reported below. See util/mirror-normalize.
   const clean = (spec: ScannedSpec): ScannedSpec =>
     stripUnreproducibleInnerFields(stripUnbindableBindings(normalizeForDiff(spec)));
-  const { equal, diffs } = structuralDiff(clean(specA), clean(specB));
+  const { equal, diffs, normalized } = structuralDiff(clean(specA), clean(specB));
   return {
     nodeId,
     rebuiltId,
@@ -137,6 +138,9 @@ export async function execute(
       ...NORMALIZED_FIELDS,
       ...unbindableNotes(specA),
       ...unreproducibleInnerNotes(specA),
+      // The diff's own concession (P17): a bound literal it read as a projection, and
+      // only where the two scans' literals actually diverged.
+      ...normalized,
     ],
   };
 }

--- a/figma-agent/cli/src/util/structural-diff-bound-projection.ts
+++ b/figma-agent/cli/src/util/structural-diff-bound-projection.ts
@@ -1,0 +1,140 @@
+// The mirror linter's PROJECTION layer (spec-005 P17) — why a BOUND value's literal
+// is not data, and must not be diffed.
+//
+// THE BUG THIS CLOSES (live, probed on the P16 gate). The inner child `…;5198:1124`
+// carries a paint bound to `VariableID:5140:17717` (`base/sidebar-foreground`). The
+// binding is IDENTICAL on both sides — the round-trip carried it perfectly. Yet the
+// literal colour the two scans recorded differs (`r=0` on the original, `r=0.0392` on
+// the rebuild), because the rebuild sits in a different variable-MODE context and a
+// bound value resolves per mode. The diff called that data loss. It is the opposite:
+// the one field that WAS carried is the one it flagged.
+//
+// THE RULE. For a field whose binding MATCHES on both sides, the literal is only the
+// projection of that binding into whichever mode the scan happened to run in — so the
+// binding is compared (it always was: `figmaScanBindings` / `keyedBindings` are fields
+// like any other) and the literal is not. Every other case keeps the literal, because
+// there the literal IS the data:
+//   - unbound on both sides            → literal compared (the only record there is)
+//   - bound on one side only           → binding lost/gained → the diff stands
+//   - bound both sides, DIFFERENT ids  → a different variable → the diff stands
+// The gate never got quieter by forgetting a field: it stopped reading a projection as
+// a fact.
+//
+// AND IT IS SAID OUT LOUD. Every skipped literal that ACTUALLY differed is reported in
+// the diff's `normalized` list, by path, with the binding that made it a projection —
+// so `equal: true` never hides a colour change (see structural-diff).
+//
+// WHAT THIS DELIBERATELY DOES NOT DO: a multi-paint `fills` array. The walker records
+// ONE binding per field (`readBindings` takes the first bound paint's colour), so with
+// two paints nothing in the spec says WHICH one it names — and skipping both literals
+// could forgive a real loss on the unbound sibling. Those keep positional literal
+// comparison: a false red is a bug report, a false green is a lie.
+
+/** A plain object — same stance as structural-diff (walks JSON, not the type). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+const asRec = (v: unknown): Record<string, unknown> | undefined =>
+  (isPlainObject(v) ? v : undefined);
+
+/** `path` + a key, honouring the root case (no leading dot) — mirrors structural-diff. */
+const joinPath = (path: string, key: string): string => (path ? `${path}.${key}` : key);
+
+/** Paint arrays: bound through the paint's own `boundVariables.color`, not the node's. */
+const PAINT_FIELDS = ['fills', 'strokes'];
+
+/** The publish key the walker resolved for `field`, if it reached the variable. */
+function keyOf(spec: Record<string, unknown>, field: string): string | undefined {
+  const key = asRec(asRec(spec.keyedBindings)?.[field])?.key;
+  return typeof key === 'string' && key ? key : undefined;
+}
+
+/** The raw variable id the walker read off `field` — present for every binding. */
+function idOf(spec: Record<string, unknown>, field: string): string | undefined {
+  const id = asRec(spec.figmaScanBindings)?.[field];
+  return typeof id === 'string' && id ? id : undefined;
+}
+
+/**
+ * How the two sides' bindings on `field` agree, as a human-readable identity — or
+ * undefined when they do not agree, or when either side is unbound.
+ *
+ * The publish KEY is asked first because it survives the join the rebuild does (a
+ * variable imported by key into another file gets a NEW id but keeps its key), and
+ * the raw id answers for every binding the walker could not resolve to a key. An
+ * unbound side never matches, which is the whole guard: only a binding that provably
+ * travelled makes its literal a projection.
+ */
+function matchingBinding(
+  a: Record<string, unknown>, b: Record<string, unknown>, field: string,
+): string | undefined {
+  const ka = keyOf(a, field);
+  const kb = keyOf(b, field);
+  if (ka && kb) return ka === kb ? `the variable published as ${ka}` : undefined;
+  const ia = idOf(a, field);
+  const ib = idOf(b, field);
+  if (ia && ib) return ia === ib ? ia : undefined;
+  return undefined;
+}
+
+const typeOf = (paint: unknown): unknown => asRec(paint)?.type;
+
+/** Skippable iff exactly one paint per side and both SOLID — see the header. */
+function soleSolidPaint(a: unknown, b: unknown): boolean {
+  return Array.isArray(a) && Array.isArray(b) && a.length === 1 && b.length === 1
+    && typeOf(a[0]) === 'SOLID' && typeOf(b[0]) === 'SOLID';
+}
+
+const isLiteral = (v: unknown): boolean =>
+  typeof v === 'number' || typeof v === 'string' || typeof v === 'boolean';
+
+export interface ProjectedPath {
+  /** Absolute JSON path of the literal that is only a projection. */
+  path: string;
+  /** The binding that makes it one — quoted back in the `normalized` note. */
+  binding: string;
+}
+
+/**
+ * Every literal under `a`/`b` that is a mode projection of a binding both sides share,
+ * as absolute paths for the caller to skip.
+ *
+ * Works on ANY object carrying a binding record — a scanned node (`figmaScanBindings`)
+ * and an inner child's overridden visual layer (`keyedBindings` only) are the same
+ * shape to this rule, so neither is special-cased.
+ */
+export function boundProjectedPaths(
+  a: unknown, b: unknown, path: string,
+): ProjectedPath[] {
+  const specA = asRec(a);
+  const specB = asRec(b);
+  if (!specA || !specB) return [];
+  const out: ProjectedPath[] = [];
+
+  for (const field of PAINT_FIELDS) {
+    const binding = matchingBinding(specA, specB, field);
+    if (!binding) continue;
+    if (!soleSolidPaint(specA[field], specB[field])) continue;
+    out.push({ path: `${joinPath(path, field)}[0].color`, binding });
+    // TEXT's `textColor` is the walker's own copy of `fills[0].color` (scan-node-text),
+    // so it is the same projection read twice — forgiving one and not the other would
+    // leave the identical false red on every bound TEXT node.
+    if (field === 'fills' && asRec(specA.textColor) && asRec(specB.textColor)) {
+      out.push({ path: joinPath(path, 'textColor'), binding });
+    }
+  }
+
+  // Scalar bindings (cornerRadius, itemSpacing, padding…) resolve per mode by the same
+  // mechanism, and their binding names the field 1:1 — no "which paint" ambiguity to
+  // guard against, so the same rule applies with no extra condition.
+  const bound = asRec(specA.figmaScanBindings) ?? {};
+  for (const field of Object.keys(bound).sort()) {
+    if (PAINT_FIELDS.includes(field)) continue;
+    if (!isLiteral(specA[field]) || !isLiteral(specB[field])) continue;
+    const binding = matchingBinding(specA, specB, field);
+    if (!binding) continue;
+    out.push({ path: joinPath(path, field), binding });
+  }
+  return out;
+}

--- a/figma-agent/cli/src/util/structural-diff.ts
+++ b/figma-agent/cli/src/util/structural-diff.ts
@@ -21,10 +21,15 @@
 //    structural-diff-keyed for the shape rules and the proof that this cannot change
 //    the verdict, only the report). Without it one missing member of `innerOverrides`
 //    shifted the whole tail and turned 5 real diffs into 43.
+//  - The literal of a value BOUND to the same variable on both sides is not compared:
+//    it is that binding's projection into the scan's current variable mode, not data
+//    (spec-005 P17 — see structural-diff-bound-projection). Every skipped literal that
+//    actually differed is reported in `normalized`, so this never buys silence.
 
 import {
   innerOverrideKeys, stringSetMembers, unionKeys,
 } from './structural-diff-keyed.ts';
+import { boundProjectedPaths } from './structural-diff-bound-projection.ts';
 
 /** One field that did not survive the round-trip. */
 export interface StructuralDiffEntry {
@@ -37,6 +42,20 @@ export interface StructuralDiffEntry {
 export interface StructuralDiffResult {
   equal: boolean;
   diffs: StructuralDiffEntry[];
+  /**
+   * Literals that were NOT compared because they are a shared binding's mode
+   * projection (P17) AND that do differ between the two scans — one line per path, so
+   * a reader can see exactly what `equal: true` looked past and why.
+   */
+  normalized: string[];
+}
+
+/** The walk's accumulators — one per structuralDiff call, never shared. */
+interface Ctx {
+  diffs: StructuralDiffEntry[];
+  notes: string[];
+  /** Absolute path → the binding that makes the literal there a projection. */
+  projected: Map<string, string>;
 }
 
 /** Float tolerance — matches the fixed-point test's `toBeCloseTo(x, 5)`. */
@@ -64,7 +83,7 @@ function numbersEqual(a: number, b: number): boolean {
  * reported AT ITS OWN KEY, which says strictly more than a count does. The two
  * together would be the cascade this rule exists to remove, just shorter.
  */
-function walkAsSet(a: unknown[], b: unknown[], path: string, out: StructuralDiffEntry[]): boolean {
+function walkAsSet(a: unknown[], b: unknown[], path: string, ctx: Ctx): boolean {
   const keysA = innerOverrideKeys(a);
   const keysB = innerOverrideKeys(b);
   if (keysA && keysB) {
@@ -73,7 +92,7 @@ function walkAsSet(a: unknown[], b: unknown[], path: string, out: StructuralDiff
     const ma = byKey(a, keysA);
     const mb = byKey(b, keysB);
     for (const key of unionKeys(keysA, keysB)) {
-      walk(ma.get(key), mb.get(key), `${path}[childKey=${key}]`, out);
+      walk(ma.get(key), mb.get(key), `${path}[childKey=${key}]`, ctx);
     }
     return true;
   }
@@ -87,7 +106,7 @@ function walkAsSet(a: unknown[], b: unknown[], path: string, out: StructuralDiff
       // Membership is the only thing a string set can differ in — the member IS its
       // own value, so a present/absent pair is the whole story.
       if (inA.has(member) !== inB.has(member)) {
-        out.push({
+        ctx.diffs.push({
           path: `${path}[${member}]`,
           left: inA.has(member) ? member : undefined,
           right: inB.has(member) ? member : undefined,
@@ -99,33 +118,54 @@ function walkAsSet(a: unknown[], b: unknown[], path: string, out: StructuralDiff
   return false;
 }
 
-function walk(a: unknown, b: unknown, path: string, out: StructuralDiffEntry[]): void {
+/**
+ * Report a projection that was skipped — but ONLY when the two literals really do
+ * differ, so the `normalized` list stays a record of what was forgiven rather than an
+ * inventory of every bound field on the node. The re-walk runs with an empty context:
+ * it asks the plain question "are these two literals equal?", and its findings are
+ * thrown away either way.
+ */
+function noteProjection(a: unknown, b: unknown, path: string, binding: string, ctx: Ctx): void {
+  const probe: Ctx = { diffs: [], notes: [], projected: new Map() };
+  walk(a, b, path, probe);
+  if (!probe.diffs.length) return;
+  ctx.notes.push(`${path} — bound to ${binding} on both sides; a bound value's literal is only its projection into the scan's current variable mode, so the two differ while the data — the binding — is identical`);
+}
+
+function walk(a: unknown, b: unknown, path: string, ctx: Ctx): void {
   if (a === undefined && b === undefined) return;
 
+  const binding = ctx.projected.get(path);
+  if (binding !== undefined) {
+    noteProjection(a, b, path, binding, ctx);
+    return;
+  }
+
   if (typeof a === 'number' && typeof b === 'number') {
-    if (!numbersEqual(a, b)) out.push({ path, left: a, right: b });
+    if (!numbersEqual(a, b)) ctx.diffs.push({ path, left: a, right: b });
     return;
   }
 
   if (Array.isArray(a) && Array.isArray(b)) {
-    if (walkAsSet(a, b, path, out)) return;
+    if (walkAsSet(a, b, path, ctx)) return;
     if (a.length !== b.length) {
-      out.push({ path: joinPath(path, 'length'), left: a.length, right: b.length });
+      ctx.diffs.push({ path: joinPath(path, 'length'), left: a.length, right: b.length });
     }
     const n = Math.max(a.length, b.length);
-    for (let i = 0; i < n; i++) walk(a[i], b[i], `${path}[${i}]`, out);
+    for (let i = 0; i < n; i++) walk(a[i], b[i], `${path}[${i}]`, ctx);
     return;
   }
 
   if (isPlainObject(a) && isPlainObject(b)) {
+    for (const p of boundProjectedPaths(a, b, path)) ctx.projected.set(p.path, p.binding);
     const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
-    for (const key of keys) walk(a[key], b[key], joinPath(path, key), out);
+    for (const key of keys) walk(a[key], b[key], joinPath(path, key), ctx);
     return;
   }
 
   // Primitives, null, and every type mismatch (array↔object, object↔primitive,
   // present↔absent) land here: one comparison, one entry.
-  if (a !== b) out.push({ path, left: a, right: b });
+  if (a !== b) ctx.diffs.push({ path, left: a, right: b });
 }
 
 /**
@@ -133,7 +173,7 @@ function walk(a: unknown, b: unknown, path: string, out: StructuralDiffEntry[]):
  * every field that does, in a deterministic order.
  */
 export function structuralDiff(a: unknown, b: unknown): StructuralDiffResult {
-  const diffs: StructuralDiffEntry[] = [];
-  walk(a, b, '', diffs);
-  return { equal: diffs.length === 0, diffs };
+  const ctx: Ctx = { diffs: [], notes: [], projected: new Map() };
+  walk(a, b, '', ctx);
+  return { equal: ctx.diffs.length === 0, diffs: ctx.diffs, normalized: ctx.notes.sort() };
 }

--- a/figma-agent/tests/structural-diff-bound-projection.test.ts
+++ b/figma-agent/tests/structural-diff-bound-projection.test.ts
@@ -1,0 +1,177 @@
+// spec-005 P17 — a BOUND value's literal is a mode projection, not data.
+//
+// THE LIVE BUG. On the P16 gate, inner child `…;5198:1124` carries a paint bound to
+// `VariableID:5140:17717` (`base/sidebar-foreground`). Both scans recorded the SAME
+// binding — the round-trip carried the only thing that IS the data — yet the literal
+// colours differ (`r=0` original, `r=0.0392` rebuild) because the rebuild resolves the
+// variable in a different MODE. The diff scored a perfect round-trip as data loss. On
+// the DS that never fired (one mode); on VSF-PCP, which uses several, it would.
+//
+// The claim these tests defend is two-sided, and the second half is the load-bearing
+// one: a MATCHING binding makes the literal a projection, and NOTHING ELSE does. Every
+// forgiving test below has a twin that proves the same code still fails the gate when
+// the binding is different, one-sided, or absent — because a literal with no binding
+// behind it is the only record of that colour there is.
+//
+// Shapes here are the walker's real output (plugin/src/main/scan-node-instance.ts,
+// instance-inner-visual.ts): a node carries `figmaScanBindings` (raw id, always) and
+// `keyedBindings` (publish key, when the variable resolved); an inner child's `visual`
+// layer carries `keyedBindings` ONLY. Both must work — the rule reads the object it is
+// given, not a path it expects.
+import { describe, it, expect } from 'vitest';
+import { structuralDiff } from '../cli/src/util/structural-diff.ts';
+
+const VAR_ID = 'VariableID:5140:17717';
+const VAR_KEY = 'e3f0a1c2d4b5';
+
+const solid = (r: number) => ({ type: 'SOLID', color: { r, g: 0, b: 0, a: 1 } });
+
+/** A TEXT node as the walker emits it when its fill is bound: literal + both signals. */
+const boundText = (r: number, over: Record<string, unknown> = {}) => ({
+  type: 'TEXT',
+  name: 'Label',
+  characters: 'Dashboard',
+  fills: [solid(r)],
+  textColor: { r, g: 0, b: 0, a: 1 },
+  figmaScanBindings: { fills: VAR_ID },
+  keyedBindings: { fills: { key: VAR_KEY, name: 'base/sidebar-foreground' } },
+  ...over,
+});
+
+describe('spec-005 P17 — a matching binding makes the paint literal a projection', () => {
+  it('the LIVE case: same binding, different resolved colour → equal, not a diff', () => {
+    const { equal, diffs } = structuralDiff(boundText(0), boundText(0.0392));
+    expect(equal).toBe(true);
+    expect(diffs).toEqual([]);
+  });
+
+  it('says out loud what it looked past — never a silent pass', () => {
+    const { normalized } = structuralDiff(boundText(0), boundText(0.0392));
+    expect(normalized).toEqual([
+      expect.stringContaining('fills[0].color'),
+      expect.stringContaining('textColor'),
+    ]);
+    expect(normalized[0]).toContain(VAR_KEY);
+    expect(normalized[0]).toContain('projection');
+  });
+
+  it('reports NOTHING when the projections happen to agree — the list records what was forgiven, not what is bound', () => {
+    expect(structuralDiff(boundText(0), boundText(0)).normalized).toEqual([]);
+  });
+
+  it('forgives the literal ONLY — a real change next to it still fails the gate', () => {
+    const a = boundText(0);
+    const b = boundText(0.0392, { characters: 'Settings' });
+    const { equal, diffs } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    expect(diffs).toEqual([{ path: 'characters', left: 'Dashboard', right: 'Settings' }]);
+  });
+});
+
+describe('spec-005 P17 — and nothing else is forgiven', () => {
+  it('a DIFFERENT binding is a real diff: the colours differ AND the binding does', () => {
+    const a = boundText(0);
+    const b = boundText(0.0392, {
+      figmaScanBindings: { fills: 'VariableID:1:1' },
+      keyedBindings: { fills: { key: 'other-key', name: 'base/other' } },
+    });
+    const { equal, diffs, normalized } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    expect(normalized).toEqual([]);
+    expect(diffs.map((d) => d.path)).toEqual(expect.arrayContaining([
+      'fills[0].color.r', 'keyedBindings.fills.key', 'textColor.r',
+    ]));
+  });
+
+  it('BOUND on one side, literal on the other is a binding LOST — the reddest case there is', () => {
+    const a = boundText(0);
+    const { fills, textColor, type, name, characters } = a;
+    const b = { type, name, characters, fills: [solid(0.0392)], textColor: { r: 0.0392, g: 0, b: 0, a: 1 } };
+    expect(fills).toBeDefined();
+    expect(textColor).toBeDefined();
+    const { equal, diffs, normalized } = structuralDiff(a, b);
+    expect(equal).toBe(false);
+    expect(normalized).toEqual([]);
+    // Both signals are absent wholesale on the rebuild, so the diff names them at the
+    // record itself — the loss is the binding, and the colour is reported beside it.
+    expect(diffs.map((d) => d.path)).toEqual(expect.arrayContaining([
+      'fills[0].color.r', 'figmaScanBindings', 'keyedBindings',
+    ]));
+  });
+
+  it('UNBOUND on both sides: the literal IS the data, so a different colour is a loss', () => {
+    const bare = (r: number) => ({ type: 'FRAME', name: 'Card', fills: [solid(r)] });
+    const { equal, diffs, normalized } = structuralDiff(bare(0), bare(0.0392));
+    expect(equal).toBe(false);
+    expect(normalized).toEqual([]);
+    expect(diffs).toEqual([{ path: 'fills[0].color.r', left: 0, right: 0.0392 }]);
+  });
+
+  it('a MULTI-paint fills array keeps its literals: nothing says WHICH paint the one binding names', () => {
+    // readBindings records the first bound paint's id for the whole field, so with two
+    // paints the spec cannot prove the overlay is bound too. A false red beats
+    // forgiving a real loss on the unbound sibling.
+    const multi = (r: number) => ({
+      type: 'FRAME',
+      name: 'Card',
+      fills: [solid(r), { type: 'SOLID', color: { r: 1, g: 1, b: 1, a: 0.1 } }],
+      figmaScanBindings: { fills: VAR_ID },
+      keyedBindings: { fills: { key: VAR_KEY } },
+    });
+    const { equal, diffs } = structuralDiff(multi(0), multi(0.0392));
+    expect(equal).toBe(false);
+    expect(diffs).toEqual([{ path: 'fills[0].color.r', left: 0, right: 0.0392 }]);
+  });
+
+  it('a binding with NO shared signal is not a match — an id on one side, a key on the other proves nothing', () => {
+    const a = { type: 'FRAME', name: 'Card', fills: [solid(0)], figmaScanBindings: { fills: VAR_ID } };
+    const b = { type: 'FRAME', name: 'Card', fills: [solid(0.0392)], keyedBindings: { fills: { key: VAR_KEY } } };
+    expect(structuralDiff(a, b).equal).toBe(false);
+  });
+});
+
+describe('spec-005 P17 — the same rule on an inner child, and on scalars', () => {
+  it("an inner child's visual layer is bound by KEY alone, and is forgiven the same way", () => {
+    const inner = (r: number) => ({
+      innerOverrides: [{
+        childKey: '5198:1124',
+        fields: {},
+        visual: {
+          fills: [solid(r)],
+          keyedBindings: { fills: { key: VAR_KEY, name: 'base/sidebar-foreground' } },
+        },
+      }],
+    });
+    const { equal, normalized } = structuralDiff(inner(0), inner(0.0392));
+    expect(equal).toBe(true);
+    expect(normalized).toEqual([
+      expect.stringContaining('innerOverrides[childKey=5198:1124].visual.fills[0].color'),
+    ]);
+  });
+
+  it('a bound SCALAR resolves per mode by the same mechanism, so its literal goes too', () => {
+    const card = (radius: number) => ({
+      type: 'FRAME',
+      name: 'Card',
+      cornerRadius: radius,
+      figmaScanBindings: { cornerRadius: VAR_ID },
+      keyedBindings: { cornerRadius: { key: VAR_KEY, name: 'radius/card' } },
+    });
+    const { equal, normalized } = structuralDiff(card(8), card(12));
+    expect(equal).toBe(true);
+    expect(normalized).toEqual([expect.stringContaining('cornerRadius')]);
+  });
+
+  it('an UNBOUND scalar next to a bound one is still compared — the binding names ONE field', () => {
+    const card = (radius: number, gap: number) => ({
+      type: 'FRAME',
+      name: 'Card',
+      cornerRadius: radius,
+      itemSpacing: gap,
+      figmaScanBindings: { cornerRadius: VAR_ID },
+    });
+    const { equal, diffs } = structuralDiff(card(8, 4), card(12, 16));
+    expect(equal).toBe(false);
+    expect(diffs).toEqual([{ path: 'itemSpacing', left: 4, right: 16 }]);
+  });
+});

--- a/figma-agent/tests/structural-diff-keyed.test.ts
+++ b/figma-agent/tests/structural-diff-keyed.test.ts
@@ -46,7 +46,7 @@ describe('spec-005 P16 — innerOverrides pair by childKey, not by index', () =>
   it('reports equal for the same members — and pairing is what makes that true', () => {
     const members = [entry('a:1', { width: 10 }), entry('b:2', { name: 'X' })];
     const res = structuralDiff({ innerOverrides: members }, { innerOverrides: structuredClone(members) });
-    expect(res).toEqual({ equal: true, diffs: [] });
+    expect(res).toEqual({ equal: true, diffs: [], normalized: [] });
   });
 
   it('falls back to POSITIONAL when the keys are not strictly ascending', () => {
@@ -97,7 +97,7 @@ describe('spec-005 P16 — a sorted string array is a SET, compared by membershi
 
   it('reports equal for identical sets', () => {
     const set = ['effects', 'fills', 'name'];
-    expect(structuralDiff({ f: set }, { f: [...set] })).toEqual({ equal: true, diffs: [] });
+    expect(structuralDiff({ f: set }, { f: [...set] })).toEqual({ equal: true, diffs: [], normalized: [] });
   });
 
   it('keeps an ORDERED string array positional — a font stack is not a set', () => {

--- a/figma-agent/tests/structural-diff.test.ts
+++ b/figma-agent/tests/structural-diff.test.ts
@@ -12,7 +12,7 @@ describe('structuralDiff — equal specs', () => {
       children: [{ type: 'TEXT', name: 'Title', characters: 'Hello', fontSize: 20 }],
     };
     const res = structuralDiff(spec, structuredClone(spec));
-    expect(res).toEqual({ equal: true, diffs: [] });
+    expect(res).toEqual({ equal: true, diffs: [], normalized: [] });
   });
 
   it('treats an explicitly-undefined field as absent (the walker deletes empties)', () => {
@@ -31,6 +31,7 @@ describe('structuralDiff — a single field that lost the round-trip', () => {
     expect(structuralDiff(a, b)).toEqual({
       equal: false,
       diffs: [{ path: 'children[0].characters', left: 'Hello', right: 'Hi' }],
+      normalized: [],
     });
   });
 


### PR DESCRIPTION
## The bug (live-probed, not inferred)

A scan of a bound paint records **two** things: the **binding** — which is the data — and the **literal colour** that binding resolved to, which is only a projection into whichever variable **MODE** the scan ran in. The mirror diff compared both. So a round-trip that carried the binding *perfectly* was scored as data loss the moment the rebuild resolved in a different mode.

Live proof, inside **one** scan of node `25579:749755` — the same published variable, two different literals:

| child | field | literal `r` | binding key |
|---|---|---|---|
| `…5198:1123;5197:2307` | strokes | `0.0392` | `96b0777b13d5…` (`base/sidebar-foreground`) |
| `…5198:1124` | fills | `0.0000` | `96b0777b13d5…` (`base/sidebar-foreground`) |

P16's probe saw the same across the round-trip on `5198:1124`: identical binding both sides, `r=0` original vs `r=0.0392` rebuild. The DS gate passes 9/9 only because it happens to sit in one mode. **VSF-PCP uses several** — this lands before that dogfood.

## The rule

A field whose binding **matches on both sides** has its literal skipped. **Nothing else does** — each of these keeps the literal, because there the literal is the only record of that colour there is:

- unbound on both sides → compared
- bound on one side only → binding lost/gained → red
- bound to a *different* variable → red
- a **multi-paint** `fills` array → compared: the walker records one binding per field, so nothing in the spec proves *which* paint it names. A false red is a bug report; a false green is a lie.

Scalar bindings (`cornerRadius`, `itemSpacing`, …) resolve per mode by the same mechanism and their binding names the field 1:1 — no ambiguity to guard against — so they follow the same rule.

Every skipped literal **that actually differed** is reported in the diff's `normalized` list, by path, with the binding behind it. `equal: true` never buys silence.

## Where the signal comes from

The spec the walker **already** emits: `figmaScanBindings` (raw id, always present) and `keyedBindings` (publish key — preferred, since it survives an import-by-key into another file). An inner child's `visual` layer carries `keyedBindings` only; the rule reads the object it is handed rather than a path it expects, so both work with no special case. **No walker change, no plugin change** (`code.js` untouched).

## Verification

- **figma-agent 396 tests** (12 new), 4 BARE gates green. Every forgiving test has a twin proving the same code still fails on a different / one-sided / absent binding.
- **Live vs a real baseline-main rebuild** — verdicts identical, so nothing regressed and nothing was quietly forgiven: `25579:749755` → 8 diffs both, `25581:1683581` → 96 both.
- **DS regress**: `25575:353653` and `25575:353516` → still `equal:true`, 0 diff, 0 warning, and **zero** P17 entries (same mode → nothing to forgive).

Honest note: P17 fires **0 times** on today's live gate. The pairs where the literal diverges are exactly the 6 inner-override members the rebuild still omits (P16's known 8 residual), so there is no pair to compare literals on yet. This is a correctness fix landing *ahead* of the data that would otherwise turn a perfect round-trip red — the mechanism itself is proven live by the table above.