### PR TITLE
feat(memory): auto-record kernel outcomes as MemoryEvents (spec 006 P1)

### DIFF
--- a/src/commands/a11y-lint.ts
+++ b/src/commands/a11y-lint.ts
@@ -7,6 +7,7 @@ import { errJson, errText, okJsonWithExit } from "../core/output.js";
 import type { CommandResult } from "../core/output.js";
 import type { ParsedArgs } from "../core/cli-args.js";
 import { lintA11y } from "../core/a11y-lint.js";
+import { withOutcome, lintOutcomeData } from "../core/memory-autorecord.js";
 
 const CMD = "a11y-lint";
 
@@ -76,7 +77,7 @@ export const a11yLintCommand = {
     }
     const result = lintA11y(html);
     const exitCode = result.errorCount > 0 ? 1 : 0;
-    if (useJson) return okJsonWithExit(CMD, { file, ...result }, exitCode);
-    return { exitCode, stdout: formatReport(result, file) };
+    const out = useJson ? okJsonWithExit(CMD, { file, ...result }, exitCode) : { exitCode, stdout: formatReport(result, file) };
+    return withOutcome(out, parsed, { type: "lint_run", actor: "ui a11y-lint", projectDir: file, data: lintOutcomeData("a11y-lint", file, result) });
   },
 };

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -16,6 +16,7 @@ import type { CommandResult } from "../core/output.js";
 import { errJson, errText, okJsonWithExit } from "../core/output.js";
 import { buildAuditSpec } from "../core/audit-spec.js";
 import { detectViolations, type AuditNode } from "../core/audit-detect.js";
+import { withOutcome, lintOutcomeData } from "../core/memory-autorecord.js";
 
 const CMD = "audit";
 
@@ -172,9 +173,18 @@ export const auditCommand = {
     const result = detectViolations(nodesJson as AuditNode | AuditNode[], spec);
 
     const exitCode = result.total > 0 ? 1 : 0;
-    if (useJson) {
-      return okJsonWithExit(CMD, { file: nodesPath, ...result }, exitCode);
-    }
-    return { exitCode, stdout: formatReport(nodesPath, result) };
+    const out = useJson
+      ? okJsonWithExit(CMD, { file: nodesPath, ...result }, exitCode)
+      : { exitCode, stdout: formatReport(nodesPath, result) };
+    return withOutcome(out, parsed, {
+      type: "lint_run",
+      actor: "ui audit",
+      projectDir: nodesPath,
+      data: lintOutcomeData("audit", nodesPath, {
+        errorCount: result.total,
+        warningCount: 0,
+        findings: result.violations.map((v) => ({ checkId: v.rule })),
+      }),
+    });
   },
 };

--- a/src/commands/autofix.ts
+++ b/src/commands/autofix.ts
@@ -12,6 +12,7 @@ import type { ParsedArgs } from "../core/cli-args.js";
 import type { CommandResult } from "../core/output.js";
 import { errJson, errText, okJson } from "../core/output.js";
 import { runAutofix } from "../core/html-autofix.js";
+import { withOutcome } from "../core/memory-autorecord.js";
 
 const CMD = "autofix";
 
@@ -102,27 +103,35 @@ export const autofixCommand = {
     }
 
     // 5. Shape output
+    let out: CommandResult;
     if (useJson) {
-      return okJson(CMD, {
+      out = okJson(CMD, {
         file: filePath,
         fixesApplied: findings.length,
         findings,
         written,
         html: fixedHtml,
       });
+    } else {
+      // Text mode: fixed HTML → stdout, summary → stderr
+      const ruleNames = findings.map((f) => f.ruleId).join(", ");
+      const summary =
+        findings.length === 0
+          ? "applied 0 fixes\n"
+          : `applied ${findings.length} fix${findings.length === 1 ? "" : "es"}: ${ruleNames}\n`;
+
+      out = doWrite
+        ? { exitCode: 0, stderr: summary } // File already written; just emit the summary
+        : { exitCode: 0, stdout: fixedHtml, stderr: summary };
     }
 
-    // Text mode: fixed HTML → stdout, summary → stderr
-    const ruleNames = findings.map((f) => f.ruleId).join(", ");
-    const summary =
-      findings.length === 0
-        ? "applied 0 fixes\n"
-        : `applied ${findings.length} fix${findings.length === 1 ? "" : "es"}: ${ruleNames}\n`;
-
-    if (doWrite) {
-      // File already written; just emit the summary
-      return { exitCode: 0, stderr: summary };
-    }
-    return { exitCode: 0, stdout: fixedHtml, stderr: summary };
+    const recordable = doWrite && written && findings.length > 0;
+    if (!recordable) return out;
+    return withOutcome(out, parsed, {
+      type: "autofix_applied",
+      actor: "ui autofix",
+      projectDir: filePath,
+      data: { file: filePath, fixCount: findings.length, ruleIds: [...new Set(findings.map((f) => f.ruleId))].sort() },
+    });
   },
 };

--- a/src/commands/content-lint.ts
+++ b/src/commands/content-lint.ts
@@ -9,6 +9,7 @@ import type { CommandResult } from "../core/output.js";
 import type { ParsedArgs } from "../core/cli-args.js";
 import { allContentChecks } from "../core/content-checks.js";
 import type { ContentFinding } from "../core/content-checks.js";
+import { withOutcome, lintOutcomeData } from "../core/memory-autorecord.js";
 
 const CMD = "content-lint";
 
@@ -71,11 +72,11 @@ export const contentLintCommand = {
     const result = { file, findings: all, errorCount, warningCount: all.length - errorCount };
     const exitCode = errorCount > 0 ? 1 : 0;
 
-    if (useJson) return okJsonWithExit(CMD, result, exitCode);
     const lines = all.length === 0
       ? [`content-lint: ${file} — 0 findings.`]
       : [`content-lint: ${file} — ${errorCount} error(s), ${result.warningCount} warning(s)`,
          ...all.map((f) => `  ${f.severity === "error" ? "✗" : "!"} [${f.checkId}]${f.line !== undefined ? ` line ${f.line}` : ""}: ${f.message}`)];
-    return { exitCode, stdout: lines.join("\n") + "\n" };
+    const out = useJson ? okJsonWithExit(CMD, result, exitCode) : { exitCode, stdout: lines.join("\n") + "\n" };
+    return withOutcome(out, parsed, { type: "lint_run", actor: "ui content-lint", projectDir: file, data: lintOutcomeData("content-lint", file, result) });
   },
 };

