### PR TITLE
feat: shrink the activity feed to a mini data-log, and give status a shape

### DIFF
--- a/figma-agent/plugin/src/ui/activity-feed.ts
+++ b/figma-agent/plugin/src/ui/activity-feed.ts
@@ -49,29 +49,52 @@ export function formatClock(at: number): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-/** A completed request's duration: "12ms" under a second, else "1.2s". */
+/** Absolute stamp for a row's `title`: "2026-07-16 14:32:07" (local). The compact age
+ *  ("2m") is unreadable to a screen reader — "1m" gets announced as "1 meter" — and
+ *  answers "how long ago", never "when". This is the hover/AT answer to "when". */
+export function formatTimestamp(at: number): string {
+  if (!Number.isFinite(at)) return '—';
+  const d = new Date(at);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${formatClock(at)}`;
+}
+
+/** A completed request's duration: "12ms" under a second, "1.2s" under a minute, else "2m 4s". */
 export function formatDuration(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return '—';
   if (ms < 1000) return `${Math.round(ms)}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const total = Math.round(ms / 1000);
+  return `${Math.floor(total / 60)}m ${total % 60}s`;
 }
 
-/** Relative time for the activity log: "just now", "5s ago", "3m ago", "2h ago". */
+/**
+ * Relative age for the activity log, COMPACT: "now", "5s", "3m", "2h" — no "ago".
+ * The column already means "ago", so the word is 4 characters of pure repetition on
+ * the row whose whole problem is width; it is the last thing on the meta line, so it
+ * is also the first thing truncation eats. The absolute time survives in the `title`
+ * (formatTimestamp) for anyone who needs to actually read it.
+ */
 export function timeAgo(nowMs: number, atMs: number): string {
   const s = Math.floor((nowMs - atMs) / 1000);
-  if (s < 1) return 'just now';
-  if (s < 60) return `${s}s ago`;
+  if (s < 1) return 'now';
+  if (s < 60) return `${s}s`;
   const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  return `${Math.floor(m / 60)}h ago`;
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
 }
 
 /**
  * The row's SECOND line — outcome and timing folded into ONE muted sentence:
- *   "→ 42 nodes · 173ms · 2m ago" | "running… · just now" | "✗ node not found · 8ms · 3s ago"
+ *   "→ 42 nodes · 173ms · 2m" | "running… · now" | "✗ node not found · 8ms · 3s"
  * Deliberately carries no wall-clock stamp: the relative age already answers "when",
  * and the absolute time is what used to crowd the label — the only line that says WHAT
- * the plugin is doing — off the row entirely on a narrow panel.
+ * the plugin is doing — off the row entirely on a narrow panel. It survives in the
+ * row's `title` instead (panel-ui.ts).
+ *
+ * Part ORDER is outcome-first on purpose: the parts are ellipsised from the right, so
+ * the least-durable fact (the age, which the 1s heartbeat re-renders anyway) is the
+ * one truncation eats, and the outcome — the reason to read the row — never is.
  */
 export function activityMeta(rec: ActivityRecord, now: number): string {
   const parts: string[] = [];

--- a/figma-agent/plugin/src/ui/panel-ui.ts
+++ b/figma-agent/plugin/src/ui/panel-ui.ts
@@ -16,7 +16,7 @@ import {
   type PanelMode,
 } from './panel-model';
 import {
-  activityLabel, activityMeta,
+  activityLabel, activityMeta, formatTimestamp,
   toActivityRecord, toActivityResult, pushActivity, resolveActivity,
   type ActivityRecord,
 } from './activity-feed';
@@ -87,29 +87,40 @@ const ACTIVITY_ROWS = 20;
 /**
  * One feed row — the LABEL is the hero, the timing is footnote:
  *   ● Mirror-verify · rebuild
- *     → Hero card · 2 warnings · 1.2s · 5s ago
+ *     → Hero card · 2 warnings · 1.2s · 16s
  * The priority is deliberate. The old row laid time/label/duration out on ONE flex
  * line, so on a ~300px panel the two fixed-width footnotes ate the width and the
  * label — the only part that says WHAT is happening — ellipsised down to "R".
+ *
+ * `stale` dims every row but the newest (recency, at zero vertical cost). The mark's
+ * SHAPE carries the state (filled / hollow / ✗) because colour alone is not a channel
+ * every eye has, and its aria-label carries it again because neither is a channel a
+ * screen reader has.
  */
-function activityRow(r: ActivityRecord, now: number): HTMLElement {
+function activityRow(r: ActivityRecord, now: number, stale: boolean): HTMLElement {
   const li = document.createElement('li');
-  li.className = 'activity-row';
+  li.className = stale ? 'activity-row is-stale' : 'activity-row';
 
   const dot = document.createElement('span');
   dot.className = 'log-dot';
   dot.dataset.ok = String(r.ok);
   dot.dataset.pending = String(r.pending);
+  const state = r.pending ? 'running' : (r.ok ? 'ok' : 'failed');
+  dot.setAttribute('aria-label', state);
+  // A failure IS the ✗ (CSS drops the square for it); the other two are the square.
+  dot.textContent = state === 'failed' ? '✗' : '';
 
   const label = document.createElement('div');
   label.className = 'log-label';
   label.textContent = activityLabel(r);
+  label.title = activityLabel(r); // the row ellipsises — hover still tells the truth
 
-  // One muted line: outcome (if any) + duration (or "running…") + relative age.
+  // One muted line: outcome (if any) + duration (or "running…") + compact age.
   const m = document.createElement('div');
   m.className = 'log-meta';
   m.dataset.ok = String(r.ok);
   m.textContent = activityMeta(r, now);
+  m.title = formatTimestamp(r.at); // the compact age never says WHEN; this does
 
   const body = document.createElement('div');
   body.className = 'log-body';
@@ -121,7 +132,9 @@ function activityRow(r: ActivityRecord, now: number): HTMLElement {
 
 function renderActivity(now: number): void {
   if (activity.length === 0) return; // leave the static "No activity yet" empty-state row
-  activityList.replaceChildren(...activity.slice(0, ACTIVITY_ROWS).map((r) => activityRow(r, now)));
+  activityList.replaceChildren(
+    ...activity.slice(0, ACTIVITY_ROWS).map((r, i) => activityRow(r, now, i > 0)),
+  );
 }
 
 function render(): void {

--- a/figma-agent/plugin/src/ui/panel.html
+++ b/figma-agent/plugin/src/ui/panel.html
@@ -216,11 +216,21 @@
 /* Panel override (spec P5 §Tokens): the plugin iframe cannot fetch a webfont, so
    the display/body families keep Inter first but fall back to the host system
    stack — self-contained, no network. A mono family var carries the brand's
-   JetBrains-Mono data/label voice (falls back to the system monospace). */
+   JetBrains-Mono data/label voice (falls back to the system monospace).
+
+   The two sub-xs sizes and the hair space are PANEL-ONLY, and live here rather
+   than in the compiled block above on purpose: the brand scale bottoms out at
+   --font-size-xs (14px) because it is authored for page surfaces, whereas this
+   is a 300px-wide dense DATA LOG — the one place the chrome shows a scannable
+   history rather than prose. Regenerating the brand tokens must not clobber them.
+   11px is the floor: below it the mono digits stop being legible at 1× zoom. */
 :root {
   --font-family-body: Inter, -apple-system, system-ui, sans-serif;
   --font-family-display: Inter, -apple-system, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+  --font-size-2xs: 12px; /* feed label — the dense-feed primary */
+  --font-size-3xs: 11px; /* feed meta — the floor */
+  --space-hair: 4px;     /* the sub-space-1 gap a mini row needs */
 }
 
 /* ── Panel chrome — Swiss Monolith brutalism, COMPACT-FIRST (P5.1) ─────────────
@@ -431,38 +441,62 @@ code {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
-  max-height: 180px;
+  gap: var(--space-hair);
+  max-height: 168px; /* ~7 mini rows — the band scrolls past that */
   overflow-y: auto;
 }
 /* A row is [dot][body], where body stacks the LABEL over the meta line. Nothing
    shares the label's line: on a ~300px panel a side-by-side stamp and duration
-   squeezed it to a single ellipsised letter, which is what this band is FOR. */
+   squeezed it to a single ellipsised letter, which is what this band is FOR.
+   Mini sizing (~31px/row, was ~44px): a log is READ BY SCANNING, so more history
+   on screen beats a larger typeface — the density IS the legibility here. */
 .activity-row {
   display: flex;
   align-items: flex-start;
-  gap: var(--space-1);
+  gap: var(--space-hair);
   font-family: var(--font-mono);
 }
+/* Every row but the newest is dimmed. Recency needs a channel, and dimming the
+   past costs no vertical space — which is the whole currency of this band. */
+.activity-row.is-stale { opacity: 0.6; }
+/* Status reads by SHAPE first, colour second (a hue-only signal is invisible to a
+   colour-blind eye): ok = filled square, running = hollow, failed = an ink ✗. */
 .log-dot {
   width: 6px;
   height: 6px;
-  margin-top: 5px; /* optically centred on the label line, not the whole row */
+  margin-top: 4px; /* optically centred on the smaller label line, not the row */
   flex: 0 0 auto;
   background: var(--color-success);
 }
-.log-dot[data-ok="false"] { background: var(--color-danger); }
-/* In-flight beats the ok/fail colour — nothing has been decided yet. */
-.log-dot[data-pending="true"] { background: var(--color-warning); }
+/* In-flight beats the ok/fail colour — nothing has been decided yet. It also goes
+   HOLLOW and breathes, so "still running" is legible without reading the meta. */
+.log-dot[data-pending="true"] {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--color-warning);
+  animation: fga-breathe 1s ease-in-out infinite;
+}
+/* A failure swaps the mark entirely — same glyph the meta line already uses. The
+   box stays pinned at 6px (the ✗ is a hair wider and simply overhangs into the gap)
+   so every row's label starts on the SAME left edge: in a column read by scanning,
+   that edge is the anchor, and a per-row glyph width would ripple it. */
+.log-dot[data-ok="false"][data-pending="false"] {
+  height: auto;
+  margin-top: 0;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-3xs);
+  line-height: 1.35;
+  color: var(--color-danger);
+}
 .log-body {
   flex: 1 1 auto;
   min-width: 0; /* lets the ellipsis in .log-label / .log-meta actually engage */
 }
 /* The hero line — what the plugin is doing, on what. Owns the full row width. */
 .log-label {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-2xs);
   font-weight: var(--font-weight-medium);
-  line-height: 1.4;
+  line-height: 1.35;
   color: var(--color-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -470,8 +504,8 @@ code {
 }
 /* The footnote — outcome + duration + age, one muted line under the label. */
 .log-meta {
-  font-size: var(--font-size-xs);
-  line-height: 1.4;
+  font-size: var(--font-size-3xs);
+  line-height: 1.35;
   color: var(--color-muted-foreground);
   font-variant-numeric: tabular-nums;
   overflow: hidden;
@@ -554,8 +588,17 @@ code {
   0%   { opacity: 0.5; transform: scale(1); }
   100% { opacity: 0;   transform: scale(2.4); }
 }
+/* The in-flight feed mark breathes. This is a STATUS channel, not decoration — it
+   is the only thing distinguishing "running" from "finished" at a glance — so it
+   animates opacity alone (never a layout prop) and stops under reduced-motion,
+   where the hollow shape still carries the state on its own. */
+@keyframes fga-breathe {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+}
 @media (prefers-reduced-motion: reduce) {
   .status-dot.is-pulsing::after { animation: none; }
+  .log-dot[data-pending="true"] { animation: none; }
   .footer-cell { transition: none; }
 }
 </style>

--- a/figma-agent/plugin/ui.html
+++ b/figma-agent/plugin/ui.html
@@ -216,11 +216,21 @@
 /* Panel override (spec P5 §Tokens): the plugin iframe cannot fetch a webfont, so
    the display/body families keep Inter first but fall back to the host system
    stack — self-contained, no network. A mono family var carries the brand's
-   JetBrains-Mono data/label voice (falls back to the system monospace). */
+   JetBrains-Mono data/label voice (falls back to the system monospace).
+
+   The two sub-xs sizes and the hair space are PANEL-ONLY, and live here rather
+   than in the compiled block above on purpose: the brand scale bottoms out at
+   --font-size-xs (14px) because it is authored for page surfaces, whereas this
+   is a 300px-wide dense DATA LOG — the one place the chrome shows a scannable
+   history rather than prose. Regenerating the brand tokens must not clobber them.
+   11px is the floor: below it the mono digits stop being legible at 1× zoom. */
 :root {
   --font-family-body: Inter, -apple-system, system-ui, sans-serif;
   --font-family-display: Inter, -apple-system, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+  --font-size-2xs: 12px; /* feed label — the dense-feed primary */
+  --font-size-3xs: 11px; /* feed meta — the floor */
+  --space-hair: 4px;     /* the sub-space-1 gap a mini row needs */
 }
 
 /* ── Panel chrome — Swiss Monolith brutalism, COMPACT-FIRST (P5.1) ─────────────
@@ -431,38 +441,62 @@ code {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
-  max-height: 180px;
+  gap: var(--space-hair);
+  max-height: 168px; /* ~7 mini rows — the band scrolls past that */
   overflow-y: auto;
 }
 /* A row is [dot][body], where body stacks the LABEL over the meta line. Nothing
    shares the label's line: on a ~300px panel a side-by-side stamp and duration
-   squeezed it to a single ellipsised letter, which is what this band is FOR. */
+   squeezed it to a single ellipsised letter, which is what this band is FOR.
+   Mini sizing (~31px/row, was ~44px): a log is READ BY SCANNING, so more history
+   on screen beats a larger typeface — the density IS the legibility here. */
 .activity-row {
   display: flex;
   align-items: flex-start;
-  gap: var(--space-1);
+  gap: var(--space-hair);
   font-family: var(--font-mono);
 }
+/* Every row but the newest is dimmed. Recency needs a channel, and dimming the
+   past costs no vertical space — which is the whole currency of this band. */
+.activity-row.is-stale { opacity: 0.6; }
+/* Status reads by SHAPE first, colour second (a hue-only signal is invisible to a
+   colour-blind eye): ok = filled square, running = hollow, failed = an ink ✗. */
 .log-dot {
   width: 6px;
   height: 6px;
-  margin-top: 5px; /* optically centred on the label line, not the whole row */
+  margin-top: 4px; /* optically centred on the smaller label line, not the row */
   flex: 0 0 auto;
   background: var(--color-success);
 }
-.log-dot[data-ok="false"] { background: var(--color-danger); }
-/* In-flight beats the ok/fail colour — nothing has been decided yet. */
-.log-dot[data-pending="true"] { background: var(--color-warning); }
+/* In-flight beats the ok/fail colour — nothing has been decided yet. It also goes
+   HOLLOW and breathes, so "still running" is legible without reading the meta. */
+.log-dot[data-pending="true"] {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--color-warning);
+  animation: fga-breathe 1s ease-in-out infinite;
+}
+/* A failure swaps the mark entirely — same glyph the meta line already uses. The
+   box stays pinned at 6px (the ✗ is a hair wider and simply overhangs into the gap)
+   so every row's label starts on the SAME left edge: in a column read by scanning,
+   that edge is the anchor, and a per-row glyph width would ripple it. */
+.log-dot[data-ok="false"][data-pending="false"] {
+  height: auto;
+  margin-top: 0;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-3xs);
+  line-height: 1.35;
+  color: var(--color-danger);
+}
 .log-body {
   flex: 1 1 auto;
   min-width: 0; /* lets the ellipsis in .log-label / .log-meta actually engage */
 }
 /* The hero line — what the plugin is doing, on what. Owns the full row width. */
 .log-label {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-2xs);
   font-weight: var(--font-weight-medium);
-  line-height: 1.4;
+  line-height: 1.35;
   color: var(--color-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -470,8 +504,8 @@ code {
 }
 /* The footnote — outcome + duration + age, one muted line under the label. */
 .log-meta {
-  font-size: var(--font-size-xs);
-  line-height: 1.4;
+  font-size: var(--font-size-3xs);
+  line-height: 1.35;
   color: var(--color-muted-foreground);
   font-variant-numeric: tabular-nums;
   overflow: hidden;
@@ -554,8 +588,17 @@ code {
   0%   { opacity: 0.5; transform: scale(1); }
   100% { opacity: 0;   transform: scale(2.4); }
 }
+/* The in-flight feed mark breathes. This is a STATUS channel, not decoration — it
+   is the only thing distinguishing "running" from "finished" at a glance — so it
+   animates opacity alone (never a layout prop) and stops under reduced-motion,
+   where the hollow shape still carries the state on its own. */
+@keyframes fga-breathe {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+}
 @media (prefers-reduced-motion: reduce) {
   .status-dot.is-pulsing::after { animation: none; }
+  .log-dot[data-pending="true"] { animation: none; }
   .footer-cell { transition: none; }
 }
 </style>
@@ -730,18 +773,32 @@ code {
     const label = typeof rec.label === "string" ? rec.label.trim() : "";
     return label !== "" ? label : humanizeTool(rec.tool);
   }
+  function formatClock(at) {
+    if (!Number.isFinite(at)) return "--:--:--";
+    const d = new Date(at);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  }
+  function formatTimestamp(at) {
+    if (!Number.isFinite(at)) return "\u2014";
+    const d = new Date(at);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${formatClock(at)}`;
+  }
   function formatDuration(ms) {
     if (!Number.isFinite(ms) || ms < 0) return "\u2014";
     if (ms < 1e3) return `${Math.round(ms)}ms`;
-    return `${(ms / 1e3).toFixed(1)}s`;
+    if (ms < 6e4) return `${(ms / 1e3).toFixed(1)}s`;
+    const total = Math.round(ms / 1e3);
+    return `${Math.floor(total / 60)}m ${total % 60}s`;
   }
   function timeAgo(nowMs, atMs) {
     const s = Math.floor((nowMs - atMs) / 1e3);
-    if (s < 1) return "just now";
-    if (s < 60) return `${s}s ago`;
+    if (s < 1) return "now";
+    if (s < 60) return `${s}s`;
     const m = Math.floor(s / 60);
-    if (m < 60) return `${m}m ago`;
-    return `${Math.floor(m / 60)}h ago`;
+    if (m < 60) return `${m}m`;
+    return `${Math.floor(m / 60)}h`;
   }
   function activityMeta(rec, now) {
     const parts = [];
@@ -846,20 +903,25 @@ code {
     dPage.textContent = scenePage || "\u2014";
   }
   var ACTIVITY_ROWS = 20;
-  function activityRow(r, now) {
+  function activityRow(r, now, stale) {
     const li = document.createElement("li");
-    li.className = "activity-row";
+    li.className = stale ? "activity-row is-stale" : "activity-row";
     const dot2 = document.createElement("span");
     dot2.className = "log-dot";
     dot2.dataset.ok = String(r.ok);
     dot2.dataset.pending = String(r.pending);
+    const state = r.pending ? "running" : r.ok ? "ok" : "failed";
+    dot2.setAttribute("aria-label", state);
+    dot2.textContent = state === "failed" ? "\u2717" : "";
     const label = document.createElement("div");
     label.className = "log-label";
     label.textContent = activityLabel(r);
+    label.title = activityLabel(r);
     const m = document.createElement("div");
     m.className = "log-meta";
     m.dataset.ok = String(r.ok);
     m.textContent = activityMeta(r, now);
+    m.title = formatTimestamp(r.at);
     const body = document.createElement("div");
     body.className = "log-body";
     body.append(label, m);
@@ -868,7 +930,9 @@ code {
   }
   function renderActivity(now) {
     if (activity.length === 0) return;
-    activityList.replaceChildren(...activity.slice(0, ACTIVITY_ROWS).map((r) => activityRow(r, now)));
+    activityList.replaceChildren(
+      ...activity.slice(0, ACTIVITY_ROWS).map((r, i) => activityRow(r, now, i > 0))
+    );
   }
   function render() {
     const now = Date.now();

--- a/figma-agent/tests/activity-feed.test.ts
+++ b/figma-agent/tests/activity-feed.test.ts
@@ -5,7 +5,7 @@
 // human watching the plugin work, so a wrong one is a lie, not a cosmetic bug.
 import { describe, it, expect } from 'vitest';
 import {
-  activityLabel, activityMeta, humanizeTool, formatClock, formatDuration, timeAgo,
+  activityLabel, activityMeta, humanizeTool, formatClock, formatTimestamp, formatDuration, timeAgo,
   toActivityRecord, toActivityResult, pushActivity, resolveActivity,
   type ActivityRecord,
 } from '../plugin/src/ui/activity-feed.ts';
@@ -34,7 +34,7 @@ describe('activityLabel — the CLI names the intent, the cmd is only the fallba
   });
 });
 
-describe('formatClock / formatDuration / timeAgo', () => {
+describe('formatClock / formatTimestamp / formatDuration / timeAgo', () => {
   it('formatClock is a zero-padded local HH:MM:SS', () => {
     const at = new Date(2026, 6, 16, 9, 5, 3).getTime();
     expect(formatClock(at)).toBe('09:05:03');
@@ -42,34 +42,53 @@ describe('formatClock / formatDuration / timeAgo', () => {
   it('formatClock refuses to invent a time from a broken stamp', () => {
     expect(formatClock(Number.NaN)).toBe('--:--:--');
   });
-  it('formatDuration is ms under a second, then 1-decimal seconds', () => {
+  it('formatTimestamp is the absolute date+time the compact age cannot say', () => {
+    expect(formatTimestamp(new Date(2026, 6, 16, 14, 32, 7).getTime())).toBe('2026-07-16 14:32:07');
+  });
+  it('formatTimestamp refuses to invent a stamp from a broken one', () => {
+    expect(formatTimestamp(Number.NaN)).toBe('—');
+  });
+  it('formatDuration is ms under a second, then 1-decimal seconds, then m+s', () => {
     expect(formatDuration(12)).toBe('12ms');
     expect(formatDuration(1_250)).toBe('1.3s');
     expect(formatDuration(-1)).toBe('—');
   });
-  it('timeAgo is relative to now', () => {
+  it('formatDuration breaks to minutes past 60s — "124.0s" is a number, not a duration', () => {
+    expect(formatDuration(60_000)).toBe('1m 0s');
+    expect(formatDuration(124_000)).toBe('2m 4s');
+    expect(formatDuration(59_900)).toBe('59.9s'); // still under the minute
+  });
+  it('timeAgo is relative to now and COMPACT — the column already means "ago"', () => {
     const now = 1_000_000;
-    expect(timeAgo(now, now)).toBe('just now');
-    expect(timeAgo(now, now - 5_000)).toBe('5s ago');
-    expect(timeAgo(now, now - 180_000)).toBe('3m ago');
-    expect(timeAgo(now, now - 7_200_000)).toBe('2h ago');
+    expect(timeAgo(now, now)).toBe('now');
+    expect(timeAgo(now, now - 5_000)).toBe('5s');
+    expect(timeAgo(now, now - 180_000)).toBe('3m');
+    expect(timeAgo(now, now - 7_200_000)).toBe('2h');
+  });
+  it('timeAgo never spends width on the word "ago" — it is the first thing truncation eats', () => {
+    expect(timeAgo(1_000_000, 940_000)).not.toContain('ago');
   });
 });
 
 describe('activityMeta — the row FOOTNOTE: outcome + timing on one line, never the label', () => {
   it('folds outcome, duration and age into one sentence', () => {
     const r = rec({ at: 1_000, ms: 173, pending: false, result: '→ 42 nodes' });
-    expect(activityMeta(r, 121_000)).toBe('→ 42 nodes · 173ms · 2m ago');
+    expect(activityMeta(r, 121_000)).toBe('→ 42 nodes · 173ms · 2m');
   });
   it('an in-flight row has no duration to report — it says so instead of "0ms"', () => {
-    expect(activityMeta(rec({ at: 1_000 }), 1_000)).toBe('running… · just now');
+    expect(activityMeta(rec({ at: 1_000 }), 1_000)).toBe('running… · now');
   });
   it('a failure reads its own error, not a generic "failed"', () => {
     const r = rec({ at: 1_000, ms: 8, pending: false, ok: false, result: '✗ node not found' });
-    expect(activityMeta(r, 4_000)).toBe('✗ node not found · 8ms · 3s ago');
+    expect(activityMeta(r, 4_000)).toBe('✗ node not found · 8ms · 3s');
   });
   it('a command with nothing countable to report still times itself', () => {
-    expect(activityMeta(rec({ at: 1_000, ms: 40, pending: false }), 6_000)).toBe('40ms · 5s ago');
+    expect(activityMeta(rec({ at: 1_000, ms: 40, pending: false }), 6_000)).toBe('40ms · 5s');
+  });
+  it('orders the parts outcome-FIRST so the age, not the outcome, is what truncation eats', () => {
+    const r = rec({ at: 1_000, ms: 173, pending: false, result: '→ 42 nodes' });
+    const parts = activityMeta(r, 121_000).split(' · ');
+    expect(parts).toEqual(['→ 42 nodes', '173ms', '2m']);
   });
   it('carries NO wall-clock stamp — the age already answers "when", and the stamp is what crowded out the label', () => {
     const meta = activityMeta(rec({ at: new Date(2026, 6, 16, 9, 5, 3).getTime(), ms: 5, pending: false }), Date.now());


### PR DESCRIPTION
Shrinks the 2-line activity feed (landed in #65/#66) into a mini data-log, per the researched spec (VS Code / Raycast / Linear / GitHub Actions dense-feed practice).

## Why
The feed was sized like prose — 16px label, 14px meta, ~44px rows — but it is read by **scanning**, not reading. That scale spent the panel's scarcest resource (vertical space) on the wrong thing. Mini sizing fits ~7 rows where 5 fit before.

## What changed
- **Rows ~44px → 31px** (measured): label 12px, meta 11px, line-height 1.35, 4px gaps, list max-height 168px.
- **Recency at zero space cost** — every row but the newest dims to `opacity: 0.6` (`.is-stale`).
- **Status reads by SHAPE, not hue** — ok = filled square, running = hollow + breathing, failed = `✗`. Colour alone is invisible to a colour-blind eye; each mark also carries an `aria-label` (`ok|failed|running`), because shape is invisible to a screen reader.
- **Time** — age goes compact (`16s` / `2m` / `3h`, no "ago" — the column already means it); the absolute stamp moves to the row's `title` (`2026-07-16 14:32:07`), since "2m" cannot say *when* and a screen reader reads "1m" as "1 meter". `formatDuration` breaks to `2m 4s` past a minute.

## Tokens
`--font-size-2xs` / `--font-size-3xs` / `--space-hair` go in the panel's **own `:root` override**, not the compiled brand block — the brand scale bottoms out at 14px because it is authored for page surfaces, and `ui tokens compile` must not clobber a 300px data log's floor.

## Verification
- **Real render** (Chromium, 300px viewport, driven through the actual relay events): rows land at exactly **31px**, every label starts on the same **32px** left edge, no label/meta clipping. Pinning the `✗` box at 6px fixed a 0.63px ragged left edge the glyph's width introduced.
- **4-linter gate**: `validate-layout` / `a11y-lint` / `taste-lint` / `content-lint` report **zero findings** (not just zero errors). The breathing mark passes on merit — it is a status channel, animates opacity alone (never a layout prop), and stops under `prefers-reduced-motion`, where the hollow shape still carries the state.
- **Suites**: figma-agent 441 passed (436 + 5 new); BARE 1891 passed. typecheck / lint / build green on both.

```
▫ Scan · 1:23
  running… · now
✗ Import · payload                      (dimmed)
  ✗ node not found · 8ms · 3s
◼ Mirror-verify · rebuild               (dimmed)
  → Hero card · 2 warnings · 1.2s · 16s
◼ Scan · 25579:749755                   (dimmed)
  → 42 nodes · 173ms · 2m
```