### PR TITLE
fix: stop the activity feed's timestamps from squeezing the label down to "R"

### DIFF
--- a/figma-agent/plugin/src/ui/activity-feed.ts
+++ b/figma-agent/plugin/src/ui/activity-feed.ts
@@ -41,7 +41,7 @@ export function activityLabel(rec: ActivityRecord): string {
   return label !== '' ? label : humanizeTool(rec.tool);
 }
 
-/** Wall-clock stamp for a row: "14:32:07" (local time, zero-padded). */
+/** Wall-clock stamp for a row: "14:32:07" (local time, zero-padded). Kept for the status snapshot. */
 export function formatClock(at: number): string {
   if (!Number.isFinite(at)) return '--:--:--';
   const d = new Date(at);
@@ -64,6 +64,21 @@ export function timeAgo(nowMs: number, atMs: number): string {
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m ago`;
   return `${Math.floor(m / 60)}h ago`;
+}
+
+/**
+ * The row's SECOND line — outcome and timing folded into ONE muted sentence:
+ *   "→ 42 nodes · 173ms · 2m ago" | "running… · just now" | "✗ node not found · 8ms · 3s ago"
+ * Deliberately carries no wall-clock stamp: the relative age already answers "when",
+ * and the absolute time is what used to crowd the label — the only line that says WHAT
+ * the plugin is doing — off the row entirely on a narrow panel.
+ */
+export function activityMeta(rec: ActivityRecord, now: number): string {
+  const parts: string[] = [];
+  if (rec.result) parts.push(rec.result);
+  parts.push(rec.pending ? 'running…' : formatDuration(rec.ms));
+  parts.push(timeAgo(now, rec.at));
+  return parts.join(' · ');
 }
 
 /**

--- a/figma-agent/plugin/src/ui/panel-ui.ts
+++ b/figma-agent/plugin/src/ui/panel-ui.ts
@@ -16,7 +16,7 @@ import {
   type PanelMode,
 } from './panel-model';
 import {
-  activityLabel, formatClock, formatDuration, timeAgo,
+  activityLabel, activityMeta,
   toActivityRecord, toActivityResult, pushActivity, resolveActivity,
   type ActivityRecord,
 } from './activity-feed';
@@ -85,11 +85,12 @@ function renderDetails(): void {
 const ACTIVITY_ROWS = 20;
 
 /**
- * One feed row — two lines:
- *   ● 14:32:07  MIRROR-VERIFY · REBUILD            1.2s · 5s ago
- *               → Hero card, 2 warnings
- * The second line is omitted while a request is in flight (no outcome yet) and
- * whenever the command had nothing countable to report.
+ * One feed row — the LABEL is the hero, the timing is footnote:
+ *   ● Mirror-verify · rebuild
+ *     → Hero card · 2 warnings · 1.2s · 5s ago
+ * The priority is deliberate. The old row laid time/label/duration out on ONE flex
+ * line, so on a ~300px panel the two fixed-width footnotes ate the width and the
+ * label — the only part that says WHAT is happening — ellipsised down to "R".
  */
 function activityRow(r: ActivityRecord, now: number): HTMLElement {
   const li = document.createElement('li');
@@ -100,36 +101,19 @@ function activityRow(r: ActivityRecord, now: number): HTMLElement {
   dot.dataset.ok = String(r.ok);
   dot.dataset.pending = String(r.pending);
 
-  const time = document.createElement('span');
-  time.className = 'log-time';
-  time.textContent = formatClock(r.at);
+  const label = document.createElement('div');
+  label.className = 'log-label';
+  label.textContent = activityLabel(r);
 
-  const tool = document.createElement('span');
-  tool.className = 'log-tool';
-  tool.textContent = activityLabel(r);
-
-  const m = document.createElement('span');
+  // One muted line: outcome (if any) + duration (or "running…") + relative age.
+  const m = document.createElement('div');
   m.className = 'log-meta';
-  // Pending rows have no duration to report yet — they say so instead of showing "0ms".
-  m.textContent = r.pending
-    ? 'running…'
-    : `${r.ok ? '' : 'failed · '}${formatDuration(r.ms)} · ${timeAgo(now, r.at)}`;
-
-  const head = document.createElement('div');
-  head.className = 'log-head';
-  head.append(time, tool, m);
+  m.dataset.ok = String(r.ok);
+  m.textContent = activityMeta(r, now);
 
   const body = document.createElement('div');
   body.className = 'log-body';
-  body.append(head);
-
-  if (r.result) {
-    const res = document.createElement('div');
-    res.className = 'log-result';
-    res.dataset.ok = String(r.ok);
-    res.textContent = r.result;
-    body.append(res);
-  }
+  body.append(label, m);
 
   li.append(dot, body);
   return li;

--- a/figma-agent/plugin/src/ui/panel.html
+++ b/figma-agent/plugin/src/ui/panel.html
@@ -418,7 +418,9 @@ code {
   color: var(--color-muted-foreground);
 }
 
-/* Activity band — mono, uppercase-tracked rows. */
+/* Activity band — mono rows, but SENTENCE-case and untracked: this is the one place
+   in the chrome a human READS prose rather than scans a data chip, and the brand's
+   uppercase tracking cost more legibility here than it bought identity. */
 .activity {
   border-top: 2px solid var(--color-foreground);
   padding: var(--space-1) var(--space-2);
@@ -433,19 +435,19 @@ code {
   max-height: 180px;
   overflow-y: auto;
 }
-/* A row is [dot][body], where body stacks the head line over the result line. */
+/* A row is [dot][body], where body stacks the LABEL over the meta line. Nothing
+   shares the label's line: on a ~300px panel a side-by-side stamp and duration
+   squeezed it to a single ellipsised letter, which is what this band is FOR. */
 .activity-row {
   display: flex;
   align-items: flex-start;
-  gap: var(--space-2);
-  padding: 2px 0;
+  gap: var(--space-1);
   font-family: var(--font-mono);
-  font-size: var(--font-size-xs);
 }
 .log-dot {
   width: 6px;
   height: 6px;
-  margin-top: 4px; /* optically centred on the head line, not the whole row */
+  margin-top: 5px; /* optically centred on the label line, not the whole row */
   flex: 0 0 auto;
   background: var(--color-success);
 }
@@ -454,43 +456,30 @@ code {
 .log-dot[data-pending="true"] { background: var(--color-warning); }
 .log-body {
   flex: 1 1 auto;
-  min-width: 0; /* lets the ellipsis in .log-tool / .log-result actually engage */
+  min-width: 0; /* lets the ellipsis in .log-label / .log-meta actually engage */
 }
-.log-head {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-2);
-}
-.log-time {
-  flex: 0 0 auto;
-  color: var(--color-muted-foreground);
-  font-variant-numeric: tabular-nums;
-}
-.log-tool {
-  font-weight: var(--font-weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+/* The hero line — what the plugin is doing, on what. Owns the full row width. */
+.log-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
   color: var(--color-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* The footnote — outcome + duration + age, one muted line under the label. */
 .log-meta {
-  margin-left: auto;
-  flex: 0 0 auto;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
   color: var(--color-muted-foreground);
   font-variant-numeric: tabular-nums;
-}
-/* Result line — indented under the label, one line, truncated. */
-.log-result {
-  color: var(--color-muted-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.log-result[data-ok="false"] { color: var(--color-danger); }
+/* A failure's outcome IS this line ("✗ node not found · …") — colour the whole line. */
+.log-meta[data-ok="false"] { color: var(--color-danger); }
 .activity-empty {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);

--- a/figma-agent/plugin/ui.html
+++ b/figma-agent/plugin/ui.html
@@ -418,7 +418,9 @@ code {
   color: var(--color-muted-foreground);
 }
 
-/* Activity band — mono, uppercase-tracked rows. */
+/* Activity band — mono rows, but SENTENCE-case and untracked: this is the one place
+   in the chrome a human READS prose rather than scans a data chip, and the brand's
+   uppercase tracking cost more legibility here than it bought identity. */
 .activity {
   border-top: 2px solid var(--color-foreground);
   padding: var(--space-1) var(--space-2);
@@ -433,19 +435,19 @@ code {
   max-height: 180px;
   overflow-y: auto;
 }
-/* A row is [dot][body], where body stacks the head line over the result line. */
+/* A row is [dot][body], where body stacks the LABEL over the meta line. Nothing
+   shares the label's line: on a ~300px panel a side-by-side stamp and duration
+   squeezed it to a single ellipsised letter, which is what this band is FOR. */
 .activity-row {
   display: flex;
   align-items: flex-start;
-  gap: var(--space-2);
-  padding: 2px 0;
+  gap: var(--space-1);
   font-family: var(--font-mono);
-  font-size: var(--font-size-xs);
 }
 .log-dot {
   width: 6px;
   height: 6px;
-  margin-top: 4px; /* optically centred on the head line, not the whole row */
+  margin-top: 5px; /* optically centred on the label line, not the whole row */
   flex: 0 0 auto;
   background: var(--color-success);
 }
@@ -454,43 +456,30 @@ code {
 .log-dot[data-pending="true"] { background: var(--color-warning); }
 .log-body {
   flex: 1 1 auto;
-  min-width: 0; /* lets the ellipsis in .log-tool / .log-result actually engage */
+  min-width: 0; /* lets the ellipsis in .log-label / .log-meta actually engage */
 }
-.log-head {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-2);
-}
-.log-time {
-  flex: 0 0 auto;
-  color: var(--color-muted-foreground);
-  font-variant-numeric: tabular-nums;
-}
-.log-tool {
-  font-weight: var(--font-weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+/* The hero line — what the plugin is doing, on what. Owns the full row width. */
+.log-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
   color: var(--color-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* The footnote — outcome + duration + age, one muted line under the label. */
 .log-meta {
-  margin-left: auto;
-  flex: 0 0 auto;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
   color: var(--color-muted-foreground);
   font-variant-numeric: tabular-nums;
-}
-/* Result line — indented under the label, one line, truncated. */
-.log-result {
-  color: var(--color-muted-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.log-result[data-ok="false"] { color: var(--color-danger); }
+/* A failure's outcome IS this line ("✗ node not found · …") — colour the whole line. */
+.log-meta[data-ok="false"] { color: var(--color-danger); }
 .activity-empty {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
@@ -741,12 +730,6 @@ code {
     const label = typeof rec.label === "string" ? rec.label.trim() : "";
     return label !== "" ? label : humanizeTool(rec.tool);
   }
-  function formatClock(at) {
-    if (!Number.isFinite(at)) return "--:--:--";
-    const d = new Date(at);
-    const pad = (n) => String(n).padStart(2, "0");
-    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-  }
   function formatDuration(ms) {
     if (!Number.isFinite(ms) || ms < 0) return "\u2014";
     if (ms < 1e3) return `${Math.round(ms)}ms`;
@@ -759,6 +742,13 @@ code {
     const m = Math.floor(s / 60);
     if (m < 60) return `${m}m ago`;
     return `${Math.floor(m / 60)}h ago`;
+  }
+  function activityMeta(rec, now) {
+    const parts = [];
+    if (rec.result) parts.push(rec.result);
+    parts.push(rec.pending ? "running\u2026" : formatDuration(rec.ms));
+    parts.push(timeAgo(now, rec.at));
+    return parts.join(" \xB7 ");
   }
   function toActivityRecord(detail) {
     if (detail === null || typeof detail !== "object") return null;
@@ -863,28 +853,16 @@ code {
     dot2.className = "log-dot";
     dot2.dataset.ok = String(r.ok);
     dot2.dataset.pending = String(r.pending);
-    const time = document.createElement("span");
-    time.className = "log-time";
-    time.textContent = formatClock(r.at);
-    const tool = document.createElement("span");
-    tool.className = "log-tool";
-    tool.textContent = activityLabel(r);
-    const m = document.createElement("span");
+    const label = document.createElement("div");
+    label.className = "log-label";
+    label.textContent = activityLabel(r);
+    const m = document.createElement("div");
     m.className = "log-meta";
-    m.textContent = r.pending ? "running\u2026" : `${r.ok ? "" : "failed \xB7 "}${formatDuration(r.ms)} \xB7 ${timeAgo(now, r.at)}`;
-    const head = document.createElement("div");
-    head.className = "log-head";
-    head.append(time, tool, m);
+    m.dataset.ok = String(r.ok);
+    m.textContent = activityMeta(r, now);
     const body = document.createElement("div");
     body.className = "log-body";
-    body.append(head);
-    if (r.result) {
-      const res = document.createElement("div");
-      res.className = "log-result";
-      res.dataset.ok = String(r.ok);
-      res.textContent = r.result;
-      body.append(res);
-    }
+    body.append(label, m);
     li.append(dot2, body);
     return li;
   }

--- a/figma-agent/tests/activity-feed.test.ts
+++ b/figma-agent/tests/activity-feed.test.ts
@@ -5,7 +5,7 @@
 // human watching the plugin work, so a wrong one is a lie, not a cosmetic bug.
 import { describe, it, expect } from 'vitest';
 import {
-  activityLabel, humanizeTool, formatClock, formatDuration, timeAgo,
+  activityLabel, activityMeta, humanizeTool, formatClock, formatDuration, timeAgo,
   toActivityRecord, toActivityResult, pushActivity, resolveActivity,
   type ActivityRecord,
 } from '../plugin/src/ui/activity-feed.ts';
@@ -53,6 +53,27 @@ describe('formatClock / formatDuration / timeAgo', () => {
     expect(timeAgo(now, now - 5_000)).toBe('5s ago');
     expect(timeAgo(now, now - 180_000)).toBe('3m ago');
     expect(timeAgo(now, now - 7_200_000)).toBe('2h ago');
+  });
+});
+
+describe('activityMeta — the row FOOTNOTE: outcome + timing on one line, never the label', () => {
+  it('folds outcome, duration and age into one sentence', () => {
+    const r = rec({ at: 1_000, ms: 173, pending: false, result: '→ 42 nodes' });
+    expect(activityMeta(r, 121_000)).toBe('→ 42 nodes · 173ms · 2m ago');
+  });
+  it('an in-flight row has no duration to report — it says so instead of "0ms"', () => {
+    expect(activityMeta(rec({ at: 1_000 }), 1_000)).toBe('running… · just now');
+  });
+  it('a failure reads its own error, not a generic "failed"', () => {
+    const r = rec({ at: 1_000, ms: 8, pending: false, ok: false, result: '✗ node not found' });
+    expect(activityMeta(r, 4_000)).toBe('✗ node not found · 8ms · 3s ago');
+  });
+  it('a command with nothing countable to report still times itself', () => {
+    expect(activityMeta(rec({ at: 1_000, ms: 40, pending: false }), 6_000)).toBe('40ms · 5s ago');
+  });
+  it('carries NO wall-clock stamp — the age already answers "when", and the stamp is what crowded out the label', () => {
+    const meta = activityMeta(rec({ at: new Date(2026, 6, 16, 9, 5, 3).getTime(), ms: 5, pending: false }), Date.now());
+    expect(meta).not.toContain('09:05:03');
   });
 });
 


### PR DESCRIPTION
## Problem (owner, a designer, called the feed useless)

`.log-head` laid the row out as one flex line: `[.log-time | .log-tool | .log-meta]`. `.log-time` ("22:44:46") is `flex: 0 0 auto` and `.log-meta` ("1.9S · 16S AGO") is `margin-left: auto` — the two **footnotes** claim the width first. `.log-tool`, which carries the *intent*, had no `flex-grow` and did have an ellipsis, so on the real ~300px panel it collapsed to `R` / `R…`.

Priority was inverted: secondary info covered primary info.

## New row

Label is the hero and owns the full width; timing is a footnote beneath it.

```
● Mirror-verify · rebuild
  → Hero card · 2 warnings · 1.2s · 16s ago
● Scan · 25579:749755
  → 42 nodes · 173ms · 2m ago
● Run script
  running… · just now
● Scan · 1:23
  ✗ node not found · 8ms · 3s ago      ← whole line renders danger
```

(That block is real output from `activityLabel` + `activityMeta`, not a mock.)

- **Line 1** `.log-label` — `font-size-sm`, `font-weight-medium`, `line-height 1.4`, sentence-case, **no tracking**, `flex: 1 1 auto; min-width: 0`. Ellipsis only when genuinely long. The uppercase and tracking were CSS-only — the CLI already names intents in sentence-case (`Mirror-verify · rebuild`), so no CLI/label change was needed.
- **Line 2** `.log-meta` — `font-size-xs`, muted, `tabular-nums`. New pure `activityMeta(rec, now)` folds outcome + duration + age into one string. `data-ok="false"` colours the **whole** line danger, because on a failure that line *is* the error.
- **Absolute stamp dropped from the row.** `16s ago` already answers "when", and the stamp is what crowded the label out. `formatClock` keeps its export — the Copy-status snapshot and its tests still use it.
- Spacing: `--space-1` (8px) row gap, `1.4` line-height, dot re-centred optically on the label line.
- Brand held: mono, existing colour tokens only, radius 0, no animation, no gradient.

## Verify

- `figma-agent`: typecheck clean · **436 tests pass** (431 + 5 new `activityMeta` cases: folded line, pending `running…`, failure reads its own error, no-result row still times itself, and a regression test that the meta line carries **no** wall-clock stamp).
- Root BARE gates: `typecheck` · `lint` · `build` · `test` (**1891 pass**, 4 skipped) all green.
- 4-linter gate on the generated `plugin/ui.html`: `validate-layout` **0 errors**, `taste-lint` **0 violations**, `a11y-lint` **0 findings**, `content-lint` **0 errors**. Warning counts are byte-identical to `origin/main` (5 layout / 1 content, all pre-existing in bundled code) — this diff adds none.
- `npm run build` re-ran; regenerated `ui.html` is committed. `code.js` is untouched (no main-thread change).

## Not verified

Not yet seen on a live Figma canvas — needs the plugin open. The widths above are computed from the tokens (JetBrains Mono at 16px ≈ 26 chars in the row's ~254px), not measured in the plugin iframe.