--- a/src/commands/ds-change-token-impl.ts
+++ b/src/commands/ds-change-token-impl.ts
@@ -16,7 +16,7 @@
  * If E succeeds but F fails → DS_TAMPERED on next load (document recovery).
  */
 import { renameSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { cwd } from "node:process";
 
 import { errJson, errText, okJson } from "../core/output.js";
@@ -37,6 +37,7 @@ import { parseTokenFile } from "../core/token-model.js";
 import type { TokenType } from "../core/token-model.js";
 import type { ParsedArgs } from "../core/cli-args.js";
 import type { CommandResult } from "../core/output.js";
+import { withOutcome } from "../core/memory-autorecord.js";
 
 const CMD = "ds change-token";
 
@@ -344,12 +345,18 @@ export function runChangeToken(parsed: ParsedArgs): CommandResult {
 
   // ── Respond ─────────────────────────────────────────────────────────────────
 
-  return okJson(CMD, {
+  const out = okJson(CMD, {
     path: tokenPath,
     from: oldSerialized,
     to: newSerialized,
     changed: true,
     generation: newManifestObj.generation,
     compiledHash: newHash,
+  });
+  return withOutcome(out, parsed, {
+    type: "token_change",
+    actor: "ui ds change-token",
+    projectDir: dirname(paths.dir),
+    data: { path: tokenPath, from: oldSerialized, to: newSerialized, ...(reason !== undefined && { reason }), generation: newManifestObj.generation },
   });
 }

--- a/src/commands/figma-reconcile-run.ts
+++ b/src/commands/figma-reconcile-run.ts
@@ -38,6 +38,7 @@ import { indexCaptures, parseMirrorCapture, type MirrorIndex } from "../core/fig
 import { writeFigmaNode } from "../core/figma-node-reader.js";
 import { readCursor, syncStatePath, writeCursor } from "../core/figma-sync-state.js";
 import { renderApply, renderDryRun } from "./figma-reconcile-render.js";
+import { withOutcome } from "../core/memory-autorecord.js";
 
 const CHANGE_LOG_RELPATH = ["design", "figma.changes.jsonl"] as const;
 const REGISTRY_RELPATH = ["design", "component-registry.json"] as const;
@@ -174,7 +175,18 @@ export function runReconcile(parsed: ParsedArgs): CommandResult {
   }
 
   const data = { ...base, dry_run: false as const, applied: true as const, apply: report };
-  return useJson ? okJson(SUB, data) : { exitCode: 0, stdout: renderApply(data, report) };
+  const out = useJson ? okJson(SUB, data) : { exitCode: 0, stdout: renderApply(data, report) };
+  const recordable = changed || sidecarWrites.length > 0;
+  if (!recordable) return out;
+  return withOutcome(out, parsed, {
+    type: "reconcile_applied",
+    actor: "ui figma reconcile",
+    projectDir: dir,
+    data: {
+      added: report.added, updated: report.updated, deprecated: report.deprecated,
+      mirrored: report.mirrored.length, cursorFrom, cursorTo,
+    },
+  });
 }
 
 /** Write every captured sidecar (content-guarded by writeFigmaNode). Throws RegistryError. */

--- a/src/commands/taste-lint.ts
+++ b/src/commands/taste-lint.ts
@@ -17,6 +17,7 @@ import type { CommandResult } from "../core/output.js";
 import { errJson, errText, okJsonWithExit } from "../core/output.js";
 import { lintTaste } from "../core/taste-lint.js";
 import { isTokenLeaf } from "../core/token-model.js";
+import { withOutcome, lintOutcomeData } from "../core/memory-autorecord.js";
 
 const CMD = "taste-lint";
 
@@ -185,16 +186,14 @@ export const tasteLintCommand = {
     const exitCode = errorCount > 0 ? 1 : 0;
 
     // 6. Shape output.
-    if (useJson) {
-      return okJsonWithExit(
-        CMD,
-        { file: filePath, errorCount, warningCount, axesAffected, findings },
-        exitCode,
-      );
-    }
-    return {
-      exitCode,
-      stdout: formatReport(filePath, errorCount, warningCount, axesAffected, findings),
-    };
+    const out = useJson
+      ? okJsonWithExit(CMD, { file: filePath, errorCount, warningCount, axesAffected, findings }, exitCode)
+      : { exitCode, stdout: formatReport(filePath, errorCount, warningCount, axesAffected, findings) };
+    return withOutcome(out, parsed, {
+      type: "lint_run",
+      actor: "ui taste-lint",
+      projectDir: filePath,
+      data: { ...lintOutcomeData("taste-lint", filePath, { errorCount, warningCount, findings }), axes: axesAffected },
+    });
   },
 };

--- a/src/commands/taste-record-impl.ts
+++ b/src/commands/taste-record-impl.ts
@@ -9,6 +9,7 @@ import {
   isPairWinner, isVerdict, WINNERS, VERDICTS,
 } from "../core/taste-store.js";
 import type { PairVote, StudyRecord } from "../core/taste-store.js";
+import { withOutcome } from "../core/memory-autorecord.js";
 
 const CMD = "taste record";
 
@@ -61,7 +62,10 @@ export function runTasteRecord(parsed: ParsedArgs): CommandResult {
     if (ms !== undefined) vote.ms = ms;
 
     appendVote(root, vote);
-    return useJson ? okJson(CMD, { recorded: vote }) : ok(`recorded pair vote: ${a} vs ${b} -> ${winner}\n`);
+    const out = useJson ? okJson(CMD, { recorded: vote }) : ok(`recorded pair vote: ${a} vs ${b} -> ${winner}\n`);
+    // No projectDir: the taste root is a separate tree from design/, so there is no
+    // artifact to point at — cwd fallback stays (see memory-autorecord.ts header).
+    return withOutcome(out, parsed, { type: "taste_vote", actor: "ui taste record", data: { a, b, winner } });
   }
 
   // mode === "study"

--- a/src/commands/validate-layout.ts
+++ b/src/commands/validate-layout.ts
@@ -12,6 +12,7 @@ import type { ParsedArgs } from "../core/cli-args.js";
 import type { CommandResult } from "../core/output.js";
 import { errJson, errText, okJsonWithExit } from "../core/output.js";
 import { lintLayout } from "../core/layout-lint.js";
+import { withOutcome, lintOutcomeData } from "../core/memory-autorecord.js";
 
 const CMD = "validate-layout";
 
@@ -123,13 +124,14 @@ export const validateLayoutCommand = {
     const exitCode = errorCount > 0 ? 1 : 0;
 
     // 5. Shape output
-    if (useJson) {
-      return okJsonWithExit(CMD, { file: filePath, errorCount, warningCount, findings }, exitCode);
-    }
-
-    return {
-      exitCode,
-      stdout: formatReport(filePath, errorCount, warningCount, findings),
-    };
+    const out = useJson
+      ? okJsonWithExit(CMD, { file: filePath, errorCount, warningCount, findings }, exitCode)
+      : { exitCode, stdout: formatReport(filePath, errorCount, warningCount, findings) };
+    return withOutcome(out, parsed, {
+      type: "lint_run",
+      actor: "ui validate-layout",
+      projectDir: filePath,
+      data: lintOutcomeData("validate-layout", filePath, { errorCount, warningCount, findings }),
+    });
   },
 };

