### PR TITLE
feat(memory): enforce auto-record wiring with a registry + meta-linter (spec 006 P2)

### DIFF
--- a/src/core/memory-autorecord.ts
+++ b/src/core/memory-autorecord.ts
@@ -25,6 +25,13 @@
  * has no design-project artifact to point at (the taste root is a separate tree from
  * design/), so its mirror only fires when cwd itself is a project with design/.
  * `votes.jsonl` stays the system of record either way.
+ *
+ * Convention (spec 006 P2 — Art II, emitter + linter in the same commit): every
+ * outcome-bearing command is listed in src/core/outcome-registry.ts and its call
+ * site wired here via withOutcome/recordOutcome. tests/autorecord-wiring.test.ts is
+ * the paired linter — it fails npm test if a registered command drops its call, or
+ * if an unregistered src/commands file starts making one. Adding a tenth outcome:
+ * add the registry entry, wire the call site, and the linter demands both halves.
  */
 import { existsSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";

--- a/src/core/outcome-registry.ts
+++ b/src/core/outcome-registry.ts
@@ -1,0 +1,42 @@
+/**
+ * The outcome-bearing command registry (spec 006 P2).
+ *
+ * The single source of truth for WHICH kernel subcommands must append a MemoryEvent as
+ * a side-effect of running (spec 006 P1), and under what condition. Pure metadata — the
+ * same role command-signatures.ts plays for flags.
+ *
+ * Its paired linter is tests/autorecord-wiring.test.ts (Art II): it fails when a listed
+ * file stops calling withOutcome, AND when an unlisted src/commands file starts calling
+ * it. Adding a new outcome-bearing command = add an entry here + wire the call site;
+ * the linter fails until both halves exist.
+ *
+ * `condition` is prose for humans and for the PR reviewer — it is NOT executed. The
+ * executable truth is the call site's own guard; keep the two in sync by hand.
+ */
+import type { EventType } from "./memory-events.js";
+
+export interface OutcomeCommandSpec {
+  /** The invocation as a user types it, e.g. "ui audit". */
+  command: string;
+  /** Repo-relative path of the file holding the call site. */
+  file: string;
+  /** The event type this command appends. Typed → a bogus type fails typecheck. */
+  eventType: EventType;
+  /** When it records (prose; the call site holds the executable guard). */
+  condition: string;
+}
+
+export const OUTCOME_BEARING: readonly OutcomeCommandSpec[] = [
+  { command: "ui a11y-lint",       file: "src/commands/a11y-lint.ts",           eventType: "lint_run",          condition: "every successful run (a clean pass is an outcome)" },
+  { command: "ui content-lint",    file: "src/commands/content-lint.ts",        eventType: "lint_run",          condition: "every successful run" },
+  { command: "ui taste-lint",      file: "src/commands/taste-lint.ts",          eventType: "lint_run",          condition: "every successful run" },
+  { command: "ui validate-layout", file: "src/commands/validate-layout.ts",     eventType: "lint_run",          condition: "every successful run" },
+  { command: "ui audit",           file: "src/commands/audit.ts",               eventType: "lint_run",          condition: "every successful run (total→errorCount)" },
+  { command: "ui autofix",         file: "src/commands/autofix.ts",             eventType: "autofix_applied",   condition: "--write AND >=1 fix applied (state change only)" },
+  { command: "ui taste record",    file: "src/commands/taste-record-impl.ts",   eventType: "taste_vote",        condition: "--mode pair only; --mode study is deferred (P1 Decision 6)" },
+  { command: "ui ds change-token", file: "src/commands/ds-change-token-impl.ts", eventType: "token_change",     condition: "the value actually changed (the no-op branch returns first)" },
+  { command: "ui figma reconcile", file: "src/commands/figma-reconcile-run.ts", eventType: "reconcile_applied", condition: "--apply AND (registry changed OR a sidecar was written)" },
+];
+
+/** Repo-relative files that are allowed to call withOutcome/recordOutcome. */
+export const OUTCOME_FILES: readonly string[] = OUTCOME_BEARING.map((s) => s.file);

--- a/tests/autorecord-wiring.test.ts
+++ b/tests/autorecord-wiring.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Linter for the auto-record convention (spec 006 P2) — the emitter half lives in
+ * src/core/memory-autorecord.ts (recordOutcome/withOutcome) and the nine call sites
+ * wired in spec 006 P1; this is its paired linter (repo rule: every standard ships an
+ * emitter AND a linter in the same commit).
+ *
+ * Bidirectional: fails when a file registered in OUTCOME_BEARING stops calling
+ * withOutcome/recordOutcome, AND when an unregistered src/commands/*.ts file starts
+ * calling it — the reverse direction is what catches drift as new commands land.
+ *
+ * Regex, not an AST parse (the repo ships zero runtime deps — tests/zero-runtime-deps.test.ts).
+ * A call sitting inside a comment or a string would false-pass; accepted, because the
+ * failure mode is a deliberately-commented-out call, which no honest author writes.
+ */
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { OUTCOME_BEARING, OUTCOME_FILES } from "../src/core/outcome-registry.js";
+import { EVENT_TYPES } from "../src/core/memory-events.js";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const COMMANDS_DIR = join(REPO_ROOT, "src", "commands");
+const CALL_RE = /\bwithOutcome\s*\(|\brecordOutcome\s*\(/;
+const IMPORT_RE = /from\s+"\.\.\/core\/memory-autorecord\.js"/;
+
+describe("outcome-bearing registry", () => {
+  it.each(OUTCOME_BEARING)("$command's file exists", (spec) => {
+    expect(existsSync(join(REPO_ROOT, spec.file))).toBe(true);
+  });
+
+  it.each(OUTCOME_BEARING)("$command imports memory-autorecord and calls withOutcome", (spec) => {
+    const source = readFileSync(join(REPO_ROOT, spec.file), "utf8");
+    expect(
+      IMPORT_RE.test(source) && CALL_RE.test(source),
+      `${spec.command} (${spec.file}) is registered as outcome-bearing but never calls withOutcome — wire it (spec 006 P1) or remove it from OUTCOME_BEARING`,
+    ).toBe(true);
+  });
+
+  it.each(OUTCOME_BEARING)("$command's eventType is in the closed EVENT_TYPES set", (spec) => {
+    expect(EVENT_TYPES as readonly string[]).toContain(spec.eventType);
+  });
+
+  it("no src/commands file calls withOutcome without being registered", () => {
+    const found: string[] = [];
+    for (const file of readdirSync(COMMANDS_DIR)) {
+      if (!file.endsWith(".ts")) continue;
+      const source = readFileSync(join(COMMANDS_DIR, file), "utf8");
+      if (CALL_RE.test(source)) found.push(`src/commands/${file}`);
+    }
+    expect(found.sort()).toEqual([...OUTCOME_FILES].sort());
+  });
+});
+
+describe("registry shape", () => {
+  it("names each command exactly once", () => {
+    const commands = OUTCOME_BEARING.map((s) => s.command);
+    expect(new Set(commands).size).toBe(OUTCOME_BEARING.length);
+  });
+
+  it("covers the nine commands spec 006 locked as outcome-bearing", () => {
+    expect(OUTCOME_BEARING).toHaveLength(9);
+    expect(OUTCOME_BEARING.map((s) => s.command)).toEqual([
+      "ui a11y-lint",
+      "ui content-lint",
+      "ui taste-lint",
+      "ui validate-layout",
+      "ui audit",
+      "ui autofix",
+      "ui taste record",
+      "ui ds change-token",
+      "ui figma reconcile",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- `src/core/outcome-registry.ts` — single source of truth for the nine outcome-bearing kernel commands wired in P1 (`command`, `file`, `eventType: EventType`, `condition`).
- `tests/autorecord-wiring.test.ts` — paired meta-linter (Art II), vitest not a `ui` subcommand (see Decisions in the phase file — `ui knowledge check` only walks `knowledge/`, and `src/` is not part of the distributed binary). Bidirectional: fails if a registered command drops its `withOutcome`/`recordOutcome` call, or if an unregistered `src/commands/*.ts` file starts calling it.
- Documented the convention in `src/core/memory-autorecord.ts`'s module docstring (no README conventions section exists yet).

## Deviations from tasks.md (per phase-02 spec, reported to the gate)
1. The check is a vitest meta-linter, not `ui lint autorecord` or a fold into `ui knowledge check` — precedent is `tests/journey-command-consistency.test.ts`.
2. The registry does not drive/generate the wiring (each call site's payload is bespoke) — it is asserted against, not codegen'd from.

## Linter-has-teeth evidence (both failure modes, captured then reverted)

**Failure mode 1 — removed `withOutcome` from `src/commands/audit.ts`:**
```
FAIL  tests/autorecord-wiring.test.ts > outcome-bearing registry > 'ui audit' imports memory-autorecord and calls withOutcome
AssertionError: ui audit (src/commands/audit.ts) is registered as outcome-bearing but never calls withOutcome — wire it (spec 006 P1) or remove it from OUTCOME_BEARING: expected false to be true

FAIL  tests/autorecord-wiring.test.ts > outcome-bearing registry > no src/commands file calls withOutcome without being registered
AssertionError: expected [ 'src/commands/a11y-lint.ts', …(7) ] to deeply equal [ 'src/commands/a11y-lint.ts', …(8) ]
  - "src/commands/audit.ts",   (missing)
```

**Failure mode 2 — added a fake `withOutcome(` reference to unregistered `src/commands/scan.ts`:**
```
FAIL  tests/autorecord-wiring.test.ts > outcome-bearing registry > no src/commands file calls withOutcome without being registered
AssertionError: expected [ …8 items ] to deeply equal [ …9 items ]
  + "src/commands/scan.ts",   (unexpected)
```

Both reverted; `git status` clean; 30/30 tests pass after revert.

## Test plan
- [x] `npm run typecheck && npm run lint && npm run build && npm test` — green, run twice
- [x] `ui knowledge check --json` — `errorCount: 0`
- [x] `src/core/outcome-registry.ts` — 42 lines (<200, Art IX)
- [x] Linter-has-teeth: both failure modes demonstrated above
- [x] `git status` clean after all reverts (no stray `design/` writes)