### PR TITLE
fix: unwrap the panel from its own frame, and stop saying "fail" twice

### DIFF
--- a/figma-agent/plugin/src/ui/activity-feed.ts
+++ b/figma-agent/plugin/src/ui/activity-feed.ts
@@ -19,7 +19,7 @@ export interface ActivityRecord {
   tool: string;
   /** The CLI's intent label ("Scan · 1:23"); absent ⇒ fall back to `tool`. */
   label?: string;
-  /** Result summary once done ("→ 42 nodes", "✗ node not found"); absent while pending. */
+  /** Result summary once done ("→ 42 nodes", "node not found"); absent while pending. */
   result?: string;
   /** True until the reply lands — the row renders as in-flight. */
   pending: boolean;
@@ -86,7 +86,7 @@ export function timeAgo(nowMs: number, atMs: number): string {
 
 /**
  * The row's SECOND line — outcome and timing folded into ONE muted sentence:
- *   "→ 42 nodes · 173ms · 2m" | "running… · now" | "✗ node not found · 8ms · 3s"
+ *   "→ 42 nodes · 173ms · 2m" | "running… · now" | "node not found · 8ms · 3s"
  * Deliberately carries no wall-clock stamp: the relative age already answers "when",
  * and the absolute time is what used to crowd the label — the only line that says WHAT
  * the plugin is doing — off the row entirely on a narrow panel. It survives in the

--- a/figma-agent/plugin/src/ui/activity-summary.ts
+++ b/figma-agent/plugin/src/ui/activity-summary.ts
@@ -60,12 +60,16 @@ export function summarizeResult(cmd: string, result: unknown): string | null {
   return null;
 }
 
-/** One-line outcome for a failed reply: "✗ <message>", flattened to the single row it has. */
+/**
+ * One-line outcome for a failed reply, flattened to the single row it has. The message
+ * carries NO fail glyph: the row's own mark column already shows ✗ and the meta is tinted
+ * red — a second ✗ here is the status redundancy our own audit-ds flags.
+ */
 export function summarizeError(error: unknown): string {
   const e = (error ?? {}) as Record<string, unknown>;
   const raw = typeof e.message === 'string' && e.message !== ''
     ? e.message
     : (typeof error === 'string' && error !== '' ? error : 'failed');
   const oneLine = raw.replace(/\s+/g, ' ').trim();
-  return `✗ ${oneLine.length > MAX_ERROR_CHARS ? `${oneLine.slice(0, MAX_ERROR_CHARS - 1)}…` : oneLine}`;
+  return oneLine.length > MAX_ERROR_CHARS ? `${oneLine.slice(0, MAX_ERROR_CHARS - 1)}…` : oneLine;
 }

--- a/figma-agent/plugin/src/ui/panel.html
+++ b/figma-agent/plugin/src/ui/panel.html
@@ -234,16 +234,21 @@
 }
 
 /* ── Panel chrome — Swiss Monolith brutalism, COMPACT-FIRST (P5.1) ─────────────
-   One ink-bordered monolith block fills the tiny 300×170 iframe: a slim masthead
+   A stack of bands fills the tiny 300×170 iframe edge to edge: a slim masthead
    band, the condensed status band, and a three-cell mono footer. The DETAILS
-   footer cell expands the monolith (main resizes the iframe to 460) revealing the
+   footer cell expands the stack (main resizes the iframe to 460) revealing the
    onboarding / activity / connection bands. Flat, radius 0, separation by 2px ink
-   rules only, inversion on hover. ──────────────────────────────────────────── */
+   rules only, inversion on hover. The iframe IS the frame — no outer border and
+   no body padding, or the panel reads as a box drawn inside a box. ──────────── */
 * { box-sizing: border-box; }
+
+/* The stack must be as tall as the iframe main sized, or the footer floats mid-air with
+   bare paper under it — the borderless panel has no frame left to close that gap. */
+html, body { height: 100%; }
 
 body {
   margin: 0;
-  padding: 4px;
+  padding: 0;
   font-family: var(--font-family-body);
   font-size: var(--font-size-sm);
   line-height: 1.5;
@@ -252,11 +257,12 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-/* The monolith: a single 2px ink border wraps every band; bands never float. */
+/* The stack: bands butt against each other and against the iframe edge. Structure
+   comes from the 2px ink rules BETWEEN bands, never from a border around them. */
 .panel {
   display: flex;
   flex-direction: column;
-  border: 2px solid var(--color-foreground);
+  min-height: 100%;
   background: var(--color-background);
 }
 
@@ -512,7 +518,8 @@ code {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* A failure's outcome IS this line ("✗ node not found · …") — colour the whole line. */
+/* A failure's outcome IS this line ("node not found · …") — colour the whole line. The
+   mark column already carries the ✗; the text must not repeat it (status redundancy). */
 .log-meta[data-ok="false"] { color: var(--color-danger); }
 .activity-empty {
   font-family: var(--font-mono);

--- a/figma-agent/plugin/ui.html
+++ b/figma-agent/plugin/ui.html
@@ -234,16 +234,21 @@
 }
 
 /* ── Panel chrome — Swiss Monolith brutalism, COMPACT-FIRST (P5.1) ─────────────
-   One ink-bordered monolith block fills the tiny 300×170 iframe: a slim masthead
+   A stack of bands fills the tiny 300×170 iframe edge to edge: a slim masthead
    band, the condensed status band, and a three-cell mono footer. The DETAILS
-   footer cell expands the monolith (main resizes the iframe to 460) revealing the
+   footer cell expands the stack (main resizes the iframe to 460) revealing the
    onboarding / activity / connection bands. Flat, radius 0, separation by 2px ink
-   rules only, inversion on hover. ──────────────────────────────────────────── */
+   rules only, inversion on hover. The iframe IS the frame — no outer border and
+   no body padding, or the panel reads as a box drawn inside a box. ──────────── */
 * { box-sizing: border-box; }
+
+/* The stack must be as tall as the iframe main sized, or the footer floats mid-air with
+   bare paper under it — the borderless panel has no frame left to close that gap. */
+html, body { height: 100%; }
 
 body {
   margin: 0;
-  padding: 4px;
+  padding: 0;
   font-family: var(--font-family-body);
   font-size: var(--font-size-sm);
   line-height: 1.5;
@@ -252,11 +257,12 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-/* The monolith: a single 2px ink border wraps every band; bands never float. */
+/* The stack: bands butt against each other and against the iframe edge. Structure
+   comes from the 2px ink rules BETWEEN bands, never from a border around them. */
 .panel {
   display: flex;
   flex-direction: column;
-  border: 2px solid var(--color-foreground);
+  min-height: 100%;
   background: var(--color-background);
 }
 
@@ -512,7 +518,8 @@ code {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* A failure's outcome IS this line ("✗ node not found · …") — colour the whole line. */
+/* A failure's outcome IS this line ("node not found · …") — colour the whole line. The
+   mark column already carries the ✗; the text must not repeat it (status redundancy). */
 .log-meta[data-ok="false"] { color: var(--color-danger); }
 .activity-empty {
   font-family: var(--font-mono);
@@ -2521,7 +2528,7 @@ code {
     const e = error ?? {};
     const raw = typeof e.message === "string" && e.message !== "" ? e.message : typeof error === "string" && error !== "" ? error : "failed";
     const oneLine = raw.replace(/\s+/g, " ").trim();
-    return `\u2717 ${oneLine.length > MAX_ERROR_CHARS ? `${oneLine.slice(0, MAX_ERROR_CHARS - 1)}\u2026` : oneLine}`;
+    return oneLine.length > MAX_ERROR_CHARS ? `${oneLine.slice(0, MAX_ERROR_CHARS - 1)}\u2026` : oneLine;
   }
 
   // plugin/src/ui/ui-relay.ts

--- a/figma-agent/tests/activity-feed.test.ts
+++ b/figma-agent/tests/activity-feed.test.ts
@@ -79,8 +79,8 @@ describe('activityMeta — the row FOOTNOTE: outcome + timing on one line, never
     expect(activityMeta(rec({ at: 1_000 }), 1_000)).toBe('running… · now');
   });
   it('a failure reads its own error, not a generic "failed"', () => {
-    const r = rec({ at: 1_000, ms: 8, pending: false, ok: false, result: '✗ node not found' });
-    expect(activityMeta(r, 4_000)).toBe('✗ node not found · 8ms · 3s');
+    const r = rec({ at: 1_000, ms: 8, pending: false, ok: false, result: 'node not found' });
+    expect(activityMeta(r, 4_000)).toBe('node not found · 8ms · 3s');
   });
   it('a command with nothing countable to report still times itself', () => {
     expect(activityMeta(rec({ at: 1_000, ms: 40, pending: false }), 6_000)).toBe('40ms · 5s');

--- a/figma-agent/tests/activity-summary.test.ts
+++ b/figma-agent/tests/activity-summary.test.ts
@@ -62,20 +62,20 @@ describe('summarizeResult — what the plugin can honestly say it did', () => {
 });
 
 describe('summarizeError', () => {
-  it('marks the failure with the plugin error message', () => {
+  it('carries the plugin error message alone — the row\'s mark column says ✗, not the text', () => {
     expect(summarizeError({ code: 'E_PLUGIN_ERROR', message: 'node not found: 1:23' }))
-      .toBe('✗ node not found: 1:23');
+      .toBe('node not found: 1:23');
   });
   it('flattens a multi-line message onto the single row it has', () => {
-    expect(summarizeError({ message: 'line one\n  line two' })).toBe('✗ line one line two');
+    expect(summarizeError({ message: 'line one\n  line two' })).toBe('line one line two');
   });
   it('truncates a runaway message rather than blowing up the row', () => {
     const out = summarizeError({ message: 'x'.repeat(500) });
-    expect(out.length).toBeLessThanOrEqual(122);
+    expect(out.length).toBeLessThanOrEqual(120);
     expect(out.endsWith('…')).toBe(true);
   });
   it('still says something when the error carries no message', () => {
-    expect(summarizeError({})).toBe('✗ failed');
-    expect(summarizeError('boom')).toBe('✗ boom');
+    expect(summarizeError({})).toBe('failed');
+    expect(summarizeError('boom')).toBe('boom');
   });
 });


### PR DESCRIPTION
Two polish items from owner (designer) feedback on the plugin panel.

## 1. The frame around the frame

The panel drew `border: 2px solid` around itself and sat on `body { padding: 4px }` — inside a Figma iframe that is *already* a frame. Hence "plugin wrapped into a frame, ugly": a box drawn inside a box.

The outer border was never carrying the structure. The **2px ink rules between bands** are, and they all stay. Removing the border and the padding lets the bands run edge to edge; Swiss Monolith is intact (flat, radius 0, separation by ink rules, inversion on hover).

**Panel after, band by band** (probed in a real Chrome at 300×170 and 300×460):

| Band | Rules |
|---|---|
| masthead | no top rule (flush with the iframe's top edge), 2px bottom |
| status | no rules of its own — the masthead's bottom rule and the next band's top rule bound it |
| sync prompt | 2px top + 2px bottom (unchanged) |
| onboarding | 2px top, plus its 6px burnt-orange left accent |
| activity | 2px top |
| hint | 2px top |
| connection details | 2px top |
| footer | 2px top, no bottom rule (flush with the iframe's bottom edge) |

Top and bottom edges are deliberately bare: the iframe edge *is* the frame.

One thing the border was quietly doing: the panel is content-height, and the compact iframe is 170px against ~133px of content. The border used to close that gap; without it the footer floated over bare paper. Fixed at the cause — `html, body { height: 100% }` + `.panel { min-height: 100% }` — so the footer's pre-existing `margin-top: auto` pins it to the bottom edge. Verified: panel is exactly 170/460 tall, footer bottom lands on the viewport edge, no scroll on either axis.

## 2. `✗` twice on a fail row

A failed row said "fail" three ways: the mark column glyph (`✗`), the danger-red meta tint, and `summarizeError`'s `"✗ "` prefix. That is the status redundancy this repo's own `audit-ds` flags.

`summarizeError` now returns the message alone — meta reads `node not found · 8ms · 3s`. The mark column keeps its `✗`; the red tint stays. The `MAX_ERROR_CHARS` truncation ceiling is now the whole string (120) rather than 120-plus-prefix, so the truncation test tightened 122 → 120.

## Verify

- **4-linter on the built `plugin/ui.html`** (not just the source template, and dumping warnings — not only `errorCount`): 0 errors across validate-layout / a11y-lint / taste-lint / content-lint. 6 warnings, **byte-identical to the `main` baseline** and all false positives from the inlined JS: 5 × `h-screen` from the viewport workaround line `classList.remove("h-screen", …)`, and 1 plural-hack hit on the function *name* `parseAnimDurationSec(s)`. This change adds zero findings.
- **figma-agent**: typecheck + build + 441 tests pass.
- **Root BARE gates**: typecheck, lint, build, 1891 tests pass.
- `npm run build` re-run; regenerated `ui.html` committed. `code.js` unchanged, as expected for a UI/CSS-only change.
- Rendered in real Chrome at both sizes — screenshots confirm no outer frame, bands filling the width, internal rules intact.

**Not verified live:** the fail row was not rendered on a real canvas (the feed is driven by the broker's websocket, not reachable in a headless harness). Evidence is the unit test plus the unchanged mark-column renderer (`panel-ui.ts:111`).