### PR TITLE
feat(figma-agent): inject deterministic build id into panel version chip

### DIFF
--- a/figma-agent/plugin/src/ui/panel-ui.ts
+++ b/figma-agent/plugin/src/ui/panel-ui.ts
@@ -21,9 +21,16 @@ import {
   type ActivityRecord,
 } from './activity-feed';
 
+// Injected by scripts/build.mjs via esbuild `define` — a content hash of the
+// code.js this UI bundle shipped alongside, so a reload can be verified as the
+// new build rather than a stale cached iframe. Undefined in dev/test (no
+// esbuild define pass); `typeof` never throws on an unresolved identifier.
+declare const __BUILD_ID__: string;
+
 const el = (id: string): HTMLElement => document.getElementById(id) as HTMLElement;
 
 const panelRoot = el('fga-panel');
+const versionEl = el('fga-version');
 const dot = el('fga-dot');
 const pill = el('fga-pill');
 const sentence = el('fga-sentence');
@@ -299,6 +306,8 @@ toggleBtn.addEventListener('click', () => {
   parent.postMessage({ pluginMessage: { type: 'PANEL_RESIZE', h: PANEL_HEIGHT[mode] } }, '*');
   render(); // the meta line is mode-dependent (compact disconnected override)
 });
+
+versionEl.textContent = `v0.1.0 · ${typeof __BUILD_ID__ === 'string' ? __BUILD_ID__ : 'dev'}`;
 
 // A 1s heartbeat keeps the live ages (uptime, retry elapsed, time-ago) fresh
 // between transitions.

--- a/figma-agent/plugin/ui.html
+++ b/figma-agent/plugin/ui.html
@@ -857,6 +857,7 @@ code {
   // plugin/src/ui/panel-ui.ts
   var el = (id) => document.getElementById(id);
   var panelRoot = el("fga-panel");
+  var versionEl = el("fga-version");
   var dot = el("fga-dot");
   var pill = el("fga-pill");
   var sentence = el("fga-sentence");
@@ -1086,6 +1087,7 @@ code {
     parent.postMessage({ pluginMessage: { type: "PANEL_RESIZE", h: PANEL_HEIGHT[mode] } }, "*");
     render();
   });
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "950ee34" : "dev"}`;
   setInterval(render, 1e3);
   applyMode();
   render();

--- a/figma-agent/scripts/build.mjs
+++ b/figma-agent/scripts/build.mjs
@@ -3,6 +3,7 @@
 // Usage: node scripts/build.mjs [walker-bundle|cli|plugin-main|plugin-ui|all] [--watch]
 import * as esbuild from 'esbuild';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -68,12 +69,20 @@ async function buildPluginMain() {
 }
 
 async function buildPluginUi() {
+  // The build id the panel shows must match the code.js the user actually has
+  // loaded — rebuild it first so `plugin-ui` run standalone still hashes fresh
+  // bytes (same prerequisite pattern as buildCli/buildWalkerBundle above).
+  await buildPluginMain();
+  const codeJs = readFileSync(resolve(root, 'plugin/code.js'));
+  const buildId = createHash('sha256').update(codeJs).digest('hex').slice(0, 7);
+
   const res = await esbuild.build({
     ...common,
     entryPoints: [resolve(root, 'plugin/src/ui/ui-relay.ts')],
     platform: 'browser',
     format: 'iife',
     write: false,
+    define: { __BUILD_ID__: JSON.stringify(buildId) },
   });
   const js = res.outputFiles[0].text;
   // The panel chrome is authored in plugin/src/ui/panel.html — the SOURCE the P2
@@ -97,7 +106,9 @@ const jobs = {
   'plugin-ui': buildPluginUi,
 };
 // `all` omits walker-bundle on purpose: buildCli regenerates it as its prerequisite.
-const ALL = ['cli', 'plugin-main', 'plugin-ui'];
+// `all` also omits plugin-main: buildPluginUi regenerates it as its own
+// prerequisite (needed to hash code.js for the deterministic build id).
+const ALL = ['cli', 'plugin-ui'];
 if (target === 'all') {
   for (const t of ALL) await jobs[t]();
 } else if (jobs[target]) {


### PR DESCRIPTION
## Summary
- `scripts/build.mjs`: `buildPluginUi` now rebuilds `plugin-main` first, hashes the resulting `code.js` (sha256, first 7 hex chars) and passes it into the UI bundle via esbuild `define: { __BUILD_ID__ }`. Same code → same build id, deterministic.
- `plugin/src/ui/panel-ui.ts`: renders `v0.1.0 · <buildId>` in the `#fga-version` chip; falls back to `dev` when `__BUILD_ID__` is undefined (unit tests, non-esbuild contexts).

## Test plan
- [x] `npm run build` (figma-agent) succeeds, `ui.html` embeds a 7-char hex build id matching `sha256(code.js)`
- [x] Two consecutive builds with unchanged source produce byte-identical `ui.html` (same build id)
- [x] Changing `plugin/src/main/main.ts` changes the build id on rebuild; reverting restores the original id
- [x] `npm run typecheck` (figma-agent) passes
- [x] `npm test` (figma-agent) — 441/441 passing