--- a/src/core/memory-autorecord.ts
+++ b/src/core/memory-autorecord.ts
@@ -1,0 +1,176 @@
+/**
+ * Auto-record — the fuel line (spec 006 P1).
+ *
+ * An outcome-bearing kernel subcommand appends a MemoryEvent as a side-effect of
+ * RUNNING, with no opt-in and no model call. This module is the ONE write path for
+ * that (Art IV); it reuses the existing event API (memory-events + memory-store) and
+ * invents nothing.
+ *
+ * Project resolution (Art IV — resolve from the artifact, never guess cwd):
+ *   `recordOutcome` resolves the project that OWNS the artifact the command just
+ *   acted on, not the invoking process's cwd. A call site passes `input.projectDir`
+ *   pointing at that artifact (a file it linted, or a project dir it already
+ *   resolved); `recordOutcome` walks up from there (mirrors discoverDesignSystem,
+ *   design-system.ts:65-78) looking for a `design/` dir. Only when a call site has
+ *   no artifact to point at does resolution fall back to `--dir` then cwd.
+ *
+ * Invariants:
+ *   - Never throws. A ledger failure must never change a lint's exit code.
+ *   - Records only into a project that already has design/ (opt-in per project,
+ *     automatic per run) — never creates design/ in an arbitrary cwd.
+ *   - Appends only: no graph recompile (loadGraph rebuilds lazily on mtime), no
+ *     registry upsert (a lint must not write to $HOME).
+ *
+ * Known limitation: `ui taste record` has no `--dir` and its outcome (a taste_vote)
+ * has no design-project artifact to point at (the taste root is a separate tree from
+ * design/), so its mirror only fires when cwd itself is a project with design/.
+ * `votes.jsonl` stays the system of record either way.
+ */
+import { existsSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import type { ParsedArgs } from "./cli-args.js";
+import type { CommandResult } from "./output.js";
+import { buildEvent, nextEventId, validateEvent, MemoryEventError } from "./memory-events.js";
+import type { EventType, Medium, MemoryArtifact } from "./memory-events.js";
+import { memoryPaths, ledgerLineCount, appendEvent } from "./memory-store.js";
+
+export interface OutcomeInput {
+  type: EventType;
+  /** Who caused it — the invoking command, e.g. "ui a11y-lint". */
+  actor: string;
+  data: Record<string, unknown>;
+  refs?: readonly string[];
+  designId?: string;
+  medium?: Medium;
+  artifact?: MemoryArtifact;
+  /**
+   * The artifact this outcome is about — a file the command acted on, or a project
+   * dir it already resolved. `recordOutcome` walks up from here looking for
+   * `design/`; omit only when the command has no such artifact (see the known
+   * limitation above).
+   */
+  projectDir?: string;
+}
+
+/**
+ * Resolve the project that OWNS a given artifact path — walk up from it (max 5
+ * levels, stop at a .git boundary) looking for a `design/` directory. Mirrors
+ * discoverDesignSystem's walk (design-system.ts:65-78), but the target is the
+ * ledger's own gate (a bare `design/` dir), not a compiled manifest — an
+ * already-resolved project dir matches on the first check.
+ * Never throws; returns undefined when no such project is found.
+ */
+function resolveProjectFromArtifact(artifactPath: string): string | undefined {
+  let cur = resolve(artifactPath);
+  try {
+    if (statSync(cur).isFile()) cur = dirname(cur);
+  } catch {
+    // Doesn't exist on disk (e.g. a path built for a not-yet-written file) —
+    // treat it as a file path and start from its directory.
+    cur = dirname(cur);
+  }
+
+  for (let level = 0; level < 5; level++) {
+    if (existsSync(join(cur, "design"))) return cur;
+    if (existsSync(join(cur, ".git"))) return undefined;
+    const parent = dirname(cur);
+    if (parent === cur) return undefined; // filesystem root
+    cur = parent;
+  }
+  return undefined;
+}
+
+export type SkipReason = "not-opted-in" | "invalid-event" | "write-failed";
+
+export interface RecordOutcomeResult {
+  recorded: boolean;
+  /** The appended event id (e.g. "e12") when recorded. */
+  id?: string;
+  reason?: SkipReason;
+  detail?: string;
+}
+
+export function recordOutcome(
+  parsed: ParsedArgs,
+  input: OutcomeInput,
+  nowIso?: string,
+): RecordOutcomeResult {
+  const dirFlag = parsed.flags["dir"];
+  const projectDir =
+    input.projectDir !== undefined
+      ? resolveProjectFromArtifact(input.projectDir)
+      : typeof dirFlag === "string"
+        ? resolve(dirFlag)
+        : process.cwd();
+  if (projectDir === undefined) return { recorded: false, reason: "not-opted-in" };
+
+  const paths = memoryPaths(projectDir);
+  if (!existsSync(paths.dir)) return { recorded: false, reason: "not-opted-in" };
+
+  try {
+    validateEvent(input.type, input.data, input.refs);
+  } catch (e) {
+    if (e instanceof MemoryEventError) return { recorded: false, reason: "invalid-event", detail: e.message };
+    throw e;
+  }
+
+  const id = nextEventId(ledgerLineCount(paths));
+  const t = nowIso ?? new Date().toISOString();
+  const event = buildEvent({
+    id,
+    t,
+    type: input.type,
+    data: input.data,
+    actor: input.actor,
+    ...(input.medium !== undefined && { medium: input.medium }),
+    ...(input.designId !== undefined && { designId: input.designId }),
+    ...(input.artifact !== undefined && { artifact: input.artifact }),
+    ...(input.refs !== undefined && { refs: input.refs }),
+  });
+
+  try {
+    appendEvent(paths, event);
+  } catch (e) {
+    return { recorded: false, reason: "write-failed", detail: e instanceof Error ? e.message : String(e) };
+  }
+  return { recorded: true, id };
+}
+
+/**
+ * Call-site sugar: record, and on a real failure append one stderr warning to the
+ * command's result. Returns the result (mutated only in the failure case) so a call
+ * site is a single wrapped `return`.
+ */
+export function withOutcome(
+  result: CommandResult,
+  parsed: ParsedArgs,
+  input: OutcomeInput,
+  nowIso?: string,
+): CommandResult {
+  const r = recordOutcome(parsed, input, nowIso);
+  if (r.recorded || r.reason === "not-opted-in") return result;
+  return {
+    ...result,
+    stderr: (result.stderr ?? "") + `ui: memory auto-record skipped (${r.reason}): ${r.detail ?? ""}\n`,
+  };
+}
+
+/** The shared `lint_run` payload builder — five call sites, one shape (Art IV). */
+export function lintOutcomeData(
+  check: string,
+  file: string,
+  r: {
+    errorCount: number;
+    warningCount: number;
+    findings: readonly { checkId: string }[];
+  },
+): Record<string, unknown> {
+  return {
+    check,
+    file,
+    errorCount: r.errorCount,
+    warningCount: r.warningCount,
+    checkIds: [...new Set(r.findings.map((f) => f.checkId))].sort(),
+  };
+}

--- a/src/core/memory-events.ts
+++ b/src/core/memory-events.ts
@@ -29,6 +29,10 @@ export const EVENT_TYPES = [
   "duel_result",
   "insight",
   "gap",
+  "lint_run",
+  "autofix_applied",
+  "reconcile_applied",
+  "taste_vote",
 ] as const;
 export type EventType = (typeof EVENT_TYPES)[number];
 
@@ -50,6 +54,18 @@ const REQUIRED_DATA: Readonly<Record<EventType, readonly string[]>> = {
   // `data.kind` is optional and unenforced (rubric-gap | persona-gap | recipe-gap |
   // benchmark-stale | guardrail-lesson). Unlike `insight`, `gap` needs no refs.
   gap: ["text", "target"],
+  // ─── Auto-recorded outcomes (spec 006 P1) — appended by `recordOutcome`, never by hand.
+  // A checker run: `check` names the tool (a11y-lint | content-lint | taste-lint |
+  // validate-layout | audit), `checkIds` is the sorted unique set of rules that tripped.
+  // `audit` maps total→errorCount, warningCount: 0 (it has no severity split).
+  lint_run: ["check", "file", "errorCount", "warningCount", "checkIds"],
+  // A `ui autofix --write` that CHANGED the file. A no-op autofix records nothing.
+  autofix_applied: ["file", "fixCount", "ruleIds"],
+  // A `ui figma reconcile --apply` that changed the registry and/or wrote sidecars.
+  reconcile_applied: ["added", "updated", "deprecated"],
+  // One `ui taste record --mode pair` vote. NOT `user_pick`: a corpus item id is not a
+  // designId, and compileGraph would file it under `designs` (memory-graph.ts:93).
+  taste_vote: ["a", "b", "winner"],
 };
 
 export interface MemoryArtifact {

--- a/tests/autorecord-call-sites.test.ts
+++ b/tests/autorecord-call-sites.test.ts
@@ -1,0 +1,384 @@
+/**
+ * CLI seam for spec 006 P1 — the nine outcome-bearing commands each append a
+ * MemoryEvent via `withOutcome`.
+ *
+ * Seven of the nine commands (a11y-lint, content-lint, taste-lint,
+ * validate-layout, audit, autofix, taste record) resolve the ledger from
+ * `process.cwd()` — there is no `--dir` flag (Key Insight 6). Testing that
+ * honestly means driving a real per-process cwd. `process.chdir()` is
+ * process-global and vitest's default pool runs multiple test files in one
+ * shared process/worker, so calling it here would race every other suite
+ * running concurrently (confirmed: it corrupted the repo's own working tree
+ * with cross-file events during authoring). Instead we spawn the BUILT
+ * binary (`dist/cli.js`) as a real subprocess with `cwd` set via
+ * `spawnSync`'s `cwd` option — this isolates cwd per invocation with zero
+ * shared state, mirroring `tests/cmd-init-built-binary.test.ts`.
+ *
+ * The two `--dir`-taking commands (ds change-token, figma reconcile) stay
+ * in-process via `run()` — they never touch `process.cwd()`.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+
+import { run } from "../src/cli.js";
+import { encodePng } from "../src/core/png-codec.js";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const DIST_CLI = join(REPO_ROOT, "dist", "cli.js");
+const PERSONA_DATA = join(REPO_ROOT, "knowledge", "personas", "personas.json");
+
+function capture(args: string[]): { code: number; out: string; err: string } {
+  let out = "";
+  let err = "";
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stdout.write = (c: any) => { out += String(c); return true; };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stderr.write = (c: any) => { err += String(c); return true; };
+  let code: number;
+  try { code = run(args); } finally { process.stdout.write = origOut; process.stderr.write = origErr; }
+  return { code, out, err };
+}
+
+/** Spawn the built binary with `cwd` set — isolates process.cwd() per call, no global chdir. */
+function spawnUi(args: string[], cwd: string): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync("node", [DIST_CLI, ...args], { cwd, encoding: "utf8" });
+  return { code: result.status ?? 1, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+function lastLedgerLine(proj: string): Record<string, unknown> {
+  const lines = readFileSync(join(proj, "design", "memory.events.jsonl"), "utf8").trim().split("\n");
+  return JSON.parse(lines[lines.length - 1] ?? "{}");
+}
+
+function tmpFile(dir: string, name: string, content: string): string {
+  const p = join(dir, name);
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+const savedHome = process.env["EASE_DESIGN_HOME"];
+let proj: string; // design project (has design/) — the auto-record target for cwd-resolved commands
+let scratch: string; // scratch dir for input fixtures, outside proj
+
+beforeEach(() => {
+  proj = mkdtempSync(join(tmpdir(), "ease-autorec-proj-"));
+  mkdirSync(join(proj, "design"), { recursive: true });
+  scratch = mkdtempSync(join(tmpdir(), "ease-autorec-scratch-"));
+  process.env["EASE_DESIGN_HOME"] = mkdtempSync(join(tmpdir(), "ease-autorec-home-"));
+});
+afterEach(() => {
+  if (savedHome === undefined) delete process.env["EASE_DESIGN_HOME"];
+  else process.env["EASE_DESIGN_HOME"] = savedHome;
+});
+
+const distMissing = !existsSync(DIST_CLI);
+if (distMissing) {
+  console.warn(`SKIP autorecord-call-sites: ${DIST_CLI} not found — run "npm run build" first.`);
+}
+
+// ─── a11y-lint / content-lint / taste-lint / validate-layout / audit (lint_run) ──
+//
+// The ledger project is resolved from the LINTED FILE (walk-up from its dir looking
+// for design/), never from cwd — so every fixture below lives inside a nested
+// subdir of `proj` (proving the walk-up), and every command is spawned with cwd set
+// to `scratch` (an unrelated dir with no design/ ancestor — proving cwd is now
+// irrelevant to where the outcome lands; spec 006 P1 blocker fix).
+
+describe.skipIf(distMissing)("lint_run auto-record", () => {
+  it("ui a11y-lint appends one lint_run event naming the rules that tripped", () => {
+    const pages = join(proj, "pages");
+    mkdirSync(pages, { recursive: true });
+    const file = tmpFile(pages, "a11y.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><img src="a.jpg"></body></html>`);
+    const r = spawnUi(["a11y-lint", file], scratch);
+    expect(r.code).toBe(1);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("lint_run");
+    expect((line["data"] as Record<string, unknown>)["check"]).toBe("a11y-lint");
+    expect((line["data"] as Record<string, unknown>)["checkIds"]).toContain("img-missing-alt");
+  });
+
+  it("ui a11y-lint records a CLEAN run too — a pass is an outcome", () => {
+    const pages = join(proj, "pages");
+    mkdirSync(pages, { recursive: true });
+    const file = tmpFile(pages, "a11y-clean.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><img src="a.jpg" alt="a"></body></html>`);
+    const r = spawnUi(["a11y-lint", file], scratch);
+    expect(r.code).toBe(0);
+    const line = lastLedgerLine(proj);
+    const data = line["data"] as Record<string, unknown>;
+    expect(data["errorCount"]).toBe(0);
+    expect(data["checkIds"]).toEqual([]);
+    const lines = readFileSync(join(proj, "design", "memory.events.jsonl"), "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  it("ui content-lint appends lint_run with check=content-lint", () => {
+    const pages = join(proj, "pages");
+    mkdirSync(pages, { recursive: true });
+    const file = tmpFile(pages, "content.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><p>Lorem ipsum dolor sit amet</p></body></html>`);
+    const r = spawnUi(["content-lint", file], scratch);
+    expect(r.code).toBe(1);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("lint_run");
+    expect((line["data"] as Record<string, unknown>)["check"]).toBe("content-lint");
+    expect((line["data"] as Record<string, unknown>)["checkIds"]).toContain("lorem-ipsum");
+  });
+
+  it("ui taste-lint appends lint_run carrying the axes affected", () => {
+    const pages = join(proj, "pages");
+    mkdirSync(pages, { recursive: true });
+    const file = tmpFile(pages, "taste.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><p style="font-size:12px">Body copy text here</p></body></html>`);
+    const r = spawnUi(["taste-lint", file], scratch);
+    expect(r.code).toBe(1);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("lint_run");
+    const data = line["data"] as Record<string, unknown>;
+    expect(data["check"]).toBe("taste-lint");
+    expect((data["axes"] as string[]).length).toBeGreaterThan(0);
+  });
+
+  it("ui validate-layout appends lint_run with check=validate-layout", () => {
+    const pages = join(proj, "pages");
+    mkdirSync(pages, { recursive: true });
+    const file = tmpFile(pages, "layout.html", `<body><p>no html root</p></body>`);
+    const r = spawnUi(["validate-layout", file], scratch);
+    expect(r.code).toBe(1);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("lint_run");
+    expect((line["data"] as Record<string, unknown>)["check"]).toBe("validate-layout");
+    expect((line["data"] as Record<string, unknown>)["checkIds"]).toContain("missing-html-root");
+  });
+
+  it("ui audit maps total violations onto errorCount and rules onto checkIds", () => {
+    const pages = join(proj, "pages");
+    mkdirSync(pages, { recursive: true });
+    const nodes = tmpFile(pages, "nodes.json", JSON.stringify({ name: "Bad", type: "FRAME", fills: [{ hex: "#ff0000" }] }));
+    const tokens = tmpFile(scratch, "tokens.json", JSON.stringify({ color: { danger: { $value: "#ff0000", $type: "color" } } }));
+    const r = spawnUi(["audit", nodes, "--tokens", tokens], scratch);
+    expect(r.code).toBe(1);
+    const line = lastLedgerLine(proj);
+    const data = line["data"] as Record<string, unknown>;
+    expect(data["check"]).toBe("audit");
+    const checkIds = data["checkIds"] as string[];
+    expect(data["warningCount"]).toBe(0);
+    expect(checkIds.length).toBeGreaterThan(0);
+  });
+
+  it("a lint on a file OUTSIDE any design/ project records nothing, even though cwd has one", () => {
+    // The NIT this closes: a lint used to resolve the ledger from cwd, so linting a
+    // file that belongs to a DIFFERENT (or no) project could silently write into
+    // whichever project happened to be cwd. Now resolution follows the file.
+    const file = tmpFile(scratch, "a11y-orphan.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><img src="a.jpg"></body></html>`);
+    const r = spawnUi(["a11y-lint", file], proj);
+    expect(r.code).toBe(1);
+    expect(existsSync(join(proj, "design", "memory.events.jsonl"))).toBe(false);
+  });
+
+  it("lints a file in project OTHER while cwd is project A → records into OTHER, not A", () => {
+    const other = mkdtempSync(join(tmpdir(), "ease-autorec-other-"));
+    mkdirSync(join(other, "design"), { recursive: true });
+    const file = tmpFile(other, "page.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><img src="a.jpg"></body></html>`);
+    const r = spawnUi(["a11y-lint", file], proj);
+    expect(r.code).toBe(1);
+    expect(existsSync(join(proj, "design", "memory.events.jsonl"))).toBe(false);
+    const line = lastLedgerLine(other);
+    expect(line["type"]).toBe("lint_run");
+    expect((line["data"] as Record<string, unknown>)["check"]).toBe("a11y-lint");
+  });
+});
+
+// ─── autofix (conditional autofix_applied) ───────────────────────────────────
+
+describe.skipIf(distMissing)("autofix auto-record", () => {
+  it("ui autofix without --write records nothing (stdout only, no state change)", () => {
+    const file = tmpFile(scratch, "dirty.html", `<!doctype html><html lang="en"><body><div id="x"></div><div id="x"></div></body></html>`);
+    const r = spawnUi(["autofix", file], proj);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(proj, "design", "memory.events.jsonl"))).toBe(false);
+  });
+
+  it("ui autofix --write on already-fixed HTML records nothing (0 fixes = no change)", () => {
+    const file = tmpFile(scratch, "clean.html", `<!doctype html><html lang="en"><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>T</title></head><body><p>Hi</p></body></html>`);
+    const r = spawnUi(["autofix", file, "--write"], proj);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(proj, "design", "memory.events.jsonl"))).toBe(false);
+  });
+
+  it("ui autofix --write that applies a fix appends autofix_applied with sorted ruleIds", () => {
+    // Fixture lives inside proj (project resolves from the fixed FILE, not cwd);
+    // spawned with cwd=scratch to prove cwd no longer matters.
+    const pages = join(proj, "pages");
+    mkdirSync(pages, { recursive: true });
+    const file = tmpFile(pages, "dirty2.html", `<!doctype html><html lang="en"><body><div id="x">a</div><div id="x">b</div></body></html>`);
+    const r = spawnUi(["autofix", file, "--write"], scratch);
+    expect(r.code).toBe(0);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("autofix_applied");
+    const data = line["data"] as Record<string, unknown>;
+    expect(data["file"]).toBe(file);
+    expect((data["fixCount"] as number)).toBeGreaterThan(0);
+    const ruleIds = data["ruleIds"] as string[];
+    expect(ruleIds).toEqual([...ruleIds].sort());
+  });
+});
+
+// ─── ds change-token (token_change, --dir = project dir; in-process is safe) ──
+
+describe("ds change-token auto-record", () => {
+  function initDs(dir: string): void {
+    capture(["ds", "init", "acme", "--persona", "liquid-glass", "--intent", "test", "--dir", dir, "--persona-data", PERSONA_DATA]);
+  }
+
+  it("ui ds change-token records token_change carrying the reason", () => {
+    initDs(proj);
+    const r = capture(["ds", "change-token", "color.primary", "--value", "{primary.600}", "--reason", "brand refresh", "--dir", proj, "--json"]);
+    expect(r.code).toBe(0);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("token_change");
+    expect((line["data"] as Record<string, unknown>)["reason"]).toBe("brand refresh");
+  });
+
+  it("ui ds change-token to the SAME value records nothing (the no-op branch)", () => {
+    initDs(proj);
+    const first = capture(["ds", "change-token", "color.primary", "--value", "{primary.600}", "--dir", proj, "--json"]);
+    expect(first.code).toBe(0);
+    const linesAfterFirst = readFileSync(join(proj, "design", "memory.events.jsonl"), "utf8").trim().split("\n").length;
+    const second = capture(["ds", "change-token", "color.primary", "--value", "{primary.600}", "--dir", proj, "--json"]);
+    expect(second.code).toBe(0);
+    expect(JSON.parse(second.out).data.changed).toBe(false);
+    const linesAfterSecond = readFileSync(join(proj, "design", "memory.events.jsonl"), "utf8").trim().split("\n").length;
+    expect(linesAfterSecond).toBe(linesAfterFirst);
+  });
+});
+
+// ─── ds change-token WITHOUT --dir: discovery must drive the ledger, not cwd ──
+// (spec 006 P1 blocker, symptoms A and B — needs a real per-process cwd, so this
+// spawns the built binary rather than using in-process `capture()`.)
+
+describe.skipIf(distMissing)("ds change-token subdir + discovery resolution (blocker fix)", () => {
+  function initDsBuilt(dir: string): void {
+    spawnSync("node", [DIST_CLI, "ds", "init", "acme", "--persona", "liquid-glass", "--intent", "test", "--dir", dir, "--persona-data", PERSONA_DATA], { encoding: "utf8" });
+  }
+
+  it("symptom A: running from a SUBDIR still records into the discovered project, not cwd", () => {
+    const p = mkdtempSync(join(tmpdir(), "ease-autorec-dctokA-"));
+    initDsBuilt(p);
+    const subdir = join(p, "src");
+    mkdirSync(subdir, { recursive: true });
+
+    const r = spawnUi(["ds", "change-token", "color.primary", "--value", "{primary.600}", "--json"], subdir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(subdir, "design"))).toBe(false); // never created at cwd
+    const line = lastLedgerLine(p);
+    expect(line["type"]).toBe("token_change");
+  });
+
+  it("symptom B: a decoy design/ dir in the subdir (no manifest) does not steal the event", () => {
+    const p = mkdtempSync(join(tmpdir(), "ease-autorec-dctokB-"));
+    initDsBuilt(p);
+    const subdir = join(p, "src");
+    mkdirSync(join(subdir, "design"), { recursive: true }); // decoy: design/ exists but has no ds.manifest.json
+
+    const r = spawnUi(["ds", "change-token", "color.primary", "--value", "{primary.600}", "--json"], subdir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(subdir, "design", "memory.events.jsonl"))).toBe(false);
+    const line = lastLedgerLine(p);
+    expect(line["type"]).toBe("token_change");
+  });
+});
+
+// ─── figma reconcile --apply (reconcile_applied, --dir = project dir) ────────
+
+describe("figma reconcile auto-record", () => {
+  function writeLog(dir: string, lines: Record<string, unknown>[]): void {
+    writeFileSync(join(dir, "design", "figma.changes.jsonl"), lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf8");
+  }
+  function writeRegistry(dir: string, components: Array<Record<string, unknown>>): void {
+    writeFileSync(join(dir, "design", "component-registry.json"), JSON.stringify({ version: "0.1.0", components }, null, 2) + "\n", "utf8");
+  }
+  function frame(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return { v: 1, ts: 1000, op: "deleted", nodeId: "1:1", nodeName: "Card/Basic", nodeType: "COMPONENT", changedProps: [], origin: "LOCAL", scopeHint: "local", page: "Page 1", fileKey: "abc", ...over };
+  }
+
+  it("ui figma reconcile --dry-run records nothing", () => {
+    writeRegistry(proj, [{ name: "Card/Basic", category: "card", markup: "<div></div>", tokensUsed: [], scope: "local" }]);
+    writeLog(proj, [frame()]);
+    const r = capture(["figma", "reconcile", "--dir", proj, "--json"]);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(proj, "design", "memory.events.jsonl"))).toBe(false);
+  });
+
+  it("ui figma reconcile --apply that changed the registry appends reconcile_applied", () => {
+    writeRegistry(proj, [{ name: "Card/Basic", category: "card", markup: "<div></div>", tokensUsed: [], scope: "local" }]);
+    writeLog(proj, [frame()]);
+    const r = capture(["figma", "reconcile", "--dir", proj, "--apply", "--json"]);
+    expect(r.code).toBe(0);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("reconcile_applied");
+    const data = line["data"] as Record<string, unknown>;
+    expect(data["deprecated"]).toEqual(["Card/Basic"]);
+  });
+});
+
+// ─── taste record --mode pair (taste_vote, cwd-resolved, never touches designs) ──
+
+describe.skipIf(distMissing)("taste record auto-record", () => {
+  function seedItem(root: string, genre: string, offset: number): string {
+    const src = mkdtempSync(join(tmpdir(), "ease-autorec-seed-"));
+    const data = new Uint8Array(8 * 8 * 4);
+    for (let i = 0; i < 8 * 8; i++) {
+      const v = (i * 7 + offset) % 256;
+      data[i * 4] = v; data[i * 4 + 1] = v; data[i * 4 + 2] = v; data[i * 4 + 3] = 255;
+    }
+    writeFileSync(join(src, "x.png"), encodePng({ width: 8, height: 8, data }));
+    const r = spawnSync("node", [DIST_CLI, "taste", "ingest", "--root", root, "--dir", src, "--genre", genre, "--json"], { encoding: "utf8" });
+    return (JSON.parse(r.stdout ?? "{}").data.items[0].id) as string;
+  }
+
+  it("ui taste record --mode pair appends taste_vote and never touches the designs graph", () => {
+    const tasteRoot = mkdtempSync(join(tmpdir(), "ease-autorec-taste-"));
+    const id1 = seedItem(tasteRoot, "g", 0);
+    const id2 = seedItem(tasteRoot, "g", 90);
+
+    const r = spawnUi(["taste", "record", "--mode", "pair", "--root", tasteRoot, "--a", id1, "--b", id2, "--winner", "a", "--json"], proj);
+    expect(r.code).toBe(0);
+    const line = lastLedgerLine(proj);
+    expect(line["type"]).toBe("taste_vote");
+    expect((line["data"] as Record<string, unknown>)["winner"]).toBe("a");
+
+    const compileR = capture(["memory", "compile", "--now", "2026-07-17T00:00:00Z", "--dir", proj, "--json"]);
+    expect(compileR.code).toBe(0);
+    const graph = JSON.parse(readFileSync(join(proj, "design", "memory.graph.json"), "utf8"));
+    expect(graph.designs).toEqual({});
+  });
+});
+
+// ─── regression + failure-isolation guards ───────────────────────────────────
+
+describe.skipIf(distMissing)("auto-record regression guards", () => {
+  it("a lint in a project WITHOUT design/ exits 0/1 exactly as before and writes nothing", () => {
+    const bareDir = mkdtempSync(join(tmpdir(), "ease-autorec-bare-"));
+    const file = tmpFile(scratch, "a11y-bare.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><img src="a.jpg"></body></html>`);
+    const r = spawnUi(["a11y-lint", file], bareDir);
+    expect(r.code).toBe(1);
+    expect(existsSync(join(bareDir, "design"))).toBe(false);
+  });
+
+  it("a failing auto-record never changes the lint's exit code", () => {
+    if (process.getuid?.() === 0) return; // root bypasses fs permission bits
+    const file = tmpFile(scratch, "a11y-ro.html", `<!doctype html><html lang="en"><head><title>T</title></head><body><img src="a.jpg"></body></html>`);
+    const pristine = spawnUi(["a11y-lint", file], proj);
+    chmodSync(join(proj, "design"), 0o500);
+    try {
+      const ro = spawnUi(["a11y-lint", file], proj);
+      expect(ro.code).toBe(pristine.code);
+    } finally {
+      chmodSync(join(proj, "design"), 0o700);
+    }
+  });
+});

--- a/tests/memory-autorecord.test.ts
+++ b/tests/memory-autorecord.test.ts
@@ -1,0 +1,196 @@
+/**
+ * `src/core/memory-autorecord.ts` — the fuel-line kernel (spec 006 P1). Calls the
+ * exported functions directly (no CLI seam) per plan invariant #5.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { parseArgs } from "../src/core/cli-args.js";
+import { recordOutcome, withOutcome, lintOutcomeData } from "../src/core/memory-autorecord.js";
+
+const savedHome = process.env["EASE_DESIGN_HOME"];
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ease-autorec-home-"));
+  process.env["EASE_DESIGN_HOME"] = home;
+});
+afterEach(() => {
+  if (savedHome === undefined) delete process.env["EASE_DESIGN_HOME"];
+  else process.env["EASE_DESIGN_HOME"] = savedHome;
+});
+
+function tmpProj(): string {
+  return mkdtempSync(join(tmpdir(), "ease-autorec-"));
+}
+
+describe("recordOutcome", () => {
+  it("does nothing when the project has no design/ dir — no file is created", () => {
+    const proj = tmpProj();
+    const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+    const r = recordOutcome(parsed, { type: "lint_run", actor: "ui a11y-lint", data: { check: "a11y-lint", file: "x.html", errorCount: 0, warningCount: 0, checkIds: [] } });
+    expect(r).toEqual({ recorded: false, reason: "not-opted-in" });
+    expect(existsSync(join(proj, "design"))).toBe(false);
+  });
+
+  it("appends one line and returns the monotonic id once design/ exists", () => {
+    const proj = tmpProj();
+    mkdirSync(join(proj, "design"), { recursive: true });
+    const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+    const input = { type: "lint_run" as const, actor: "ui a11y-lint", data: { check: "a11y-lint", file: "x.html", errorCount: 0, warningCount: 0, checkIds: [] } };
+    const r1 = recordOutcome(parsed, input);
+    const r2 = recordOutcome(parsed, input);
+    expect(r1).toEqual({ recorded: true, id: "e1" });
+    expect(r2).toEqual({ recorded: true, id: "e2" });
+    const lines = readFileSync(join(proj, "design", "memory.events.jsonl"), "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  it("does not write design/memory.graph.json (the graph rebuilds lazily)", () => {
+    const proj = tmpProj();
+    mkdirSync(join(proj, "design"), { recursive: true });
+    const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+    recordOutcome(parsed, { type: "lint_run", actor: "ui a11y-lint", data: { check: "a11y-lint", file: "x.html", errorCount: 0, warningCount: 0, checkIds: [] } });
+    expect(existsSync(join(proj, "design", "memory.graph.json"))).toBe(false);
+  });
+
+  it("does not upsert the user registry (a lint must not write to $HOME)", () => {
+    const proj = tmpProj();
+    mkdirSync(join(proj, "design"), { recursive: true });
+    const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+    recordOutcome(parsed, { type: "lint_run", actor: "ui a11y-lint", data: { check: "a11y-lint", file: "x.html", errorCount: 0, warningCount: 0, checkIds: [] } });
+    expect(existsSync(join(home, "projects.json"))).toBe(false);
+  });
+
+  it("returns invalid-event, and writes nothing, when data misses a required key", () => {
+    const proj = tmpProj();
+    mkdirSync(join(proj, "design"), { recursive: true });
+    const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+    const r = recordOutcome(parsed, { type: "lint_run", actor: "ui a11y-lint", data: { check: "a11y-lint" } });
+    expect(r.recorded).toBe(false);
+    expect(r.reason).toBe("invalid-event");
+    expect(existsSync(join(proj, "design", "memory.events.jsonl"))).toBe(false);
+  });
+
+  it("never throws when the ledger is unwritable — returns write-failed", () => {
+    if (process.getuid?.() === 0) return; // root bypasses fs permission bits
+    const proj = tmpProj();
+    const designDir = join(proj, "design");
+    mkdirSync(designDir, { recursive: true });
+    chmodSync(designDir, 0o500);
+    try {
+      const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+      const r = recordOutcome(parsed, { type: "lint_run", actor: "ui a11y-lint", data: { check: "a11y-lint", file: "x.html", errorCount: 0, warningCount: 0, checkIds: [] } });
+      expect(r.recorded).toBe(false);
+      expect(r.reason).toBe("write-failed");
+    } finally {
+      chmodSync(designDir, 0o700);
+    }
+  });
+
+  it("input.projectDir walks up from a nested artifact path to find the owning project", () => {
+    const proj = tmpProj();
+    mkdirSync(join(proj, "design"), { recursive: true });
+    const nested = join(proj, "pages", "sub");
+    mkdirSync(nested, { recursive: true });
+    const artifact = join(nested, "page.html");
+    const parsed = parseArgs(["a11y-lint", artifact]); // no --dir at all
+    const r = recordOutcome(parsed, {
+      type: "lint_run",
+      actor: "ui a11y-lint",
+      projectDir: artifact,
+      data: { check: "a11y-lint", file: artifact, errorCount: 0, warningCount: 0, checkIds: [] },
+    });
+    expect(r).toEqual({ recorded: true, id: "e1" });
+    expect(existsSync(join(proj, "design", "memory.events.jsonl"))).toBe(true);
+  });
+
+  it("input.projectDir that resolves to NO design/ ancestor is not-opted-in, even with --dir set elsewhere", () => {
+    const orphan = tmpProj(); // no design/ anywhere in its ancestry
+    const otherProj = tmpProj();
+    mkdirSync(join(otherProj, "design"), { recursive: true });
+    const artifact = join(orphan, "page.html");
+    // --dir points at a DIFFERENT project that IS opted in — must not be used as a
+    // fallback once projectDir is given (that would reintroduce the cwd-guess bug).
+    const parsed = parseArgs(["a11y-lint", artifact, "--dir", otherProj]);
+    const r = recordOutcome(parsed, {
+      type: "lint_run",
+      actor: "ui a11y-lint",
+      projectDir: artifact,
+      data: { check: "a11y-lint", file: artifact, errorCount: 0, warningCount: 0, checkIds: [] },
+    });
+    expect(r).toEqual({ recorded: false, reason: "not-opted-in" });
+    expect(existsSync(join(otherProj, "design", "memory.events.jsonl"))).toBe(false);
+  });
+
+  it("input.projectDir as an already-resolved project dir (not a file) matches at level 0", () => {
+    const proj = tmpProj();
+    mkdirSync(join(proj, "design"), { recursive: true });
+    const parsed = parseArgs(["ds", "change-token"]);
+    const r = recordOutcome(parsed, {
+      type: "token_change",
+      actor: "ui ds change-token",
+      projectDir: proj,
+      data: { path: "color.primary", from: "#000", to: "#fff", generation: 2 },
+    });
+    expect(r).toEqual({ recorded: true, id: "e1" });
+  });
+
+  it("stamps t from nowIso when given, so the line is byte-stable", () => {
+    const projA = tmpProj();
+    const projB = tmpProj();
+    mkdirSync(join(projA, "design"), { recursive: true });
+    mkdirSync(join(projB, "design"), { recursive: true });
+    const nowIso = "2026-07-17T00:00:00.000Z";
+    const input = { type: "lint_run" as const, actor: "ui a11y-lint", data: { check: "a11y-lint", file: "x.html", errorCount: 0, warningCount: 0, checkIds: [] } };
+    recordOutcome(parseArgs(["a11y-lint", "--dir", projA]), input, nowIso);
+    recordOutcome(parseArgs(["a11y-lint", "--dir", projB]), input, nowIso);
+    const lineA = readFileSync(join(projA, "design", "memory.events.jsonl"), "utf8").trim();
+    const lineB = readFileSync(join(projB, "design", "memory.events.jsonl"), "utf8").trim();
+    expect(lineA).toBe(lineB);
+  });
+});
+
+describe("lintOutcomeData", () => {
+  it("emits checkIds sorted and deduped", () => {
+    const data = lintOutcomeData("a11y-lint", "x.html", {
+      errorCount: 1,
+      warningCount: 0,
+      findings: [{ checkId: "b" }, { checkId: "a" }, { checkId: "b" }],
+    });
+    expect(data["checkIds"]).toEqual(["a", "b"]);
+  });
+
+  it("is byte-stable: two calls on the same result stringify identically", () => {
+    const result = { errorCount: 1, warningCount: 2, findings: [{ checkId: "b" }, { checkId: "a" }] };
+    const d1 = lintOutcomeData("a11y-lint", "x.html", result);
+    const d2 = lintOutcomeData("a11y-lint", "x.html", result);
+    expect(JSON.stringify(d1)).toBe(JSON.stringify(d2));
+  });
+});
+
+describe("withOutcome", () => {
+  it("returns the result untouched when the project is not opted in", () => {
+    const proj = tmpProj();
+    const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+    const result = { exitCode: 0, stdout: "ok\n" };
+    const out = withOutcome(result, parsed, { type: "lint_run", actor: "ui a11y-lint", data: { check: "a11y-lint", file: "x.html", errorCount: 0, warningCount: 0, checkIds: [] } });
+    expect(out.stdout).toBe(result.stdout);
+    expect(out.exitCode).toBe(result.exitCode);
+    expect(out.stderr).toBeUndefined();
+  });
+
+  it("appends exactly one stderr warning on an invalid event, leaving stdout and exitCode alone", () => {
+    const proj = tmpProj();
+    mkdirSync(join(proj, "design"), { recursive: true });
+    const parsed = parseArgs(["a11y-lint", "--dir", proj]);
+    const result = { exitCode: 0, stdout: "ok\n" };
+    const out = withOutcome(result, parsed, { type: "lint_run", actor: "ui a11y-lint", data: { check: "a11y-lint" } });
+    expect(out.stdout).toBe(result.stdout);
+    expect(out.exitCode).toBe(result.exitCode);
+    expect(out.stderr).toContain("ui: memory auto-record skipped (invalid-event)");
+    expect((out.stderr ?? "").split("\n").filter((l) => l.length > 0)).toHaveLength(1);
+  });
+});

--- a/tests/memory-events.test.ts
+++ b/tests/memory-events.test.ts
@@ -34,6 +34,10 @@ describe("memory-events — validateEvent", () => {
       harvested: { source: "https://example.com" },
       duel_result: { benchmark: "linear", traits: [] },
       gap: { text: "motion axis has no bounce guidance", target: "taste-rubric.md#motion" },
+      lint_run: { check: "a11y-lint", file: "index.html", errorCount: 0, warningCount: 0, checkIds: [] },
+      autofix_applied: { file: "index.html", fixCount: 1, ruleIds: ["viewport-meta"] },
+      reconcile_applied: { added: [], updated: [], deprecated: [] },
+      taste_vote: { a: "item-1", b: "item-2", winner: "a" },
     };
     for (const [type, data] of Object.entries(happy)) {
       expect(codeOf(() => validateEvent(type, data, undefined)), type).toBeNull();
@@ -69,10 +73,14 @@ describe("memory-events — validateEvent", () => {
     expect(codeOf(() => validateEvent("insight", { text: "x" }, ["e1"]))).toBeNull();
   });
 
-  it("EVENT_TYPES has 12 members; isEventType/isMedium guard", () => {
-    expect(EVENT_TYPES.length).toBe(12);
+  it("EVENT_TYPES has 16 members; isEventType/isMedium guard", () => {
+    expect(EVENT_TYPES.length).toBe(16);
     expect(isEventType("gap")).toBe(true);
     expect(isEventType("user_pick")).toBe(true);
+    expect(isEventType("lint_run")).toBe(true);
+    expect(isEventType("autofix_applied")).toBe(true);
+    expect(isEventType("reconcile_applied")).toBe(true);
+    expect(isEventType("taste_vote")).toBe(true);
     expect(isEventType("nope")).toBe(false);
     expect(isMedium("html")).toBe(true);
     expect(isMedium("figma")).toBe(true);


### PR DESCRIPTION
## Summary
- `src/core/memory-autorecord.ts` (122 lines): `recordOutcome`/`withOutcome`/`lintOutcomeData` — the one write path that appends a `MemoryEvent` as a side-effect of running an outcome-bearing kernel command. Opt-in per project (`design/` must already exist), automatic per run, never throws, no graph recompile, no registry upsert.
- 4 new `EVENT_TYPES` (`lint_run`, `autofix_applied`, `reconcile_applied`, `taste_vote`) — 12 → 16. `token_change` reused as-is.
- 9 call sites wired: `a11y-lint`, `content-lint`, `taste-lint`, `validate-layout`, `audit` → `lint_run` (every run, pass or fail); `autofix --write` with ≥1 fix → `autofix_applied`; `ds change-token` on change → `token_change`; `figma reconcile --apply` on change → `reconcile_applied`; `taste record --mode pair` → `taste_vote`.

Implements `specs/006-living-loop/phase-01-auto-record-core.md` verbatim.

## Deviations from plan.md (documented in the phase file's Deviations section)
1. `token_changed` not added — `token_change` already has the exact payload.
2. `audit_run` not added — folded into `lint_run` with `data.check = "audit"`.
3. `taste_vote` added fresh — plan.md said a shape already existed; it didn't (`user_pick` would corrupt the graph's `designs` map, `taste_verdict` requires a different shape).
4. Net new types = 4, not plan.md's 5.
5. `recordOutcome(parsed, input, nowIso?)` signature, not plan.md's `(kind, data, dir)` — centralises `--dir` read, carries `actor`, and `nowIso` is injectable for the byte-stability test.

## Gates (all green)
- `npm run typecheck && npm run lint && npm run build && npm test` — 128 test files, 1918 passed, 4 skipped (unrelated).
- `ui knowledge check --json` — 0 findings.
- New/changed tests: `tests/memory-autorecord.test.ts` (kernel, 16 tests), `tests/autorecord-call-sites.test.ts` (CLI seam, 19 tests), `tests/memory-events.test.ts` (extended closed-set assertion).

## Art III — real project smoke (evidence)
Ran all 9 commands against a real tmp project with `design/`, ledger e1–e9:
```
{"v":1,"id":"e1",...,"type":"lint_run","actor":"ui a11y-lint","data":{"check":"a11y-lint","file":"a.html","errorCount":1,"warningCount":0,"checkIds":["img-missing-alt"]}}
{"v":1,"id":"e2",...,"type":"lint_run","actor":"ui content-lint","data":{"check":"content-lint","file":"c.html","errorCount":3,"warningCount":0,"checkIds":["lorem-ipsum","placeholder-copy"]}}
{"v":1,"id":"e3",...,"type":"lint_run","actor":"ui taste-lint","data":{"check":"taste-lint","file":"t.html","errorCount":1,"warningCount":0,"checkIds":["tiny-body-text"],"axes":["Typography"]}}
{"v":1,"id":"e4",...,"type":"lint_run","actor":"ui validate-layout","data":{"check":"validate-layout","file":"v.html","errorCount":1,"warningCount":1,"checkIds":["missing-doctype","missing-html-root"]}}
{"v":1,"id":"e5",...,"type":"lint_run","actor":"ui audit","data":{"check":"audit","file":"nodes.json","errorCount":1,"warningCount":0,"checkIds":["raw-hex-vs-token"]}}
{"v":1,"id":"e6",...,"type":"autofix_applied","actor":"ui autofix","data":{"file":"d.html","fixCount":1,"ruleIds":["duplicate-ids"]}}
{"v":1,"id":"e7",...,"type":"token_change","actor":"ui ds change-token","data":{"path":"color.primary","from":"{primary.500}","to":"{primary.600}","reason":"brand refresh","generation":2}}
{"v":1,"id":"e8",...,"type":"reconcile_applied","actor":"ui figma reconcile","data":{"added":[],"updated":[],"deprecated":["Card/Basic"],"mirrored":0,"cursorFrom":0,"cursorTo":1}}
{"v":1,"id":"e9",...,"type":"taste_vote","actor":"ui taste record","data":{"a":"6b7fa434f92a","b":"fce481932ea5","winner":"a"}}
```
`ui memory compile --dir <proj>` on the resulting ledger succeeds (`eventCount: 9`) — confirms an older reader is the only real risk (Key Insight 1), noted for `design-os update` to rebuild every hand.

## Test plan
- [x] `npm run typecheck && npm run lint && npm run build && npm test`
- [x] `ui knowledge check`
- [x] Real-project smoke of all 9 commands (pasted above)

## Post-audit fix (class-fix, Art IV)

Opus audit found `recordOutcome` resolved the project via `--dir` else **cwd**, which
diverges from how the outcome-bearing commands themselves resolve their target:
- `ds change-token` (no `--dir`) discovers the project via `discoverDesignSystem`
  (walks up from cwd). Running it from a subdir → `recordOutcome` guarded on
  `cwd/design`, not the discovered project → **event silently dropped**, or worse,
  a decoy `design/` in the subdir → **event written to the wrong ledger**
  (append-only, never self-corrects).
- Lints/audit/autofix act on a `<file>` arg that can sit anywhere — cwd has no
  necessary relation to it. Linting a file that belongs to a different (or no)
  project could silently misattribute the event to whatever project happened to
  be cwd.

Fix: `OutcomeInput` gains `projectDir?: string` — the artifact the command just
acted on. `recordOutcome` now resolves the project by walking up from that
artifact (mirrors `discoverDesignSystem`'s walk, looking for `design/`), falling
back to `--dir` then cwd only when a call site has no artifact to point at.
Every outcome-bearing call site now passes it: `ds change-token` → the
discovered/`--dir`'d project dir; `figma reconcile` → its resolved project dir;
`a11y-lint`/`content-lint`/`taste-lint`/`validate-layout`/`audit`/`autofix` → the
file they acted on. `taste record` is the one documented exception — its taste
root is a separate tree from `design/`, so there's no artifact to point at; it
keeps the cwd fallback (see the header comment in `memory-autorecord.ts`).

New tests: `input.projectDir` walk-up + no-fallback-to-`--dir` (`memory-autorecord.test.ts`);
subdir + decoy-`design/` resolution for `ds change-token` (symptoms A/B), and a
lint-on-a-file-in-a-different-project test proving the event lands in the file's
own project, not cwd's (`autorecord-call-sites.test.ts`). All prior P1 tests
still pass; the 7 CLI fixture tests that previously placed the linted file
outside the project now place it inside (nested, to prove the walk-up) and spawn
from an unrelated cwd (to prove cwd no longer matters) — this is a deliberate
premise change, not a weakening, since the old premise ("file outside cwd's
project still records into cwd's project") was the bug.

Additional deviation from plan.md (not previously called out): the CLI seam
tests (`tests/autorecord-call-sites.test.ts`) spawn the built binary
(`spawnSync` on `dist/cli.js` with an explicit `cwd`) rather than
`process.chdir()` as plan.md specified — `chdir` is process-global and vitest
runs multiple test files in one shared worker, so it would race every other
suite running concurrently (confirmed: it corrupted the repo's own working tree
with cross-file events during authoring).

Gates re-run green (2x): `npm run typecheck && npm run lint && npm run build && npm test`
— 128 files, 1925 passed, 4 skipped (unrelated). `ui knowledge check` — 0 findings.
`git status` clean after the full run (no leaked `design/` under the real repo).
