### PR TITLE
feat: make the panel's activity feed say what the plugin is doing, per operation

### DIFF
--- a/figma-agent/cli/src/commands/create-frame.ts
+++ b/figma-agent/cli/src/commands/create-frame.ts
@@ -3,12 +3,13 @@ import type { CommandArgs } from '../figma-agent.ts';
 import { runCommand } from '../transport/broker-client.ts';
 
 export async function run(args: CommandArgs): Promise<unknown> {
+  const name = args.req('name');
   return runCommand('CREATE_FRAME', {
-    name: args.req('name'),
+    name,
     width: args.num('w'),
     height: args.num('h'),
     parentId: args.str('parent'),
     x: args.num('x'),
     y: args.num('y'),
-  });
+  }, { activity: `Build · ${name}` });
 }

--- a/figma-agent/cli/src/commands/exec-js.ts
+++ b/figma-agent/cli/src/commands/exec-js.ts
@@ -29,5 +29,8 @@ export async function run(args: CommandArgs): Promise<unknown> {
 
   const requested = args.num('timeout') ?? COMMAND_TIMEOUTS.EXEC_JS ?? 30_000;
   const timeoutMs = Math.min(requested, EXEC_JS_MAX_TIMEOUT_MS);
-  return runCommand('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS });
+  // Generic fallback: an ad-hoc script has no intent we can read off it. Named
+  // scan/mirror-verify/build runs label themselves and never reach this line.
+  const activity = !fileArg || fileArg === '-' ? 'Run script' : `Run script · ${fileArg}`;
+  return runCommand('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS, activity });
 }

--- a/figma-agent/cli/src/commands/html-to-figma.ts
+++ b/figma-agent/cli/src/commands/html-to-figma.ts
@@ -24,6 +24,9 @@ export async function run(args: CommandArgs): Promise<unknown> {
   if (!rawHtml.trim()) throw new CliError('E_INVALID_ARGS', 'html input is empty');
 
   const { html, warnings: inlineWarnings } = await inlineImages(rawHtml);
+  // The label names the SOURCE, since HTML_TO_FIGMA's own params carry no name —
+  // main.ts names the import "HTML Import" only once the payload reaches it.
+  const source = !htmlArg || htmlArg === '-' ? 'stdin' : htmlArg;
   const result = (await runCommand('HTML_TO_FIGMA', {
     html,
     width: args.num('width') ?? 1280,
@@ -31,7 +34,7 @@ export async function run(args: CommandArgs): Promise<unknown> {
     y: args.num('y'),
     parentId: args.str('parent'),
     replaceId: args.str('replace'),
-  })) as Record<string, unknown>;
+  }, { activity: `Build · ${source}` })) as Record<string, unknown>;
 
   // Surface CLI-side inlining warnings alongside plugin conversion warnings.
   const pluginWarnings = Array.isArray(result?.warnings) ? (result.warnings as unknown[]) : [];

--- a/figma-agent/cli/src/commands/mirror-verify.ts
+++ b/figma-agent/cli/src/commands/mirror-verify.ts
@@ -89,7 +89,7 @@ export async function execute(
   run: Runner = runCommand,
 ): Promise<MirrorVerifyResult> {
   // 1. Scan the original — the same walker `scan-node` uses, not a copy.
-  const specA = await scanNodeSpec(nodeId, opts.timeoutMs, run);
+  const specA = await scanNodeSpec(nodeId, opts.timeoutMs, run, 'Mirror-verify · scan original');
 
   // 2. Rebuild it from that spec alone. IMPORT_PAYLOAD is registered in the wire
   //    protocol and the UI relay forwards every non-HTML_TO_FIGMA command to the
@@ -105,7 +105,7 @@ export async function execute(
       rootNode: specA,
     },
     parentId: opts.parentId,
-  }, { timeoutMs: COMMAND_TIMEOUTS.IMPORT_PAYLOAD })) as ImportReply | null;
+  }, { timeoutMs: COMMAND_TIMEOUTS.IMPORT_PAYLOAD, activity: 'Mirror-verify · rebuild' })) as ImportReply | null;
 
   const rebuiltId = imported?.id;
   if (!rebuiltId) throw new CliError('E_PLUGIN_ERROR', 'IMPORT_PAYLOAD returned no rebuilt node id');
@@ -114,7 +114,7 @@ export async function execute(
   //    failed verification never leaves scratch on the owner's canvas.
   let specB: ScannedSpec;
   try {
-    specB = await scanNodeSpec(rebuiltId, opts.timeoutMs, run);
+    specB = await scanNodeSpec(rebuiltId, opts.timeoutMs, run, 'Mirror-verify · scan rebuild');
   } finally {
     if (!opts.keep) await removeNode(rebuiltId, opts.timeoutMs, run);
   }
@@ -151,7 +151,7 @@ async function removeNode(id: string, timeoutMs: number, run: Runner): Promise<v
 if (n && 'remove' in n) n.remove();
 return { removed: !!n };`;
   try {
-    await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + 2_000 });
+    await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + 2_000, activity: 'Mirror-verify · remove scratch' });
   } catch {
     // The verdict is already computed; a stranded scratch node is the owner's to
     // delete and is named in the result as `rebuiltId`.

--- a/figma-agent/cli/src/commands/scan-node.ts
+++ b/figma-agent/cli/src/commands/scan-node.ts
@@ -20,7 +20,11 @@ import { runCommand } from '../transport/broker-client.ts';
 const WIRE_MARGIN_MS = 2_000;
 
 /** Transport seam — the real `runCommand` in production, a recorder in tests. */
-export type Runner = (cmd: string, params: unknown, opts?: { timeoutMs?: number }) => Promise<unknown>;
+export type Runner = (
+  cmd: string,
+  params: unknown,
+  opts?: { timeoutMs?: number; activity?: string },
+) => Promise<unknown>;
 
 /** The walker's output, opaque to the CLI: plain JSON, compared structurally. */
 export type ScannedSpec = Record<string, unknown>;
@@ -74,6 +78,7 @@ export async function scanNodeSpec(
   nodeId: string,
   timeoutMs: number,
   run: Runner = runCommand,
+  activity = `Scan · ${nodeId}`,
 ): Promise<ScannedSpec> {
   const code = `${SCAN_NODE_WALKER_BUNDLE}
 const node = await figma.getNodeByIdAsync(${JSON.stringify(nodeId)});
@@ -82,7 +87,10 @@ const tokenNames = await __scan.readTokenNameMap();
 const mainComps = await __scan.readMainComponentMap(node);
 const keyedVars = await __scan.readKeyedVariableMap(node);
 return __scan.nodeToSpec(node, tokenNames, mainComps, keyedVars);`;
-  const reply = await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS });
+  // The label is the caller's, because EXEC_JS says nothing: this same walker runs
+  // as a bare `scan-node`, as mirror-verify's "scan original" and as its "scan
+  // rebuild" — three different waits the panel must be able to tell apart.
+  const reply = await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS, activity });
   return unwrapExecJsReply(reply);
 }
 

--- a/figma-agent/cli/src/transport/broker-client.ts
+++ b/figma-agent/cli/src/transport/broker-client.ts
@@ -8,6 +8,7 @@ import {
   COMMAND_TIMEOUTS,
   DEFAULT_TIMEOUT_MS,
   PROTOCOL_VERSION,
+  makeRequestFrame,
   makeRequestId,
   type CommandName,
 } from '../../../shared/protocol.ts';
@@ -44,7 +45,13 @@ function connectWs(port: number): Promise<WebSocket> {
   });
 }
 
-function exchange(ws: WebSocket, cmd: CommandName, params: unknown, timeoutMs: number): Promise<unknown> {
+function exchange(
+  ws: WebSocket,
+  cmd: CommandName,
+  params: unknown,
+  timeoutMs: number,
+  activity?: string,
+): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const id = makeRequestId(++requestCounter);
     const assembler = new ChunkAssembler();
@@ -95,7 +102,7 @@ function exchange(ws: WebSocket, cmd: CommandName, params: unknown, timeoutMs: n
     ws.on('error', (err) => finish(() => reject(new CliError('E_NO_BROKER', `broker socket error: ${err.message}`))));
 
     try {
-      sendWireMsg(ws, { id, cmd, params, v: PROTOCOL_VERSION });
+      sendWireMsg(ws, makeRequestFrame(id, cmd, params, activity));
     } catch (err) {
       finish(() => reject(new CliError('E_NO_BROKER', `failed to send request: ${(err as Error).message}`)));
     }
@@ -131,8 +138,16 @@ export function fetchBrokerHello(port: number): Promise<Record<string, unknown>>
 /**
  * Run one command through the broker. Connect failure after a valid
  * advertisement forces one rediscovery (broker may have just died).
+ *
+ * `opts.activity` is the intent label the panel's activity feed shows instead of
+ * the wire `cmd` (see RequestMsg.activity) — pass it from any command whose `cmd`
+ * does not say what the user is actually waiting for.
  */
-export async function runCommand(cmd: string, params: unknown, opts?: { timeoutMs?: number }): Promise<unknown> {
+export async function runCommand(
+  cmd: string,
+  params: unknown,
+  opts?: { timeoutMs?: number; activity?: string },
+): Promise<unknown> {
   const wireCmd = cmd as CommandName;
   let ad = await ensureBroker();
   let ws: WebSocket;
@@ -150,7 +165,7 @@ export async function runCommand(cmd: string, params: unknown, opts?: { timeoutM
 
   const timeoutMs = opts?.timeoutMs ?? COMMAND_TIMEOUTS[wireCmd] ?? DEFAULT_TIMEOUT_MS;
   try {
-    return await exchange(ws, wireCmd, params, timeoutMs);
+    return await exchange(ws, wireCmd, params, timeoutMs, opts?.activity);
   } finally {
     try {
       ws.close();

--- a/figma-agent/plugin/src/ui/activity-feed.ts
+++ b/figma-agent/plugin/src/ui/activity-feed.ts
@@ -1,0 +1,139 @@
+// Pure view-model for the panel's ACTIVITY FEED — no DOM, no WebSocket, no Figma
+// API. Split out of panel-model.ts (which owns the connection chrome) when the feed
+// grew a per-operation vocabulary of its own; panel-ui.ts is the DOM glue and
+// ui-relay.ts feeds it. The rows' OUTCOME lines are derived in ./activity-summary.ts
+// (the relay's half). Every branch here is unit-tested in
+// figma-agent/tests/activity-feed.test.ts.
+//
+// WHY A LABEL AT ALL: the wire `cmd` is opaque about intent. EXEC_JS is injected
+// code — a scan, a mirror-verify rebuild and an ad-hoc script are the same `cmd`,
+// so a cmd-only feed can only ever say "exec js" while the user waits. The CLI
+// therefore states its intent on the request (RequestMsg.activity) and we render
+// THAT, falling back to a humanized `cmd` when it is absent (an older CLI).
+
+/** One row of the feed: a request from the moment it starts until its reply lands. */
+export interface ActivityRecord {
+  /** Wire request id — the join between the start event and its result. */
+  id: string;
+  /** Wire command name (EXEC_JS, IMPORT_PAYLOAD…) — the label's fallback. */
+  tool: string;
+  /** The CLI's intent label ("Scan · 1:23"); absent ⇒ fall back to `tool`. */
+  label?: string;
+  /** Result summary once done ("→ 42 nodes", "✗ node not found"); absent while pending. */
+  result?: string;
+  /** True until the reply lands — the row renders as in-flight. */
+  pending: boolean;
+  ok: boolean;
+  /** Round-trip duration in ms (0 while pending). */
+  ms: number;
+  /** Epoch ms the request started — the row renders a clock time from it. */
+  at: number;
+}
+
+/** Readable log label for a wire command: "CREATE_FRAME" → "create frame". */
+export function humanizeTool(tool: string): string {
+  return tool.toLowerCase().replace(/_/g, ' ');
+}
+
+/** What the row's headline reads: the CLI's intent, else the humanized command. */
+export function activityLabel(rec: ActivityRecord): string {
+  const label = typeof rec.label === 'string' ? rec.label.trim() : '';
+  return label !== '' ? label : humanizeTool(rec.tool);
+}
+
+/** Wall-clock stamp for a row: "14:32:07" (local time, zero-padded). */
+export function formatClock(at: number): string {
+  if (!Number.isFinite(at)) return '--:--:--';
+  const d = new Date(at);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/** A completed request's duration: "12ms" under a second, else "1.2s". */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Relative time for the activity log: "just now", "5s ago", "3m ago", "2h ago". */
+export function timeAgo(nowMs: number, atMs: number): string {
+  const s = Math.floor((nowMs - atMs) / 1000);
+  if (s < 1) return 'just now';
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.floor(m / 60)}h ago`;
+}
+
+/**
+ * Coerce a raw `figma-agent:activity` start-event detail (typed `unknown`) into a
+ * pending record, or null if the shape is wrong. Defensive: the event crosses an
+ * untyped DOM boundary.
+ */
+export function toActivityRecord(detail: unknown): ActivityRecord | null {
+  if (detail === null || typeof detail !== 'object') return null;
+  const d = detail as Record<string, unknown>;
+  if (typeof d.tool !== 'string' || d.tool === '') return null;
+  const at = typeof d.at === 'number' && Number.isFinite(d.at) ? d.at : Date.now();
+  const rec: ActivityRecord = {
+    id: typeof d.id === 'string' && d.id !== '' ? d.id : `${d.tool}:${at}`,
+    tool: d.tool,
+    pending: true,
+    ok: true,
+    ms: 0,
+    at,
+  };
+  if (typeof d.label === 'string' && d.label.trim() !== '') rec.label = d.label.trim();
+  return rec;
+}
+
+/** A landed reply, as carried by the `figma-agent:activity` done-event. */
+export interface ActivityResult {
+  id: string;
+  ok: boolean;
+  ms: number;
+  result?: string;
+}
+
+/** Coerce a done-event detail into a result patch, or null if the shape is wrong. */
+export function toActivityResult(detail: unknown): ActivityResult | null {
+  if (detail === null || typeof detail !== 'object') return null;
+  const d = detail as Record<string, unknown>;
+  if (typeof d.id !== 'string' || d.id === '') return null;
+  const patch: ActivityResult = {
+    id: d.id,
+    ok: d.ok === true,
+    ms: typeof d.ms === 'number' && Number.isFinite(d.ms) && d.ms >= 0 ? d.ms : 0,
+  };
+  if (typeof d.result === 'string' && d.result !== '') patch.result = d.result;
+  return patch;
+}
+
+/** Newest-first ring buffer capped at `max` (keep 50, the feed shows 20). Returns a NEW array. */
+export function pushActivity(
+  buf: readonly ActivityRecord[],
+  rec: ActivityRecord,
+  max = 50,
+): ActivityRecord[] {
+  return [rec, ...buf].slice(0, Math.max(0, max));
+}
+
+/**
+ * Land a reply onto its own start-row, matched by request id — NOT by position.
+ * Two commands can be in flight at once (the panel is shared by every CLI caller),
+ * so "newest row" is not "the row this reply belongs to". An id with no row left in
+ * the buffer (evicted by the cap) is dropped: a stale reply must never rewrite an
+ * unrelated row.
+ */
+export function resolveActivity(
+  buf: readonly ActivityRecord[],
+  patch: ActivityResult,
+): ActivityRecord[] {
+  return buf.map((rec) => {
+    if (rec.id !== patch.id) return rec;
+    const next: ActivityRecord = { ...rec, pending: false, ok: patch.ok, ms: patch.ms };
+    if (patch.result !== undefined) next.result = patch.result;
+    return next;
+  });
+}

--- a/figma-agent/plugin/src/ui/activity-summary.ts
+++ b/figma-agent/plugin/src/ui/activity-summary.ts
@@ -1,0 +1,71 @@
+// The activity feed's OUTCOME line — pure, no DOM, no Figma API. Split from
+// activity-feed.ts along the seam the import graph already drew: ui-relay.ts needs
+// only these (it holds the reply), panel-ui.ts needs only the record model (it holds
+// the rows). Unit-tested in figma-agent/tests/activity-summary.test.ts.
+//
+// The division of labour: the CLI names the INTENT ("Mirror-verify · rebuild",
+// carried on RequestMsg.activity) because only the caller knows why it called; the
+// plugin derives the OUTCOME ("→ 42 nodes") because only the plugin holds the reply.
+// Neither side guesses the other's half.
+
+const MAX_SPEC_DEPTH = 100; // the walker's tree is finite; this only bounds a malformed one
+const MAX_ERROR_CHARS = 120; // one feed row's worth
+
+/** Does this value look like a node spec from our own walker (vs any other EXEC_JS return)? */
+function isNodeSpec(v: unknown): v is Record<string, unknown> {
+  if (v === null || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.type === 'string' && (typeof o.name === 'string' || Array.isArray(o.children));
+}
+
+/** Count a spec tree's nodes, root included. */
+export function countSpecNodes(spec: unknown, depth = 0): number {
+  if (!isNodeSpec(spec) || depth > MAX_SPEC_DEPTH) return 0;
+  const children = Array.isArray(spec.children) ? spec.children : [];
+  let n = 1;
+  for (const child of children) n += countSpecNodes(child, depth + 1);
+  return n;
+}
+
+/**
+ * Unwrap opExecJs's `{result, console, ms}` envelope down to the script's own return
+ * value. Same shape-recognition the CLI does (cli/.../scan-node.ts unwrapExecJsReply)
+ * — a bare value passes through.
+ */
+function unwrapExecJs(reply: unknown): unknown {
+  if (reply === null || typeof reply !== 'object') return reply;
+  const r = reply as Record<string, unknown>;
+  return 'result' in r && ('console' in r || 'ms' in r) ? r.result : r;
+}
+
+/**
+ * One-line outcome for a successful reply, or null when the command has nothing
+ * countable to say (the row then shows just its duration).
+ */
+export function summarizeResult(cmd: string, result: unknown): string | null {
+  if (cmd === 'IMPORT_PAYLOAD' || cmd === 'HTML_TO_FIGMA') {
+    const r = (result ?? {}) as Record<string, unknown>;
+    const name = typeof r.name === 'string' && r.name !== '' ? r.name : 'imported';
+    const warnings = Array.isArray(r.warnings) ? r.warnings.length : 0;
+    return warnings > 0 ? `→ ${name}, ${warnings} warning${warnings === 1 ? '' : 's'}` : `→ ${name}`;
+  }
+  if (cmd === 'EXEC_JS') {
+    // Only a scan returns a node spec; a mirror-verify remove-scratch ({removed:true})
+    // or an ad-hoc script does not, and must not be given a fabricated count.
+    const value = unwrapExecJs(result);
+    if (!isNodeSpec(value)) return null;
+    const n = countSpecNodes(value);
+    return `→ ${n} node${n === 1 ? '' : 's'}`;
+  }
+  return null;
+}
+
+/** One-line outcome for a failed reply: "✗ <message>", flattened to the single row it has. */
+export function summarizeError(error: unknown): string {
+  const e = (error ?? {}) as Record<string, unknown>;
+  const raw = typeof e.message === 'string' && e.message !== ''
+    ? e.message
+    : (typeof error === 'string' && error !== '' ? error : 'failed');
+  const oneLine = raw.replace(/\s+/g, ' ').trim();
+  return `✗ ${oneLine.length > MAX_ERROR_CHARS ? `${oneLine.slice(0, MAX_ERROR_CHARS - 1)}…` : oneLine}`;
+}

--- a/figma-agent/plugin/src/ui/panel-model.ts
+++ b/figma-agent/plugin/src/ui/panel-model.ts
@@ -45,63 +45,8 @@ export function formatAge(ms: number): string {
   return `${h}h ${String(m % 60).padStart(2, '0')}m`;
 }
 
-/** A completed request's duration: "12ms" under a second, else "1.2s". */
-export function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 0) return '—';
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
-}
-
-/** Relative time for the activity log: "just now", "5s ago", "3m ago", "2h ago". */
-export function timeAgo(nowMs: number, atMs: number): string {
-  const s = Math.floor((nowMs - atMs) / 1000);
-  if (s < 1) return 'just now';
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  return `${Math.floor(m / 60)}h ago`;
-}
-
-export interface ActivityRecord {
-  /** Wire command name (STATUS, CREATE_FRAME, HTML_TO_FIGMA…). */
-  tool: string;
-  ok: boolean;
-  /** Round-trip duration in ms. */
-  ms: number;
-  /** Epoch ms the request started — the log renders a time-ago from it. */
-  at: number;
-}
-
-/**
- * Coerce a raw `figma-agent:activity` CustomEvent detail (typed `unknown`) into a
- * record, or null if the shape is wrong. Defensive: the event crosses an untyped
- * DOM boundary.
- */
-export function toActivityRecord(detail: unknown): ActivityRecord | null {
-  if (detail === null || typeof detail !== 'object') return null;
-  const d = detail as Record<string, unknown>;
-  if (typeof d.tool !== 'string' || d.tool === '') return null;
-  return {
-    tool: d.tool,
-    ok: d.ok === true,
-    ms: typeof d.ms === 'number' && Number.isFinite(d.ms) && d.ms >= 0 ? d.ms : 0,
-    at: typeof d.at === 'number' && Number.isFinite(d.at) ? d.at : Date.now(),
-  };
-}
-
-/** Readable log label for a wire command: "CREATE_FRAME" → "create frame". */
-export function humanizeTool(tool: string): string {
-  return tool.toLowerCase().replace(/_/g, ' ');
-}
-
-/** Newest-first ring buffer capped at `max` (spec: keep 50, show 8). Returns a NEW array. */
-export function pushActivity(
-  buf: readonly ActivityRecord[],
-  rec: ActivityRecord,
-  max = 50,
-): ActivityRecord[] {
-  return [rec, ...buf].slice(0, Math.max(0, max));
-}
+// The activity feed's own vocabulary (records, labels, durations, result
+// summaries) lives in ./activity-feed.ts — this module owns the connection chrome.
 
 /**
  * State-specific troubleshoot hint (spec §6), or null when there's nothing useful

--- a/figma-agent/plugin/src/ui/panel-ui.ts
+++ b/figma-agent/plugin/src/ui/panel-ui.ts
@@ -10,12 +10,16 @@
 import { PORT_RANGE_START } from '../../../shared/protocol';
 import type { ConnectionState, ConnectionStatePayload } from '../../../shared/protocol';
 import {
-  stateView, formatAge, formatDuration, timeAgo, humanizeTool,
-  toActivityRecord, pushActivity, troubleshootHint, showOnboarding,
+  stateView, formatAge, troubleshootHint, showOnboarding,
   togglePanelMode, detailsLabel, compactMeta, PANEL_HEIGHT,
   syncPromptLabel, syncResultLabel,
-  type ActivityRecord, type PanelMode,
+  type PanelMode,
 } from './panel-model';
+import {
+  activityLabel, formatClock, formatDuration, timeAgo,
+  toActivityRecord, toActivityResult, pushActivity, resolveActivity,
+  type ActivityRecord,
+} from './activity-feed';
 
 const el = (id: string): HTMLElement => document.getElementById(id) as HTMLElement;
 
@@ -77,24 +81,63 @@ function renderDetails(): void {
   dPage.textContent = scenePage || '—';
 }
 
+/** How many of the buffered rows the feed shows (the band scrolls past this). */
+const ACTIVITY_ROWS = 20;
+
+/**
+ * One feed row — two lines:
+ *   ● 14:32:07  MIRROR-VERIFY · REBUILD            1.2s · 5s ago
+ *               → Hero card, 2 warnings
+ * The second line is omitted while a request is in flight (no outcome yet) and
+ * whenever the command had nothing countable to report.
+ */
+function activityRow(r: ActivityRecord, now: number): HTMLElement {
+  const li = document.createElement('li');
+  li.className = 'activity-row';
+
+  const dot = document.createElement('span');
+  dot.className = 'log-dot';
+  dot.dataset.ok = String(r.ok);
+  dot.dataset.pending = String(r.pending);
+
+  const time = document.createElement('span');
+  time.className = 'log-time';
+  time.textContent = formatClock(r.at);
+
+  const tool = document.createElement('span');
+  tool.className = 'log-tool';
+  tool.textContent = activityLabel(r);
+
+  const m = document.createElement('span');
+  m.className = 'log-meta';
+  // Pending rows have no duration to report yet — they say so instead of showing "0ms".
+  m.textContent = r.pending
+    ? 'running…'
+    : `${r.ok ? '' : 'failed · '}${formatDuration(r.ms)} · ${timeAgo(now, r.at)}`;
+
+  const head = document.createElement('div');
+  head.className = 'log-head';
+  head.append(time, tool, m);
+
+  const body = document.createElement('div');
+  body.className = 'log-body';
+  body.append(head);
+
+  if (r.result) {
+    const res = document.createElement('div');
+    res.className = 'log-result';
+    res.dataset.ok = String(r.ok);
+    res.textContent = r.result;
+    body.append(res);
+  }
+
+  li.append(dot, body);
+  return li;
+}
+
 function renderActivity(now: number): void {
   if (activity.length === 0) return; // leave the static "No activity yet" empty-state row
-  const rows = activity.slice(0, 8).map((r) => {
-    const li = document.createElement('li');
-    li.className = 'activity-row';
-    const d = document.createElement('span');
-    d.className = 'log-dot';
-    d.dataset.ok = String(r.ok);
-    const tool = document.createElement('span');
-    tool.className = 'log-tool';
-    tool.textContent = humanizeTool(r.tool);
-    const m = document.createElement('span');
-    m.className = 'log-meta';
-    m.textContent = `${r.ok ? '' : 'failed · '}${formatDuration(r.ms)} · ${timeAgo(now, r.at)}`;
-    li.append(d, tool, m);
-    return li;
-  });
-  activityList.replaceChildren(...rows);
+  activityList.replaceChildren(...activity.slice(0, ACTIVITY_ROWS).map((r) => activityRow(r, now)));
 }
 
 function render(): void {
@@ -124,10 +167,19 @@ window.addEventListener('figma-agent:conn-state', (ev) => {
   render();
 });
 
+// The relay announces each request twice: `start` opens the row (so the panel shows
+// what is running while it runs), `done` lands the outcome onto that same row, by id.
 window.addEventListener('figma-agent:activity', (ev) => {
-  const rec = toActivityRecord((ev as CustomEvent).detail);
-  if (!rec) return;
-  activity = pushActivity(activity, rec);
+  const detail = (ev as CustomEvent).detail as { phase?: unknown } | undefined;
+  if (detail?.phase === 'done') {
+    const patch = toActivityResult(detail);
+    if (!patch) return;
+    activity = resolveActivity(activity, patch);
+  } else {
+    const rec = toActivityRecord(detail);
+    if (!rec) return;
+    activity = pushActivity(activity, rec);
+  }
   renderActivity(Date.now());
 });
 
@@ -153,8 +205,21 @@ window.addEventListener('message', (ev: MessageEvent) => {
 // "Sync now" → ask the relay to send SYNC_REQUEST to the broker (which runs `ui figma
 // reconcile --apply`) AND tell main the batch was acknowledged. "Later" just hides it —
 // the next documentchange restarts the idle timer. SYNC_RESULT confirms in place.
+// A reconcile is the one operation the feed cannot learn about from the wire: it runs
+// in the kernel (`ui figma reconcile --apply`, spawned by the broker) and sends no
+// command through this relay. Its two ends ARE observable here though — the click and
+// the SYNC_RESULT — so the feed logs it from those, keyed by this id.
+let reconcileRun: { id: string; at: number } | null = null;
+
 syncNowBtn.addEventListener('click', () => {
   syncMsg.textContent = 'Syncing…';
+  const at = Date.now();
+  reconcileRun = { id: `reconcile_${at}`, at };
+  activity = pushActivity(activity, {
+    id: reconcileRun.id, tool: 'RECONCILE', label: 'Reconcile · apply',
+    pending: true, ok: true, ms: 0, at,
+  });
+  renderActivity(at);
   try { window.dispatchEvent(new CustomEvent('figma-agent:sync-request')); } catch { /* no DOM events */ }
   parent.postMessage({ pluginMessage: { type: 'SYNC_DONE' } }, '*');
 });
@@ -164,11 +229,23 @@ syncLaterBtn.addEventListener('click', () => { syncPrompt.hidden = true; });
 window.addEventListener('figma-agent:sync-result', (ev) => {
   const d = (ev as CustomEvent).detail as { ok?: boolean; summary?: string; landed?: boolean } | undefined;
   // `landed` absent (an older broker) → assume it landed; a present `false` is honoured.
-  syncMsg.textContent = syncResultLabel(
+  const label = syncResultLabel(
     d?.ok === true,
     typeof d?.summary === 'string' ? d.summary : '',
     d?.landed !== false,
   );
+  syncMsg.textContent = label;
+  // The prompt line auto-dismisses in 4s; the feed row is the durable record. It
+  // repeats the SAME sentence syncResultLabel just made — including "Nothing synced",
+  // which a feed that only said "done" would quietly upgrade to a lie.
+  if (reconcileRun) {
+    const now = Date.now();
+    activity = resolveActivity(activity, {
+      id: reconcileRun.id, ok: d?.ok === true, ms: now - reconcileRun.at, result: `→ ${label}`,
+    });
+    reconcileRun = null;
+    renderActivity(now);
+  }
   syncPrompt.hidden = false;
   setTimeout(() => { syncPrompt.hidden = true; }, 4000); // auto-dismiss the confirmation
 });

--- a/figma-agent/plugin/src/ui/panel.html
+++ b/figma-agent/plugin/src/ui/panel.html
@@ -430,12 +430,13 @@ code {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  max-height: 120px;
+  max-height: 180px;
   overflow-y: auto;
 }
+/* A row is [dot][body], where body stacks the head line over the result line. */
 .activity-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-2);
   padding: 2px 0;
   font-family: var(--font-mono);
@@ -444,23 +445,52 @@ code {
 .log-dot {
   width: 6px;
   height: 6px;
+  margin-top: 4px; /* optically centred on the head line, not the whole row */
   flex: 0 0 auto;
   background: var(--color-success);
 }
 .log-dot[data-ok="false"] { background: var(--color-danger); }
+/* In-flight beats the ok/fail colour — nothing has been decided yet. */
+.log-dot[data-pending="true"] { background: var(--color-warning); }
+.log-body {
+  flex: 1 1 auto;
+  min-width: 0; /* lets the ellipsis in .log-tool / .log-result actually engage */
+}
+.log-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.log-time {
+  flex: 0 0 auto;
+  color: var(--color-muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
 .log-tool {
   font-weight: var(--font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .log-meta {
   margin-left: auto;
+  flex: 0 0 auto;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-muted-foreground);
   font-variant-numeric: tabular-nums;
 }
+/* Result line — indented under the label, one line, truncated. */
+.log-result {
+  color: var(--color-muted-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.log-result[data-ok="false"] { color: var(--color-danger); }
 .activity-empty {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);

--- a/figma-agent/plugin/src/ui/ui-relay.ts
+++ b/figma-agent/plugin/src/ui/ui-relay.ts
@@ -20,6 +20,7 @@ import {
   type ErrorCode, type ReplyMsg, type RequestMsg,
 } from '../../../shared/protocol';
 import { renderHtmlToPayload } from './render-host';
+import { summarizeError, summarizeResult } from './activity-summary';
 
 const PLUGIN_VERSION = '0.1.0';
 const PORT_PROBE_TIMEOUT_MS = 1200; // a real broker greets in <50ms; short = fast scan
@@ -43,18 +44,36 @@ let fileInfo: Record<string, unknown> = {}; // FILE_INFO from main (fileName, fi
 const chunkBuffers = new Map<string, string[]>(); // requestId → chunk slices
 
 // ─── Activity telemetry → UI (P2) ───────────────────────────────────────────
-// Each request that reaches handleRequest is timed; on completion the relay
-// dispatches a `figma-agent:activity` {tool, ok, ms, at} CustomEvent that the P2
-// panel renders in its activity log. Lives here (not in main) because the relay
-// owns the request lifecycle on the UI side — same place conn-state is emitted.
+// Each request that reaches handleRequest is timed and announced TWICE on the
+// `figma-agent:activity` CustomEvent: `phase:'start'` the moment it arrives (so the
+// panel shows what is running WHILE the user waits — a 60s html-to-figma is exactly
+// when "what is it doing?" is asked), and `phase:'done'` when the reply lands,
+// carrying the outcome. Lives here (not in main) because the relay owns the request
+// lifecycle on the UI side — same place conn-state is emitted — and it sees both
+// halves: the CLI's intent label on the way in, and main's result on the way out.
 const activityStart = new Map<string, { cmd: CommandName; at: number }>();
 
-function emitActivity(id: string, ok: boolean): void {
+function dispatchActivity(detail: Record<string, unknown>): void {
+  try { window.dispatchEvent(new CustomEvent('figma-agent:activity', { detail })); } catch { /* no DOM event support */ }
+}
+
+/** Announce an arriving request, carrying the CLI's intent label when it sent one. */
+function startActivity(req: RequestMsg): void {
+  const at = Date.now();
+  activityStart.set(req.id, { cmd: req.cmd, at });
+  dispatchActivity({ phase: 'start', id: req.id, tool: req.cmd, label: req.activity, at });
+}
+
+/**
+ * Announce a completed request. `payload` is main's reply — the result on success,
+ * the error on failure — from which the outcome line is derived plugin-side.
+ */
+function emitActivity(id: string, ok: boolean, payload?: unknown): void {
   const started = activityStart.get(id);
   if (!started) return;
   activityStart.delete(id);
-  const detail = { tool: started.cmd, ok, ms: Date.now() - started.at, at: started.at };
-  try { window.dispatchEvent(new CustomEvent('figma-agent:activity', { detail })); } catch { /* no DOM event support */ }
+  const result = ok ? summarizeResult(started.cmd, payload) : summarizeError(payload);
+  dispatchActivity({ phase: 'done', id, ok, ms: Date.now() - started.at, result: result ?? undefined });
 }
 
 // ─── Connection state machine → UI ──────────────────────────────────
@@ -169,13 +188,13 @@ interface HtmlToFigmaParams {
 }
 
 async function handleRequest(req: RequestMsg): Promise<void> {
-  activityStart.set(req.id, { cmd: req.cmd, at: Date.now() }); // timed until completion
+  startActivity(req); // timed + announced until completion
   try {
     if (req.cmd === 'HTML_TO_FIGMA') {
       const p = (req.params ?? {}) as HtmlToFigmaParams;
       if (!p.html) {
         sendErr(req.id, 'E_INVALID_ARGS', 'HTML_TO_FIGMA requires params.html');
-        emitActivity(req.id, false);
+        emitActivity(req.id, false, { message: 'HTML_TO_FIGMA requires params.html' });
         return;
       }
       setStatusText('rendering html…', 'ok');
@@ -194,8 +213,9 @@ async function handleRequest(req: RequestMsg): Promise<void> {
     }
   } catch (err) {
     setStatusText('connected', 'ok');
-    sendErr(req.id, 'E_PLUGIN_ERROR', err instanceof Error ? err.message : String(err));
-    emitActivity(req.id, false);
+    const message = err instanceof Error ? err.message : String(err);
+    sendErr(req.id, 'E_PLUGIN_ERROR', message);
+    emitActivity(req.id, false, { message });
   }
 }
 
@@ -229,7 +249,9 @@ window.addEventListener('message', (ev: MessageEvent) => {
             ?? { code: 'E_PLUGIN_ERROR', message: 'main thread returned no error detail' },
         };
     wsSend(reply);
-    emitActivity(pm.requestId, pm.ok === true); // request round-trip completed
+    // Round-trip completed — the feed's outcome line is derived from this same
+    // reply (count of nodes scanned, name + warnings imported, or the error).
+    emitActivity(pm.requestId, pm.ok === true, pm.ok === true ? pm.result : pm.error);
   }
 });
 

--- a/figma-agent/plugin/ui.html
+++ b/figma-agent/plugin/ui.html
@@ -430,12 +430,13 @@ code {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  max-height: 120px;
+  max-height: 180px;
   overflow-y: auto;
 }
+/* A row is [dot][body], where body stacks the head line over the result line. */
 .activity-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-2);
   padding: 2px 0;
   font-family: var(--font-mono);
@@ -444,23 +445,52 @@ code {
 .log-dot {
   width: 6px;
   height: 6px;
+  margin-top: 4px; /* optically centred on the head line, not the whole row */
   flex: 0 0 auto;
   background: var(--color-success);
 }
 .log-dot[data-ok="false"] { background: var(--color-danger); }
+/* In-flight beats the ok/fail colour — nothing has been decided yet. */
+.log-dot[data-pending="true"] { background: var(--color-warning); }
+.log-body {
+  flex: 1 1 auto;
+  min-width: 0; /* lets the ellipsis in .log-tool / .log-result actually engage */
+}
+.log-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.log-time {
+  flex: 0 0 auto;
+  color: var(--color-muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
 .log-tool {
   font-weight: var(--font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .log-meta {
   margin-left: auto;
+  flex: 0 0 auto;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-muted-foreground);
   font-variant-numeric: tabular-nums;
 }
+/* Result line — indented under the label, one line, truncated. */
+.log-result {
+  color: var(--color-muted-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.log-result[data-ok="false"] { color: var(--color-danger); }
 .activity-empty {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
@@ -671,36 +701,6 @@ code {
     const h = Math.floor(m / 60);
     return `${h}h ${String(m % 60).padStart(2, "0")}m`;
   }
-  function formatDuration(ms) {
-    if (!Number.isFinite(ms) || ms < 0) return "\u2014";
-    if (ms < 1e3) return `${Math.round(ms)}ms`;
-    return `${(ms / 1e3).toFixed(1)}s`;
-  }
-  function timeAgo(nowMs, atMs) {
-    const s = Math.floor((nowMs - atMs) / 1e3);
-    if (s < 1) return "just now";
-    if (s < 60) return `${s}s ago`;
-    const m = Math.floor(s / 60);
-    if (m < 60) return `${m}m ago`;
-    return `${Math.floor(m / 60)}h ago`;
-  }
-  function toActivityRecord(detail) {
-    if (detail === null || typeof detail !== "object") return null;
-    const d = detail;
-    if (typeof d.tool !== "string" || d.tool === "") return null;
-    return {
-      tool: d.tool,
-      ok: d.ok === true,
-      ms: typeof d.ms === "number" && Number.isFinite(d.ms) && d.ms >= 0 ? d.ms : 0,
-      at: typeof d.at === "number" && Number.isFinite(d.at) ? d.at : Date.now()
-    };
-  }
-  function humanizeTool(tool) {
-    return tool.toLowerCase().replace(/_/g, " ");
-  }
-  function pushActivity(buf, rec, max = 50) {
-    return [rec, ...buf].slice(0, Math.max(0, max));
-  }
   function troubleshootHint(state, ageMs, hadConnection2) {
     if (state === "probing" && ageMs >= 1e4) {
       return "Broker not running? Any CLI command spawns it \u2014 run figma-agent status in a terminal.";
@@ -731,6 +731,73 @@ code {
   }
   function compactMeta(state) {
     return state === "disconnected" ? "First CLI command starts it" : null;
+  }
+
+  // plugin/src/ui/activity-feed.ts
+  function humanizeTool(tool) {
+    return tool.toLowerCase().replace(/_/g, " ");
+  }
+  function activityLabel(rec) {
+    const label = typeof rec.label === "string" ? rec.label.trim() : "";
+    return label !== "" ? label : humanizeTool(rec.tool);
+  }
+  function formatClock(at) {
+    if (!Number.isFinite(at)) return "--:--:--";
+    const d = new Date(at);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  }
+  function formatDuration(ms) {
+    if (!Number.isFinite(ms) || ms < 0) return "\u2014";
+    if (ms < 1e3) return `${Math.round(ms)}ms`;
+    return `${(ms / 1e3).toFixed(1)}s`;
+  }
+  function timeAgo(nowMs, atMs) {
+    const s = Math.floor((nowMs - atMs) / 1e3);
+    if (s < 1) return "just now";
+    if (s < 60) return `${s}s ago`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m ago`;
+    return `${Math.floor(m / 60)}h ago`;
+  }
+  function toActivityRecord(detail) {
+    if (detail === null || typeof detail !== "object") return null;
+    const d = detail;
+    if (typeof d.tool !== "string" || d.tool === "") return null;
+    const at = typeof d.at === "number" && Number.isFinite(d.at) ? d.at : Date.now();
+    const rec = {
+      id: typeof d.id === "string" && d.id !== "" ? d.id : `${d.tool}:${at}`,
+      tool: d.tool,
+      pending: true,
+      ok: true,
+      ms: 0,
+      at
+    };
+    if (typeof d.label === "string" && d.label.trim() !== "") rec.label = d.label.trim();
+    return rec;
+  }
+  function toActivityResult(detail) {
+    if (detail === null || typeof detail !== "object") return null;
+    const d = detail;
+    if (typeof d.id !== "string" || d.id === "") return null;
+    const patch = {
+      id: d.id,
+      ok: d.ok === true,
+      ms: typeof d.ms === "number" && Number.isFinite(d.ms) && d.ms >= 0 ? d.ms : 0
+    };
+    if (typeof d.result === "string" && d.result !== "") patch.result = d.result;
+    return patch;
+  }
+  function pushActivity(buf, rec, max = 50) {
+    return [rec, ...buf].slice(0, Math.max(0, max));
+  }
+  function resolveActivity(buf, patch) {
+    return buf.map((rec) => {
+      if (rec.id !== patch.id) return rec;
+      const next = { ...rec, pending: false, ok: patch.ok, ms: patch.ms };
+      if (patch.result !== void 0) next.result = patch.result;
+      return next;
+    });
   }
 
   // plugin/src/ui/panel-ui.ts
@@ -788,24 +855,42 @@ code {
     dFile.textContent = sceneFile || "\u2014";
     dPage.textContent = scenePage || "\u2014";
   }
+  var ACTIVITY_ROWS = 20;
+  function activityRow(r, now) {
+    const li = document.createElement("li");
+    li.className = "activity-row";
+    const dot2 = document.createElement("span");
+    dot2.className = "log-dot";
+    dot2.dataset.ok = String(r.ok);
+    dot2.dataset.pending = String(r.pending);
+    const time = document.createElement("span");
+    time.className = "log-time";
+    time.textContent = formatClock(r.at);
+    const tool = document.createElement("span");
+    tool.className = "log-tool";
+    tool.textContent = activityLabel(r);
+    const m = document.createElement("span");
+    m.className = "log-meta";
+    m.textContent = r.pending ? "running\u2026" : `${r.ok ? "" : "failed \xB7 "}${formatDuration(r.ms)} \xB7 ${timeAgo(now, r.at)}`;
+    const head = document.createElement("div");
+    head.className = "log-head";
+    head.append(time, tool, m);
+    const body = document.createElement("div");
+    body.className = "log-body";
+    body.append(head);
+    if (r.result) {
+      const res = document.createElement("div");
+      res.className = "log-result";
+      res.dataset.ok = String(r.ok);
+      res.textContent = r.result;
+      body.append(res);
+    }
+    li.append(dot2, body);
+    return li;
+  }
   function renderActivity(now) {
     if (activity.length === 0) return;
-    const rows = activity.slice(0, 8).map((r) => {
-      const li = document.createElement("li");
-      li.className = "activity-row";
-      const d = document.createElement("span");
-      d.className = "log-dot";
-      d.dataset.ok = String(r.ok);
-      const tool = document.createElement("span");
-      tool.className = "log-tool";
-      tool.textContent = humanizeTool(r.tool);
-      const m = document.createElement("span");
-      m.className = "log-meta";
-      m.textContent = `${r.ok ? "" : "failed \xB7 "}${formatDuration(r.ms)} \xB7 ${timeAgo(now, r.at)}`;
-      li.append(d, tool, m);
-      return li;
-    });
-    activityList.replaceChildren(...rows);
+    activityList.replaceChildren(...activity.slice(0, ACTIVITY_ROWS).map((r) => activityRow(r, now)));
   }
   function render() {
     const now = Date.now();
@@ -831,9 +916,16 @@ code {
     render();
   });
   window.addEventListener("figma-agent:activity", (ev) => {
-    const rec = toActivityRecord(ev.detail);
-    if (!rec) return;
-    activity = pushActivity(activity, rec);
+    const detail = ev.detail;
+    if (detail?.phase === "done") {
+      const patch = toActivityResult(detail);
+      if (!patch) return;
+      activity = resolveActivity(activity, patch);
+    } else {
+      const rec = toActivityRecord(detail);
+      if (!rec) return;
+      activity = pushActivity(activity, rec);
+    }
     renderActivity(Date.now());
   });
   window.addEventListener("message", (ev) => {
@@ -850,8 +942,21 @@ code {
     if (typeof pm.data.page === "string") scenePage = pm.data.page;
     renderDetails();
   });
+  var reconcileRun = null;
   syncNowBtn.addEventListener("click", () => {
     syncMsg.textContent = "Syncing\u2026";
+    const at = Date.now();
+    reconcileRun = { id: `reconcile_${at}`, at };
+    activity = pushActivity(activity, {
+      id: reconcileRun.id,
+      tool: "RECONCILE",
+      label: "Reconcile \xB7 apply",
+      pending: true,
+      ok: true,
+      ms: 0,
+      at
+    });
+    renderActivity(at);
     try {
       window.dispatchEvent(new CustomEvent("figma-agent:sync-request"));
     } catch {
@@ -863,11 +968,23 @@ code {
   });
   window.addEventListener("figma-agent:sync-result", (ev) => {
     const d = ev.detail;
-    syncMsg.textContent = syncResultLabel(
+    const label = syncResultLabel(
       d?.ok === true,
       typeof d?.summary === "string" ? d.summary : "",
       d?.landed !== false
     );
+    syncMsg.textContent = label;
+    if (reconcileRun) {
+      const now = Date.now();
+      activity = resolveActivity(activity, {
+        id: reconcileRun.id,
+        ok: d?.ok === true,
+        ms: now - reconcileRun.at,
+        result: `\u2192 ${label}`
+      });
+      reconcileRun = null;
+      renderActivity(now);
+    }
     syncPrompt.hidden = false;
     setTimeout(() => {
       syncPrompt.hidden = true;
@@ -2323,6 +2440,48 @@ code {
     }
   }
 
+  // plugin/src/ui/activity-summary.ts
+  var MAX_SPEC_DEPTH = 100;
+  var MAX_ERROR_CHARS = 120;
+  function isNodeSpec(v) {
+    if (v === null || typeof v !== "object") return false;
+    const o = v;
+    return typeof o.type === "string" && (typeof o.name === "string" || Array.isArray(o.children));
+  }
+  function countSpecNodes(spec, depth = 0) {
+    if (!isNodeSpec(spec) || depth > MAX_SPEC_DEPTH) return 0;
+    const children = Array.isArray(spec.children) ? spec.children : [];
+    let n = 1;
+    for (const child of children) n += countSpecNodes(child, depth + 1);
+    return n;
+  }
+  function unwrapExecJs(reply) {
+    if (reply === null || typeof reply !== "object") return reply;
+    const r = reply;
+    return "result" in r && ("console" in r || "ms" in r) ? r.result : r;
+  }
+  function summarizeResult(cmd, result) {
+    if (cmd === "IMPORT_PAYLOAD" || cmd === "HTML_TO_FIGMA") {
+      const r = result ?? {};
+      const name = typeof r.name === "string" && r.name !== "" ? r.name : "imported";
+      const warnings = Array.isArray(r.warnings) ? r.warnings.length : 0;
+      return warnings > 0 ? `\u2192 ${name}, ${warnings} warning${warnings === 1 ? "" : "s"}` : `\u2192 ${name}`;
+    }
+    if (cmd === "EXEC_JS") {
+      const value = unwrapExecJs(result);
+      if (!isNodeSpec(value)) return null;
+      const n = countSpecNodes(value);
+      return `\u2192 ${n} node${n === 1 ? "" : "s"}`;
+    }
+    return null;
+  }
+  function summarizeError(error) {
+    const e = error ?? {};
+    const raw = typeof e.message === "string" && e.message !== "" ? e.message : typeof error === "string" && error !== "" ? error : "failed";
+    const oneLine = raw.replace(/\s+/g, " ").trim();
+    return `\u2717 ${oneLine.length > MAX_ERROR_CHARS ? `${oneLine.slice(0, MAX_ERROR_CHARS - 1)}\u2026` : oneLine}`;
+  }
+
   // plugin/src/ui/ui-relay.ts
   var PLUGIN_VERSION = "0.1.0";
   var PORT_PROBE_TIMEOUT_MS = 1200;
@@ -2336,15 +2495,23 @@ code {
   var fileInfo = {};
   var chunkBuffers = /* @__PURE__ */ new Map();
   var activityStart = /* @__PURE__ */ new Map();
-  function emitActivity(id, ok) {
-    const started = activityStart.get(id);
-    if (!started) return;
-    activityStart.delete(id);
-    const detail = { tool: started.cmd, ok, ms: Date.now() - started.at, at: started.at };
+  function dispatchActivity(detail) {
     try {
       window.dispatchEvent(new CustomEvent("figma-agent:activity", { detail }));
     } catch {
     }
+  }
+  function startActivity(req) {
+    const at = Date.now();
+    activityStart.set(req.id, { cmd: req.cmd, at });
+    dispatchActivity({ phase: "start", id: req.id, tool: req.cmd, label: req.activity, at });
+  }
+  function emitActivity(id, ok, payload2) {
+    const started = activityStart.get(id);
+    if (!started) return;
+    activityStart.delete(id);
+    const result = ok ? summarizeResult(started.cmd, payload2) : summarizeError(payload2);
+    dispatchActivity({ phase: "done", id, ok, ms: Date.now() - started.at, result: result ?? void 0 });
   }
   function renderStatusDom(p) {
     const statusEl = document.getElementById("status");
@@ -2447,13 +2614,13 @@ code {
     handleWireData(buf.join(""));
   }
   async function handleRequest(req) {
-    activityStart.set(req.id, { cmd: req.cmd, at: Date.now() });
+    startActivity(req);
     try {
       if (req.cmd === "HTML_TO_FIGMA") {
         const p = req.params ?? {};
         if (!p.html) {
           sendErr(req.id, "E_INVALID_ARGS", "HTML_TO_FIGMA requires params.html");
-          emitActivity(req.id, false);
+          emitActivity(req.id, false, { message: "HTML_TO_FIGMA requires params.html" });
           return;
         }
         setStatusText("rendering html\u2026", "ok");
@@ -2471,8 +2638,9 @@ code {
       }
     } catch (err) {
       setStatusText("connected", "ok");
-      sendErr(req.id, "E_PLUGIN_ERROR", err instanceof Error ? err.message : String(err));
-      emitActivity(req.id, false);
+      const message = err instanceof Error ? err.message : String(err);
+      sendErr(req.id, "E_PLUGIN_ERROR", message);
+      emitActivity(req.id, false, { message });
     }
   }
   window.addEventListener("message", (ev) => {
@@ -2494,7 +2662,7 @@ code {
         error: pm.error ?? { code: "E_PLUGIN_ERROR", message: "main thread returned no error detail" }
       };
       wsSend(reply);
-      emitActivity(pm.requestId, pm.ok === true);
+      emitActivity(pm.requestId, pm.ok === true, pm.ok === true ? pm.result : pm.error);
     }
   });
   function stopHeartbeat() {

--- a/figma-agent/shared/protocol.ts
+++ b/figma-agent/shared/protocol.ts
@@ -49,6 +49,20 @@ export interface RequestMsg {
   cmd: CommandName;
   params: unknown;
   v: number; // PROTOCOL_VERSION
+  /**
+   * Human-readable INTENT of this request, for the panel's activity feed
+   * ("Scan · 1:23", "Mirror-verify · rebuild", "Build · Hero card").
+   *
+   * `cmd` alone is opaque to the plugin: EXEC_JS is injected code, so the panel
+   * cannot tell a scan from a mirror-verify rebuild from an ad-hoc script — it
+   * could only ever log "exec js". The CALLER knows what it is doing, so the
+   * caller says so here.
+   *
+   * OPTIONAL by contract: the broker relays the frame verbatim and the plugin
+   * falls back to humanizing `cmd`, so an older CLI (no label) and a newer plugin
+   * still interoperate — the feed is just less specific.
+   */
+  activity?: string;
 }
 
 export interface ReplyOk {
@@ -176,6 +190,26 @@ export const PLUGIN_WAIT_MS = 12_000;
 
 export function makeRequestId(counter: number): string {
   return `c_${counter}_${Date.now()}`;
+}
+
+/**
+ * Build a RequestMsg frame, stamping the protocol version and OMITTING `activity`
+ * entirely when the caller has no intent label to declare.
+ *
+ * Omission, not `activity: undefined`: an unlabelled frame must serialize
+ * byte-identically to what every pre-label CLI sent, so the field can never be the
+ * thing that makes an old broker or plugin behave differently. Pure, so that
+ * guarantee is testable without a socket.
+ */
+export function makeRequestFrame(
+  id: string,
+  cmd: CommandName,
+  params: unknown,
+  activity?: string,
+): RequestMsg {
+  const frame: RequestMsg = { id, cmd, params, v: PROTOCOL_VERSION };
+  if (typeof activity === 'string' && activity.trim() !== '') frame.activity = activity;
+  return frame;
 }
 
 // ── Connection state machine (single source of truth) ───────────────

--- a/figma-agent/tests/activity-feed.test.ts
+++ b/figma-agent/tests/activity-feed.test.ts
@@ -1,0 +1,136 @@
+// The panel activity feed's pure model — what each row SAYS the plugin is doing.
+// The contract under test: the CLI names the intent (RequestMsg.activity), the
+// plugin derives the outcome from the reply it already has, and a reply lands on
+// its own start-row by request id. Every claim here is one the panel makes to a
+// human watching the plugin work, so a wrong one is a lie, not a cosmetic bug.
+import { describe, it, expect } from 'vitest';
+import {
+  activityLabel, humanizeTool, formatClock, formatDuration, timeAgo,
+  toActivityRecord, toActivityResult, pushActivity, resolveActivity,
+  type ActivityRecord,
+} from '../plugin/src/ui/activity-feed.ts';
+
+const rec = (over: Partial<ActivityRecord> = {}): ActivityRecord => ({
+  id: 'c_1', tool: 'EXEC_JS', pending: true, ok: true, ms: 0, at: 1_000, ...over,
+});
+
+describe('humanizeTool', () => {
+  it('lowercases and de-snakes the wire command', () => {
+    expect(humanizeTool('CREATE_FRAME')).toBe('create frame');
+    expect(humanizeTool('HTML_TO_FIGMA')).toBe('html to figma');
+    expect(humanizeTool('STATUS')).toBe('status');
+  });
+});
+
+describe('activityLabel — the CLI names the intent, the cmd is only the fallback', () => {
+  it('prefers the label the CLI sent', () => {
+    expect(activityLabel(rec({ label: 'Mirror-verify · rebuild' }))).toBe('Mirror-verify · rebuild');
+  });
+  it('falls back to the humanized cmd when no label came (an older CLI)', () => {
+    expect(activityLabel(rec({ tool: 'CREATE_FRAME' }))).toBe('create frame');
+  });
+  it('treats a blank/whitespace label as absent — never renders an empty row', () => {
+    expect(activityLabel(rec({ tool: 'STATUS', label: '   ' }))).toBe('status');
+  });
+});
+
+describe('formatClock / formatDuration / timeAgo', () => {
+  it('formatClock is a zero-padded local HH:MM:SS', () => {
+    const at = new Date(2026, 6, 16, 9, 5, 3).getTime();
+    expect(formatClock(at)).toBe('09:05:03');
+  });
+  it('formatClock refuses to invent a time from a broken stamp', () => {
+    expect(formatClock(Number.NaN)).toBe('--:--:--');
+  });
+  it('formatDuration is ms under a second, then 1-decimal seconds', () => {
+    expect(formatDuration(12)).toBe('12ms');
+    expect(formatDuration(1_250)).toBe('1.3s');
+    expect(formatDuration(-1)).toBe('—');
+  });
+  it('timeAgo is relative to now', () => {
+    const now = 1_000_000;
+    expect(timeAgo(now, now)).toBe('just now');
+    expect(timeAgo(now, now - 5_000)).toBe('5s ago');
+    expect(timeAgo(now, now - 180_000)).toBe('3m ago');
+    expect(timeAgo(now, now - 7_200_000)).toBe('2h ago');
+  });
+});
+
+describe('toActivityRecord — defensive coercion of the start-event detail', () => {
+  it('opens a PENDING row carrying the id + label', () => {
+    expect(toActivityRecord({ phase: 'start', id: 'c_7', tool: 'EXEC_JS', label: 'Scan · 1:23', at: 500 }))
+      .toEqual({ id: 'c_7', tool: 'EXEC_JS', label: 'Scan · 1:23', pending: true, ok: true, ms: 0, at: 500 });
+  });
+  it('rejects a missing/blank tool', () => {
+    expect(toActivityRecord({ ok: true })).toBeNull();
+    expect(toActivityRecord({ tool: '' })).toBeNull();
+    expect(toActivityRecord(null)).toBeNull();
+    expect(toActivityRecord('nope')).toBeNull();
+  });
+  it('BACKWARD-COMPAT: a detail with no label still opens a row (the cmd carries it)', () => {
+    const r = toActivityRecord({ id: 'c_1', tool: 'STATUS', at: 500 });
+    expect(r?.label).toBeUndefined();
+    expect(activityLabel(r as ActivityRecord)).toBe('status');
+  });
+  it('synthesises an id and defaults `at` rather than dropping the row', () => {
+    const r = toActivityRecord({ tool: 'X' });
+    expect(r?.id).not.toBe('');
+    expect(typeof r?.at).toBe('number');
+  });
+});
+
+describe('toActivityResult — coercion of the done-event detail', () => {
+  it('accepts a well-formed patch', () => {
+    expect(toActivityResult({ phase: 'done', id: 'c_2', ok: true, ms: 40, result: '→ 3 nodes' }))
+      .toEqual({ id: 'c_2', ok: true, ms: 40, result: '→ 3 nodes' });
+  });
+  it('rejects a patch with no id — it could not be landed on any row', () => {
+    expect(toActivityResult({ ok: true, ms: 5 })).toBeNull();
+    expect(toActivityResult({ id: '', ok: true })).toBeNull();
+    expect(toActivityResult(null)).toBeNull();
+  });
+  it('coerces a bad ms and treats a non-true ok as failure', () => {
+    expect(toActivityResult({ id: 'c_3', ms: -3 })).toEqual({ id: 'c_3', ok: false, ms: 0 });
+  });
+});
+
+describe('pushActivity — newest-first, capped at 50', () => {
+  const at = (n: number): ActivityRecord => rec({ id: `c_${n}`, tool: `T${n}`, at: n });
+  it('prepends newest', () => {
+    const buf = pushActivity(pushActivity([], at(1)), at(2));
+    expect(buf.map((r) => r.tool)).toEqual(['T2', 'T1']);
+  });
+  it('never exceeds the cap and drops the oldest', () => {
+    let buf: ActivityRecord[] = [];
+    for (let i = 0; i < 60; i++) buf = pushActivity(buf, at(i));
+    expect(buf).toHaveLength(50);
+    expect(buf[0].tool).toBe('T59'); // newest kept
+    expect(buf.at(-1)?.tool).toBe('T10'); // oldest 10 dropped
+  });
+});
+
+describe('resolveActivity — a reply lands on ITS OWN row, by id', () => {
+  it('closes the pending row and attaches the outcome', () => {
+    const buf = pushActivity([], rec({ id: 'c_1', label: 'Scan · 1:23' }));
+    const [row] = resolveActivity(buf, { id: 'c_1', ok: true, ms: 42, result: '→ 3 nodes' });
+    expect(row).toMatchObject({ pending: false, ok: true, ms: 42, result: '→ 3 nodes', label: 'Scan · 1:23' });
+  });
+  it('matches by id, NOT by position — two commands can be in flight at once', () => {
+    // The panel is shared by every CLI caller, so the newest row is not necessarily
+    // the row a reply belongs to. Landing on position would credit the wrong request.
+    let buf = pushActivity([], rec({ id: 'first', tool: 'A', at: 1 }));
+    buf = pushActivity(buf, rec({ id: 'second', tool: 'B', at: 2 })); // newest, still running
+    const out = resolveActivity(buf, { id: 'first', ok: true, ms: 10, result: '→ done' });
+    expect(out.find((r) => r.id === 'first')).toMatchObject({ pending: false, result: '→ done' });
+    expect(out.find((r) => r.id === 'second')).toMatchObject({ pending: true });
+  });
+  it('drops a reply whose row is gone (evicted by the cap) rather than rewriting another', () => {
+    const buf = pushActivity([], rec({ id: 'alive' }));
+    expect(resolveActivity(buf, { id: 'evicted', ok: false, ms: 1 })).toEqual(buf);
+  });
+  it('marks a failure without pretending it succeeded', () => {
+    const buf = pushActivity([], rec({ id: 'c_1' }));
+    const [row] = resolveActivity(buf, { id: 'c_1', ok: false, ms: 8, result: '✗ node not found' });
+    expect(row).toMatchObject({ pending: false, ok: false, result: '✗ node not found' });
+  });
+});

--- a/figma-agent/tests/activity-labels.test.ts
+++ b/figma-agent/tests/activity-labels.test.ts
@@ -1,0 +1,84 @@
+// The CLI half of the activity feed: every command that the plugin cannot identify
+// from its wire `cmd` must SAY what it is doing (RequestMsg.activity).
+//
+// This matters most for EXEC_JS, which is injected code: a bare scan-node, both of
+// mirror-verify's scans, its rebuild-removal and an ad-hoc script are all the same
+// `cmd` on the wire. Without a label the panel can only ever log "exec js" four
+// times and the user learns nothing — the whole reason the field exists.
+import { describe, it, expect } from 'vitest';
+import { PROTOCOL_VERSION, makeRequestFrame } from '../shared/protocol.ts';
+import { scanNodeSpec } from '../cli/src/commands/scan-node.ts';
+import { execute as mirrorVerify } from '../cli/src/commands/mirror-verify.ts';
+
+interface Call { cmd: string; params: unknown; opts?: { timeoutMs?: number; activity?: string } }
+
+const SPEC = { type: 'FRAME', name: 'Card', width: 100, height: 40 };
+
+/** Records every wire call; answers each command with a plausible reply. */
+function recorder(calls: Call[]) {
+  return async (cmd: string, params: unknown, opts?: { timeoutMs?: number; activity?: string }) => {
+    calls.push({ cmd, params, opts });
+    if (cmd === 'IMPORT_PAYLOAD') return { id: '9:9', name: 'Card', warnings: [] };
+    const code = (params as { code?: string }).code ?? '';
+    return code.includes('remove') ? { result: { removed: true } } : { result: SPEC, ms: 1 };
+  };
+}
+
+describe('makeRequestFrame — the label is additive, never a behaviour change', () => {
+  it('carries the label when one is given', () => {
+    expect(makeRequestFrame('c_1', 'EXEC_JS', { code: '1' }, 'Scan · 1:23'))
+      .toEqual({ id: 'c_1', cmd: 'EXEC_JS', params: { code: '1' }, v: PROTOCOL_VERSION, activity: 'Scan · 1:23' });
+  });
+
+  it('BACKWARD-COMPAT: an unlabelled frame is byte-identical to the pre-label wire', () => {
+    // Not `activity: undefined` — the KEY must be absent, so the serialized frame an
+    // old broker/plugin sees is exactly the one it has always seen.
+    const frame = makeRequestFrame('c_1', 'STATUS', {});
+    expect('activity' in frame).toBe(false);
+    expect(JSON.stringify(frame)).toBe(JSON.stringify({ id: 'c_1', cmd: 'STATUS', params: {}, v: PROTOCOL_VERSION }));
+  });
+
+  it('treats a blank label as no label — never ships an empty row to the panel', () => {
+    expect('activity' in makeRequestFrame('c_1', 'STATUS', {}, '   ')).toBe(false);
+  });
+});
+
+describe('scan-node — labels the wait with the node it is scanning', () => {
+  it('defaults the label to "Scan · <nodeId>"', async () => {
+    const calls: Call[] = [];
+    await scanNodeSpec('1:23', 30_000, recorder(calls));
+    expect(calls[0]?.cmd).toBe('EXEC_JS');
+    expect(calls[0]?.opts?.activity).toBe('Scan · 1:23');
+  });
+
+  it('lets its caller override the label — mirror-verify scans twice, differently', async () => {
+    const calls: Call[] = [];
+    await scanNodeSpec('1:23', 30_000, recorder(calls), 'Mirror-verify · scan rebuild');
+    expect(calls[0]?.opts?.activity).toBe('Mirror-verify · scan rebuild');
+  });
+});
+
+describe('mirror-verify — one label per phase, so the feed reads as a sequence', () => {
+  it('names all four phases distinctly, in order', async () => {
+    const calls: Call[] = [];
+    await mirrorVerify('1:23', { keep: false, timeoutMs: 30_000 }, recorder(calls));
+    expect(calls.map((c) => c.opts?.activity)).toEqual([
+      'Mirror-verify · scan original',
+      'Mirror-verify · rebuild',
+      'Mirror-verify · scan rebuild',
+      'Mirror-verify · remove scratch',
+    ]);
+  });
+
+  it('keeps the labels attached to the right commands', async () => {
+    const calls: Call[] = [];
+    await mirrorVerify('1:23', { keep: false, timeoutMs: 30_000 }, recorder(calls));
+    expect(calls.map((c) => c.cmd)).toEqual(['EXEC_JS', 'IMPORT_PAYLOAD', 'EXEC_JS', 'EXEC_JS']);
+  });
+
+  it('skips the scratch-removal phase (and its label) when --keep is passed', async () => {
+    const calls: Call[] = [];
+    await mirrorVerify('1:23', { keep: true, timeoutMs: 30_000 }, recorder(calls));
+    expect(calls.map((c) => c.opts?.activity)).not.toContain('Mirror-verify · remove scratch');
+  });
+});

--- a/figma-agent/tests/activity-summary.test.ts
+++ b/figma-agent/tests/activity-summary.test.ts
@@ -1,0 +1,81 @@
+// The outcome half of the activity feed: what the plugin can HONESTLY say it just
+// did. The count is derived from the reply the relay already holds — never guessed
+// from the command name — so a script that scanned nothing may not claim a node
+// count, and an import that emitted warnings may not hide them.
+import { describe, it, expect } from 'vitest';
+import {
+  countSpecNodes, summarizeResult, summarizeError,
+} from '../plugin/src/ui/activity-summary.ts';
+
+describe('countSpecNodes — the count is derived from the reply, never guessed', () => {
+  it('counts the root alone', () => {
+    expect(countSpecNodes({ type: 'FRAME', name: 'a' })).toBe(1);
+  });
+  it('counts the whole tree, root included', () => {
+    const spec = {
+      type: 'FRAME', name: 'root',
+      children: [
+        { type: 'TEXT', name: 'a' },
+        { type: 'FRAME', name: 'b', children: [{ type: 'TEXT', name: 'c' }, { type: 'TEXT', name: 'd' }] },
+      ],
+    };
+    expect(countSpecNodes(spec)).toBe(5);
+  });
+  it('is 0 for anything that is not a node spec', () => {
+    expect(countSpecNodes(null)).toBe(0);
+    expect(countSpecNodes({ removed: true })).toBe(0);
+    expect(countSpecNodes('FRAME')).toBe(0);
+  });
+});
+
+describe('summarizeResult — what the plugin can honestly say it did', () => {
+  it('IMPORT_PAYLOAD reports the name it built', () => {
+    expect(summarizeResult('IMPORT_PAYLOAD', { id: '1:2', name: 'Hero card', warnings: [] }))
+      .toBe('→ Hero card');
+  });
+  it('IMPORT_PAYLOAD surfaces warnings rather than burying them', () => {
+    expect(summarizeResult('IMPORT_PAYLOAD', { name: 'Hero', warnings: ['a', 'b'] }))
+      .toBe('→ Hero, 2 warnings');
+    expect(summarizeResult('IMPORT_PAYLOAD', { name: 'Hero', warnings: ['a'] }))
+      .toBe('→ Hero, 1 warning');
+  });
+  it('HTML_TO_FIGMA reads the same shape (the relay converts it to IMPORT_PAYLOAD)', () => {
+    expect(summarizeResult('HTML_TO_FIGMA', { name: 'Landing', warnings: [] })).toBe('→ Landing');
+  });
+  it('EXEC_JS unwraps the {result, console, ms} envelope before counting', () => {
+    const spec = { type: 'FRAME', name: 'root', children: [{ type: 'TEXT', name: 'a' }] };
+    expect(summarizeResult('EXEC_JS', { result: spec, console: [], ms: 12 })).toBe('→ 2 nodes');
+  });
+  it('EXEC_JS counts a bare spec too (no envelope)', () => {
+    expect(summarizeResult('EXEC_JS', { type: 'FRAME', name: 'solo' })).toBe('→ 1 node');
+  });
+  it('EXEC_JS says NOTHING for a script that returned no spec — no fabricated count', () => {
+    // mirror-verify's remove-scratch returns {removed:true}; an ad-hoc script returns
+    // anything at all. Neither scanned a node, so neither may claim a node count.
+    expect(summarizeResult('EXEC_JS', { result: { removed: true }, ms: 3 })).toBeNull();
+    expect(summarizeResult('EXEC_JS', null)).toBeNull();
+    expect(summarizeResult('EXEC_JS', { result: 42, ms: 1 })).toBeNull();
+  });
+  it('is null for a command with nothing countable to report', () => {
+    expect(summarizeResult('STATUS', { ok: true })).toBeNull();
+  });
+});
+
+describe('summarizeError', () => {
+  it('marks the failure with the plugin error message', () => {
+    expect(summarizeError({ code: 'E_PLUGIN_ERROR', message: 'node not found: 1:23' }))
+      .toBe('✗ node not found: 1:23');
+  });
+  it('flattens a multi-line message onto the single row it has', () => {
+    expect(summarizeError({ message: 'line one\n  line two' })).toBe('✗ line one line two');
+  });
+  it('truncates a runaway message rather than blowing up the row', () => {
+    const out = summarizeError({ message: 'x'.repeat(500) });
+    expect(out.length).toBeLessThanOrEqual(122);
+    expect(out.endsWith('…')).toBe(true);
+  });
+  it('still says something when the error carries no message', () => {
+    expect(summarizeError({})).toBe('✗ failed');
+    expect(summarizeError('boom')).toBe('✗ boom');
+  });
+});

--- a/figma-agent/tests/panel-model.test.ts
+++ b/figma-agent/tests/panel-model.test.ts
@@ -1,15 +1,14 @@
 // P2 panel view-model — the pure layer under the DOM controller (panel-ui.ts).
-// Everything the panel decides (which pill/tone/sentence per state, how ages and
-// durations format, the activity ring buffer, onboarding + troubleshoot gating)
-// lives here so it is unit-testable without a DOM, mirroring the connection-state
-// machine's own pure tests.
+// Everything the panel decides (which pill/tone/sentence per state, how ages
+// format, onboarding + troubleshoot gating) lives here so it is unit-testable
+// without a DOM, mirroring the connection-state machine's own pure tests.
+// The activity feed's own model has moved to activity-feed.ts — see
+// activity-feed.test.ts.
 import { describe, it, expect } from 'vitest';
 import {
-  stateView, formatAge, formatDuration, timeAgo, humanizeTool,
-  toActivityRecord, pushActivity, troubleshootHint, showOnboarding,
+  stateView, formatAge, troubleshootHint, showOnboarding,
   togglePanelMode, detailsLabel, compactMeta, PANEL_WIDTH, PANEL_HEIGHT,
   syncPromptLabel, syncResultLabel,
-  type ActivityRecord,
 } from '../plugin/src/ui/panel-model.ts';
 import type { ConnectionState } from '../shared/protocol.ts';
 
@@ -39,7 +38,7 @@ describe('stateView — the four P1 states each map to one view', () => {
   });
 });
 
-describe('formatAge / formatDuration / timeAgo', () => {
+describe('formatAge', () => {
   it('formatAge steps just-now → seconds → minutes → hours', () => {
     expect(formatAge(0)).toBe('just now');
     expect(formatAge(8_000)).toBe('8s');
@@ -47,61 +46,6 @@ describe('formatAge / formatDuration / timeAgo', () => {
     expect(formatAge(3_780_000)).toBe('1h 03m');
     expect(formatAge(-5)).toBe('—');
     expect(formatAge(Number.NaN)).toBe('—');
-  });
-  it('formatDuration is ms under a second, then 1-decimal seconds', () => {
-    expect(formatDuration(12)).toBe('12ms');
-    expect(formatDuration(1_250)).toBe('1.3s');
-    expect(formatDuration(-1)).toBe('—');
-  });
-  it('timeAgo is relative to now', () => {
-    const now = 1_000_000;
-    expect(timeAgo(now, now)).toBe('just now');
-    expect(timeAgo(now, now - 5_000)).toBe('5s ago');
-    expect(timeAgo(now, now - 180_000)).toBe('3m ago');
-    expect(timeAgo(now, now - 7_200_000)).toBe('2h ago');
-  });
-});
-
-describe('humanizeTool', () => {
-  it('lowercases and de-snakes the wire command', () => {
-    expect(humanizeTool('CREATE_FRAME')).toBe('create frame');
-    expect(humanizeTool('HTML_TO_FIGMA')).toBe('html to figma');
-    expect(humanizeTool('STATUS')).toBe('status');
-  });
-});
-
-describe('toActivityRecord — defensive coercion of the CustomEvent detail', () => {
-  it('accepts a well-formed detail', () => {
-    expect(toActivityRecord({ tool: 'STATUS', ok: true, ms: 12, at: 500 }))
-      .toEqual({ tool: 'STATUS', ok: true, ms: 12, at: 500 });
-  });
-  it('rejects a missing/blank tool', () => {
-    expect(toActivityRecord({ ok: true })).toBeNull();
-    expect(toActivityRecord({ tool: '' })).toBeNull();
-    expect(toActivityRecord(null)).toBeNull();
-    expect(toActivityRecord('nope')).toBeNull();
-  });
-  it('coerces bad ms/ok and defaults at', () => {
-    const r = toActivityRecord({ tool: 'X', ms: -3 });
-    expect(r).not.toBeNull();
-    expect(r?.ok).toBe(false);
-    expect(r?.ms).toBe(0);
-    expect(typeof r?.at).toBe('number');
-  });
-});
-
-describe('pushActivity — newest-first, capped at 50', () => {
-  const rec = (n: number): ActivityRecord => ({ tool: `T${n}`, ok: true, ms: n, at: n });
-  it('prepends newest', () => {
-    const buf = pushActivity(pushActivity([], rec(1)), rec(2));
-    expect(buf.map((r) => r.tool)).toEqual(['T2', 'T1']);
-  });
-  it('never exceeds the cap and drops the oldest', () => {
-    let buf: ActivityRecord[] = [];
-    for (let i = 0; i < 60; i++) buf = pushActivity(buf, rec(i));
-    expect(buf).toHaveLength(50);
-    expect(buf[0].tool).toBe('T59'); // newest kept
-    expect(buf.at(-1)?.tool).toBe('T10'); // oldest 10 dropped
   });
 });
 

--- a/tests/figma-plugin-panel.test.ts
+++ b/tests/figma-plugin-panel.test.ts
@@ -18,9 +18,16 @@ import { allContentChecks } from "../src/core/content-checks.js";
 
 const PANEL = fileURLToPath(new URL("../figma-agent/plugin/src/ui/panel.html", import.meta.url));
 const MODEL = fileURLToPath(new URL("../figma-agent/plugin/src/ui/panel-model.ts", import.meta.url));
+// The activity feed's model split out of panel-model.ts once it grew a per-operation
+// vocabulary of its own; panel-model keeps the connection chrome. The rows' outcome
+// lines split again into activity-summary.ts — the relay's half.
+const FEED = fileURLToPath(new URL("../figma-agent/plugin/src/ui/activity-feed.ts", import.meta.url));
+const SUMMARY = fileURLToPath(new URL("../figma-agent/plugin/src/ui/activity-summary.ts", import.meta.url));
 
 const html = readFileSync(PANEL, "utf8");
 const model = readFileSync(MODEL, "utf8");
+const feed = readFileSync(FEED, "utf8");
+const summary = readFileSync(SUMMARY, "utf8");
 
 /** Count content-lint ERROR-severity findings (consumes the shared allContentChecks set). */
 function contentErrors(source: string): number {
@@ -81,11 +88,21 @@ describe("figma-agent P2 panel — states, a11y live regions, motion", () => {
     expect(model).toContain("The broker starts automatically on your first CLI command.");
   });
 
-  it("wires an activity record shape of {tool, ok, ms, at}", () => {
-    expect(model).toContain("tool:");
-    expect(model).toContain("ok:");
-    expect(model).toContain("ms:");
-    expect(model).toContain("at:");
+  it("wires an activity record shape of {id, tool, ok, ms, at}", () => {
+    for (const field of ["id:", "tool:", "ok:", "ms:", "at:"]) {
+      expect(feed, `missing ${field}`).toContain(field);
+    }
+  });
+
+  it("keeps a row's intent label and its outcome — the feed says what ran, not just which cmd", () => {
+    // `cmd` alone is opaque (EXEC_JS is injected code), so the record carries the
+    // CLI's intent label and the plugin-derived result line. Without either, the feed
+    // regresses to "exec js · 1.2s", which is what this whole module exists to fix.
+    expect(feed).toContain("label?:");
+    expect(feed).toContain("result?:");
+    expect(feed).toContain("pending:");
+    expect(summary).toContain("summarizeResult");
+    expect(summary).toContain("summarizeError");
   });
 
   it("marks status + activity as aria-live polite regions", () => {


### PR DESCRIPTION
## The problem

The panel's activity feed logged the wire `cmd`. That is opaque about intent: `EXEC_JS` is *injected code*, so a `scan-node`, both of mirror-verify's scans, its scratch removal and an ad-hoc script were all one indistinguishable row — **"exec js · 1.2s"**. The user watching the plugin work learned nothing.

## The split of labour

The **caller** knows why it called; the **plugin** holds the reply. Each says only its own half:

- **CLI → intent.** `RequestMsg` gains an **optional** `activity` label, set per command — and per *phase* in mirror-verify (`scan original` → `rebuild` → `scan rebuild` → `remove scratch`), so the feed reads as a sequence.
- **Plugin → outcome.** Derived from the reply it already has: `→ 42 nodes` (scan), `→ Hero card, 2 warnings` (import), `✗ <error>` (failure).

A command with nothing countable to report says nothing — `remove scratch` returns `{removed:true}` and is **not** given a fabricated node count.

## In-flight rows

Rows now open on arrival (`pending`, "running…") and land their result **by request id**. Two things follow: the panel shows what is running *while it runs* — a 60s `html-to-figma` is exactly when "what is it doing?" gets asked — and a reply can never credit the wrong row when two commands overlap (the panel is shared by every CLI caller, so "newest row" ≠ "this reply's row").

## Backward compatibility

`makeRequestFrame` **omits** the key entirely when unlabelled — not `activity: undefined` — so an unlabelled frame serializes byte-identically to what every pre-label CLI sent, and the plugin falls back to humanizing `cmd`. The broker relays frames verbatim and was not touched. Tested both ends.

## Notes for review

- **`main.ts` is untouched.** The relay already owns the request lifecycle *and* sees the reply, so it needs no help from the main thread — this is the existing seam (`emitActivity`), extended.
- **Reconcile** runs in the kernel (`ui figma reconcile --apply`, broker-spawned) and sends no wire command. The feed logs it from the two ends it *can* observe (the click, `SYNC_RESULT`), repeating `syncResultLabel` verbatim — including **"Nothing synced"**, which a feed that only said "done" would quietly upgrade to a lie.
- **Brand untouched** — two-line rows use existing tokens only; the 4-linter gate on `panel.html` still passes.
- `code.js` is byte-unchanged (no main-thread change); `ui.html` rebuilt and committed.

## Verification

4 BARE gates green · figma-agent typecheck + build + **431 tests / 41 files** · root **1891 passed**. Not live-tested — reload the plugin to see the feed.