### PR TITLE
feat(design-os): heartbeat harvest/reflect runners + real-data gate procedure (spec 006 P5)

### DIFF
--- a/design-os/src/design_os/commands/heartbeat.py
+++ b/design-os/src/design_os/commands/heartbeat.py
@@ -38,7 +38,7 @@ _CONFIG_REL = Path("design") / "heartbeat.json"
 _STATE_REL = Path("design") / "heartbeat-state.json"
 _LOCK_REL = Path("design") / ".heartbeat.lock"
 
-_KNOWN_TYPES = {"ds-a11y", "specimen", "audit-pages", "figma-audit"}
+_KNOWN_TYPES = {"ds-a11y", "specimen", "audit-pages", "figma-audit", "harvest", "reflect"}
 
 
 class _BadConfig(Exception):

--- a/design-os/src/design_os/commands/heartbeat_runners.py
+++ b/design-os/src/design_os/commands/heartbeat_runners.py
@@ -1,11 +1,9 @@
-"""Task runners + lock helpers for ``design-os heartbeat`` (split out of
-commands/heartbeat.py per the <200-line rule; heartbeat_render.py keeps the rendering).
-
-Each runner takes ``(project_dir, params)`` and returns ``{"status": "ok"|"error"|
-"skipped", "summary": {…numeric…}, "detail": str, "skipReason"?}`` — summaries are
-numeric-only so heartbeat_core.compare_summary stays generic (phase-02 §Bước 3). Every
-subprocess catch includes ``OSError``: a dead/non-executable resolved bin path becomes a
-task "error" naming the bin, never a traceback (Opus P2 finding #4).
+"""Task runners + lock helpers for ``design-os heartbeat`` (<200-line rule: rendering lives
+in heartbeat_render.py, the harvest/reflect runners in heartbeat_runners_learning.py —
+phase-05 Decision 1). Each runner takes ``(project_dir, params)`` and returns
+``{"status": "ok"|"error"|"skipped", "summary": {…numeric…}, "detail": str, "skipReason"?}``
+— numeric-only summaries keep heartbeat_core.compare_summary generic. Every subprocess catch
+includes ``OSError`` (dead bin → task "error", never a traceback).
 """
 
 from __future__ import annotations
@@ -20,14 +18,14 @@ from pathlib import Path
 from typing import Any
 
 from design_os.commands.audit import build_audit
+from design_os.commands.heartbeat_runners_learning import _run_harvest, _run_reflect
 from design_os.kernel import KernelNotFound
 
 _SUBPROCESS_TIMEOUT = 120.0
 _FIGMA_PROBE_TIMEOUT = 10.0
 _FIGMA_AUDIT_TIMEOUT = 300.0
 _FIGMA_RETRY_BACKOFFS = (1.0, 2.0)  # phase-02 §Bước 3: figma-audit ONLY, max 2 retries
-# Deliberately excludes `unused`/`misfiled` (day-to-day noise per phase-02 §Bước 3) and
-# `total`/`deadVariants`/`redundantFamilies` (not in the spec's tracked-metric list).
+# Excludes `unused`/`misfiled` (day-to-day noise) and `total`/`deadVariants`/`redundantFamilies`.
 _FIGMA_SUMMARY_KEYS = ("junk", "deprecated", "duplicateName", "duplicateStructure", "emptySets", "tokenViolations")
 
 
@@ -39,10 +37,9 @@ def _parse_one_json(stdout: str) -> Any:
 
 
 def _resolve_bin(name: str, env_var: str) -> str | None:
-    """Resolve a hand binary THROUGH the command module's namespace: tests monkeypatch
-    ``commands.heartbeat.resolve_bin`` (the documented seam) to simulate a missing hand, so
-    runners read it late via that module instead of capturing ``kernel.resolve_bin`` at
-    import time. The deferred import cannot cycle (heartbeat imports this module at load)."""
+    """Resolve a hand binary THROUGH the command module's namespace (tests monkeypatch
+    ``commands.heartbeat.resolve_bin`` to simulate a missing hand); deferred import avoids
+    a cycle (heartbeat imports this module at load)."""
     from design_os.commands import heartbeat as heartbeat_cmd
     return heartbeat_cmd.resolve_bin(name, env_var)
 
@@ -50,15 +47,16 @@ def _resolve_bin(name: str, env_var: str) -> str | None:
 # ─── task runners ──────────────────────────────────────────────────────────────
 
 
-def _run_ui_json(argv_tail: list[str], label: str, data_key: str, summary_key: str) -> dict[str, Any]:
-    """Shared `ui … --json` runner for the two kernel-backed task types: resolve the bin,
-    run one subprocess, parse ONE envelope, count ``data[data_key]`` into ``{summary_key: n}``."""
+def _run_ui_json(argv_tail: list[str], label: str, data_key: str, summary_key: str, *, cwd: str) -> dict[str, Any]:
+    """Shared `ui … --json` runner: resolve the bin, run one subprocess in `cwd` (the
+    project dir, never this process's own — Key Insight 5), count `data[data_key]`
+    into `{summary_key: n}`."""
     ui_bin = _resolve_bin("ui", "DESIGN_OS_UI_BIN")
     if ui_bin is None:
         return {"status": "error", "summary": {}, "detail": "the `ui` kernel binary was not found"}
     try:
         proc = subprocess.run(  # noqa: S603
-            [ui_bin, *argv_tail], capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT
+            [ui_bin, *argv_tail], capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT, cwd=cwd
         )
     except subprocess.TimeoutExpired:
         return {"status": "error", "summary": {}, "detail": f"`{label}` exceeded {_SUBPROCESS_TIMEOUT:.0f}s"}
@@ -72,21 +70,22 @@ def _run_ui_json(argv_tail: list[str], label: str, data_key: str, summary_key: s
 
 
 def _run_ds_a11y(project_dir: Path, params: dict[str, Any]) -> dict[str, Any]:
-    return _run_ui_json(["ds", "a11y", "--dir", str(project_dir), "--json"], "ui ds a11y", "failures", "failures")
-
+    return _run_ui_json(["ds", "a11y", "--dir", str(project_dir), "--json"], "ui ds a11y", "failures", "failures", cwd=str(project_dir))
 
 def _run_specimen(project_dir: Path, params: dict[str, Any]) -> dict[str, Any]:
-    return _run_ui_json(["ds", "specimen", "--dir", str(project_dir), "--strict", "--json"], "ui ds specimen", "findings", "gaps")
+    return _run_ui_json(["ds", "specimen", "--dir", str(project_dir), "--strict", "--json"], "ui ds specimen", "findings", "gaps", cwd=str(project_dir))
 
 
 def _run_audit_pages(project_dir: Path, params: dict[str, Any]) -> dict[str, Any]:
-    """Static page audit via a direct :func:`build_audit` import (no subprocess).
+    """Static page audit via a direct :func:`build_audit` import (no subprocess). Point
+    ``params.dir`` at a page dir (e.g. ``design/preview``), not project root (double-count
+    with ds-a11y/specimen, Opus P2 #2); missing dir → skip ``pages-dir-missing`` (no-silent-
+    caps, Opus P2 #3).
 
-    Point ``params.dir`` at a page directory (e.g. ``design/preview``), not the project
-    root — a project-root target re-runs the DS/flow sections the separate ds-a11y/specimen
-    tasks already cover (double-count; hardening deferred to P3, Opus P2 finding #2).
-    A missing dir skips with reason ``pages-dir-missing`` instead of reporting a
-    silently-green empty audit (no-silent-caps, Opus P2 finding #3).
+    `build_audit`'s inner `run_ui` calls have no `cwd` param and inherit THIS process's cwd;
+    its linters resolve `lint_run`'s project from a (possibly relative) file path, so the
+    wrong cwd would record into design-os's own cwd (Key Insight 5) — chdir into
+    `project_dir` for the call, restore in `finally`.
     """
     raw_dir = params.get("dir") if isinstance(params, dict) else None
     target = Path(raw_dir) if raw_dir else project_dir
@@ -94,18 +93,21 @@ def _run_audit_pages(project_dir: Path, params: dict[str, Any]) -> dict[str, Any
         target = project_dir / target
     if not target.exists():
         return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "pages-dir-missing"}
+    prev_cwd = os.getcwd()
     try:
+        os.chdir(project_dir)
         _sections, summary, _exit_code, _n_files = build_audit(target, None)
     except KernelNotFound as e:
         return {"status": "error", "summary": {}, "detail": f"`audit {target}`: {e}"}
+    except OSError as e:
+        return {"status": "error", "summary": {}, "detail": f"could not chdir into '{project_dir}': {e}"}
+    finally:
+        os.chdir(prev_cwd)
     return {"status": "ok", "summary": {"errors": summary["errors"], "warnings": summary["warnings"]}, "detail": ""}
 
 
 def _run_figma_audit(
-    project_dir: Path,
-    params: dict[str, Any],
-    *,
-    sleep: Callable[[float], None] = time.sleep,
+    project_dir: Path, params: dict[str, Any], *, sleep: Callable[[float], None] = time.sleep
 ) -> dict[str, Any]:
     bin_ = _resolve_bin("figma-agent", "DESIGN_OS_FIGMA_AGENT_BIN")
     if bin_ is None:
@@ -116,7 +118,7 @@ def _run_figma_audit(
         env["FIGMA_AGENT_FILE"] = str(file_param)
     try:
         probe = subprocess.run(  # noqa: S603
-            [bin_, "status"], capture_output=True, text=True, timeout=_FIGMA_PROBE_TIMEOUT, env=env
+            [bin_, "status"], capture_output=True, text=True, timeout=_FIGMA_PROBE_TIMEOUT, env=env, cwd=str(project_dir)
         )
     except subprocess.TimeoutExpired:
         return {"status": "error", "summary": {}, "detail": "`figma-agent status` exceeded 10s"}
@@ -132,7 +134,7 @@ def _run_figma_audit(
             sleep(backoff)
         try:
             proc = subprocess.run(  # noqa: S603
-                [bin_, "audit-ds"], capture_output=True, text=True, timeout=_FIGMA_AUDIT_TIMEOUT, env=env
+                [bin_, "audit-ds"], capture_output=True, text=True, timeout=_FIGMA_AUDIT_TIMEOUT, env=env, cwd=str(project_dir)
             )
         except subprocess.TimeoutExpired:
             detail = "`figma-agent audit-ds` exceeded 300s"
@@ -162,20 +164,18 @@ TaskRunner = Callable[[Path, dict[str, Any]], dict[str, Any]]
 # Dispatch table — tests monkeypatch entries via `monkeypatch.setitem(TASK_RUNNERS, "id", stub)`;
 # commands/heartbeat.py re-imports THIS dict object, so `heartbeat_cmd.TASK_RUNNERS` patches land.
 TASK_RUNNERS: dict[str, TaskRunner] = {
-    "ds-a11y": _run_ds_a11y,
-    "specimen": _run_specimen,
-    "audit-pages": _run_audit_pages,
-    "figma-audit": _run_figma_audit,
+    "ds-a11y": _run_ds_a11y, "specimen": _run_specimen,
+    "audit-pages": _run_audit_pages, "figma-audit": _run_figma_audit,
+    "harvest": _run_harvest, "reflect": _run_reflect,
 }
 
 # ─── lock ──────────────────────────────────────────────────────────────────────
-
 _LOCK_STALE_SECONDS = 600  # 10 minutes
 
 
 def acquire_lock(lock_path: Path, now: datetime) -> bool:
-    """True → lock acquired (absent, or stale >10min and overwritten) — caller MUST release
-    it in a `finally`. False → held by a live run; caller must skip everything, exit 0."""
+    """True → lock acquired (absent, or stale >10min, overwritten) — caller MUST release it
+    in a `finally`. False → held by a live run; caller skips everything, exit 0."""
     if lock_path.exists():
         stale = True
         try:

--- a/design-os/src/design_os/commands/heartbeat_runners_learning.py
+++ b/design-os/src/design_os/commands/heartbeat_runners_learning.py
@@ -1,0 +1,199 @@
+"""The two learning-loop heartbeat runners — `harvest` and `reflect` (spec 006 P5 Decision
+1). Split out of `heartbeat_runners.py`, already at its 200-line cap, so both stay under it.
+
+Same runner contract: ``(project_dir, params) -> {"status": "ok"|"error"|"skipped",
+"summary": {…numeric…}, "detail": str, "skipReason"?}``, never raises. Decision 2 (the
+anti-regression trap, Key Insight 1): ``summary`` carries ONLY ``failures`` — a harvest/
+reflect that found or recorded MORE must never look like "worsened" to
+`heartbeat_core.compare_summary`. Decision 4's degrade table (skip reason → condition): no-
+project → no `design/`; no-new-reports (harvest) / no-new-events (reflect, < `minEvents`);
+recall-missing (reflect, no `recall` bin); no-model-adapter (no `DESIGN_OS_MODEL_CMD`); a
+model call that fails/times out is the one exception — `status: "error"`, `failures: 1`,
+the notify-worthy case.
+
+Decision 3: both import `harvest_core`/`harvest_model`/`reflect_core` directly and pass
+`project_dir` explicitly — no cwd dependence (Key Insight 5).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from design_os import harvest_core, reflect_core
+from design_os.commands.harvest import _PROMPT_PATH, _RecordError, _run_record, _write_inbox
+from design_os.harvest_model import ModelUnavailable, extract, resolve_model_cmd
+from design_os.kernel import KernelNotFound, run_ui
+
+_RECALL_TIMEOUT = 60.0
+_DEFAULT_MIN_EVENTS = 5
+_JOB_EVENTS_REL = Path("design") / ".reflect-job-events.json"
+
+
+def _resolve_bin(name: str, env_var: str) -> str | None:
+    """Mirrors `heartbeat_runners._resolve_bin` (duplicated, not imported, to avoid a cycle:
+    `heartbeat_runners` imports this module's runners)."""
+    from design_os.commands import heartbeat as heartbeat_cmd
+    return heartbeat_cmd.resolve_bin(name, env_var)
+
+
+def _parse_one_json(stdout: str) -> Any:
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _no_project(project_dir: Path) -> dict[str, Any] | None:
+    if (project_dir / "design").is_dir():
+        return None
+    return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-project"}
+
+
+# ─── harvest ─────────────────────────────────────────────────────────────────────
+
+
+def _run_harvest(project_dir: Path, params: dict[str, Any]) -> dict[str, Any]:
+    """Harvest new end-of-phase reports into memory candidates (spec 006 P5)."""
+    skip = _no_project(project_dir)
+    if skip is not None:
+        return skip
+
+    raw_globs = params.get("glob") if isinstance(params, dict) else None
+    globs = raw_globs if isinstance(raw_globs, list) and raw_globs else list(harvest_core.DEFAULT_GLOBS)
+    reports = harvest_core.discover_reports(project_dir, globs)
+    state = harvest_core.load_state(project_dir)
+    to_harvest, _deferred = harvest_core.pending(reports, state, force=False)
+    if not to_harvest:
+        return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-new-reports"}
+
+    packet = harvest_core.build_packet(_PROMPT_PATH.read_text(encoding="utf-8"), to_harvest)
+    cmd = resolve_model_cmd()
+    if cmd is None:
+        _write_inbox(project_dir, packet, to_harvest)
+        return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-model-adapter"}
+
+    try:
+        raw = extract(packet, cmd=cmd)
+    except ModelUnavailable as e:
+        _write_inbox(project_dir, packet, to_harvest)
+        return {"status": "error", "summary": {"failures": 1}, "detail": f"harvest: model call failed: {e}"}
+
+    try:
+        candidates = harvest_core.parse_candidates(raw)
+    except harvest_core.HarvestError as e:
+        # A bad TURN (malformed model output), not a bad RUN — mirrors harvest.py: never
+        # pages the owner over one flaky turn.
+        _write_inbox(project_dir, packet, to_harvest)
+        return {"status": "skipped", "summary": {}, "detail": str(e), "skipReason": "bad-candidates"}
+
+    survivors, dropped = harvest_core.gate(candidates, to_harvest)
+    by_source: dict[str, list[harvest_core.Candidate]] = {}
+    for c in survivors:
+        by_source.setdefault(c.source, []).append(c)
+    already_recorded = harvest_core.ledger_candidate_keys(project_dir)
+    recorded = {"insight": 0, "gap": 0}
+    try:
+        for report in to_harvest:
+            report_cands = by_source.get(report.rel, [])
+            harvested_data = {"source": report.rel, "what": f"{len(report_cands)} candidates",
+                               "promptVersion": harvest_core.PROMPT_VERSION, "sha256": report.sha256}
+            hid = _run_record(project_dir, "harvested", harvested_data)
+            for c in report_cands:
+                key = harvest_core.candidate_key(c.kind, c.text, c.source)
+                if key in already_recorded:
+                    continue
+                payload: dict[str, Any] = {"text": c.text, "evidence": c.evidence, "harvestKey": key}
+                if c.kind == "gap":
+                    payload["target"] = c.target
+                    payload["kind"] = c.gap_kind
+                _run_record(project_dir, c.kind, payload, refs=[hid])
+                recorded[c.kind] += 1
+                already_recorded.add(key)
+            state.setdefault("harvested", {})[report.rel] = {"sha256": report.sha256, "recorded": len(report_cands)}
+            harvest_core.save_state(project_dir, state)
+    except (KernelNotFound, _RecordError) as e:
+        return {"status": "error", "summary": {"failures": 1}, "detail": f"harvest: record failed: {e}"}
+
+    n_recorded = recorded["insight"] + recorded["gap"]
+    n_dropped = sum(dropped.values())
+    detail = f"harvest: {len(to_harvest)} report(s) → {n_recorded} recorded, {n_dropped} dropped"
+    return {"status": "ok", "summary": {"failures": 0}, "detail": detail}
+
+
+# ─── reflect ─────────────────────────────────────────────────────────────────────
+
+
+def _run_reflect(project_dir: Path, params: dict[str, Any]) -> dict[str, Any]:
+    """Reflect over accumulated ledger events into one durable insight (spec 006 P5
+    Decision 5) — job events ride the `memory export-corpus --since` cursor; the host
+    model distils the lesson (`recall` never calls an LLM)."""
+    skip = _no_project(project_dir)
+    if skip is not None:
+        return skip
+
+    raw_min = params.get("minEvents") if isinstance(params, dict) else None
+    min_events = raw_min if isinstance(raw_min, int) and raw_min > 0 else _DEFAULT_MIN_EVENTS
+    state = reflect_core.load_state(project_dir)
+    cursor = state.get("lastEventId")
+    argv = ["memory", "export-corpus", "--json", "--dir", str(project_dir)]
+    if isinstance(cursor, str):
+        argv += ["--since", cursor]
+    try:
+        result = run_ui(argv)
+    except KernelNotFound as e:
+        return {"status": "error", "summary": {"failures": 1}, "detail": f"reflect: {e}"}
+    if result.envelope is None or not result.envelope.get("ok"):
+        return {"status": "error", "summary": {"failures": 1}, "detail": "reflect: export-corpus printed no valid envelope"}
+    items = (result.envelope.get("data") or {}).get("items")
+    items = items if isinstance(items, list) else []
+    job_ids = reflect_core.select_job_events(items, cursor if isinstance(cursor, str) else None)
+    if not reflect_core.has_enough_events(job_ids, min_events):
+        return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-new-events"}
+
+    recall_bin = _resolve_bin("recall", "DESIGN_OS_RECALL_BIN")
+    if recall_bin is None:
+        return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "recall-missing"}
+
+    job_events_path = project_dir / _JOB_EVENTS_REL
+    job_events_path.parent.mkdir(parents=True, exist_ok=True)
+    job_events_path.write_text(json.dumps(job_ids), encoding="utf-8")
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [recall_bin, "reflect", str(job_events_path), "--project", str(project_dir), "--json"],
+            capture_output=True, text=True, timeout=_RECALL_TIMEOUT, cwd=str(project_dir),
+        )
+    except subprocess.TimeoutExpired:
+        return {"status": "error", "summary": {"failures": 1}, "detail": "reflect: `recall reflect` exceeded 60s"}
+    except OSError as e:
+        return {"status": "error", "summary": {"failures": 1}, "detail": f"reflect: `{recall_bin}` could not be executed: {e}"}
+    finally:
+        job_events_path.unlink(missing_ok=True)
+
+    packet = _parse_one_json(proc.stdout)
+    if not isinstance(packet, dict) or "instruction" not in packet:
+        return {"status": "error", "summary": {"failures": 1}, "detail": "reflect: `recall reflect` printed no valid packet"}
+    prompt = reflect_core.build_reflect_prompt(packet)
+    cmd = resolve_model_cmd()
+    if cmd is None:
+        return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-model-adapter"}
+
+    try:
+        raw = extract(prompt, cmd=cmd)
+    except ModelUnavailable as e:
+        return {"status": "error", "summary": {"failures": 1}, "detail": f"reflect: model call failed: {e}"}
+
+    lesson = raw.strip()
+    accepted, reason = reflect_core.gate_lesson(lesson, reflect_core.latest_insight_text(project_dir))
+    if not accepted:
+        return {"status": "ok", "summary": {"failures": 0}, "detail": f"reflect: lesson dropped ({reason})"}
+
+    try:
+        _run_record(project_dir, "insight", {"text": lesson}, refs=job_ids)
+    except (KernelNotFound, _RecordError) as e:
+        return {"status": "error", "summary": {"failures": 1}, "detail": f"reflect: record failed: {e}"}
+
+    reflect_core.save_state(project_dir, reflect_core.advance_cursor(state, job_ids))
+    return {"status": "ok", "summary": {"failures": 0}, "detail": f"reflect: recorded 1 insight from {len(job_ids)} event(s)"}

--- a/design-os/src/design_os/reflect_core.py
+++ b/design-os/src/design_os/reflect_core.py
@@ -1,0 +1,151 @@
+"""Pure decision core for `design-os heartbeat`'s `reflect` task (spec 006 P5 Decision 5):
+the export-corpus cursor, job-event selection, the echo-guard baseline, and the one-lesson
+gate. No subprocess, no model call, no wall-clock read — the runner
+(commands/heartbeat_runners_learning.py) owns the `ui`/`recall` shell-outs and calls these
+in order: select → gate → record (its own job) → :func:`advance_cursor` LAST, only once the
+record has actually landed (Decision 5 step 6).
+
+`recall reflect` itself has no kernel seam of its own to source job events from, so the
+cursor rides `memory export-corpus --since` (Decision 5) — the same content-addressed-id
+style as harvest_core's sha256 cursor, just keyed on the ledger's own monotonic event ids
+instead.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+MIN_LESSON, MAX_LESSON = 40, 500
+
+_STATE_REL = Path("design") / "reflect-state.json"
+_LEDGER_REL = Path("design") / "memory.events.jsonl"
+_EVENT_ID_RE = re.compile(r"^e(\d+)$")
+
+
+def _event_id_number(id_: str) -> int | None:
+    """`"e12"` → `12`; `None` for anything not a well-formed monotonic ledger id."""
+    m = _EVENT_ID_RE.match(id_)
+    return int(m.group(1)) if m else None
+
+
+def load_state(project_dir: Path) -> dict[str, Any]:
+    """Read `design/reflect-state.json`; a missing/corrupt file reads as a fresh cursor
+    (`lastEventId: None` — nothing harvested yet)."""
+    default: dict[str, Any] = {"version": 1, "lastEventId": None}
+    path = project_dir / _STATE_REL
+    try:
+        data = json.loads(path.read_text()) if path.is_file() else None
+    except json.JSONDecodeError:
+        data = None
+    if not isinstance(data, dict):
+        return default
+    data.setdefault("version", 1)
+    data.setdefault("lastEventId", None)
+    return data
+
+
+def save_state(project_dir: Path, state: dict[str, Any]) -> None:
+    """Write the cursor: sorted keys, 2-space indent, trailing newline — byte-stable."""
+    path = project_dir / _STATE_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def select_job_events(corpus_items: Sequence[dict[str, Any]], cursor: str | None) -> list[str]:
+    """The ids (in the corpus's own order) whose event-id number is strictly greater than
+    `cursor`'s. Mirrors `memory-corpus.ts`'s `exportCorpus` `sinceId` cut — defense-in-depth
+    against a caller that forgot `--since` on the `export-corpus` shell-out, since the
+    runner is expected to pass it (Decision 5 step 1)."""
+    floor = (_event_id_number(cursor) or 0) if cursor else 0
+    ids: list[str] = []
+    for item in corpus_items:
+        id_ = item.get("id") if isinstance(item, dict) else None
+        if not isinstance(id_, str):
+            continue
+        n = _event_id_number(id_)
+        if n is not None and n > floor:
+            ids.append(id_)
+    return ids
+
+
+def has_enough_events(ids: Sequence[str], min_events: int) -> bool:
+    return len(ids) >= min_events
+
+
+def max_event_id(ids: Sequence[str]) -> str | None:
+    """The id with the largest event-id number — the value the cursor should advance to."""
+    numbered = [(_event_id_number(i), i) for i in ids]
+    numbered = [(n, i) for n, i in numbered if n is not None]
+    if not numbered:
+        return None
+    return max(numbered, key=lambda pair: pair[0])[1]
+
+
+def advance_cursor(state: dict[str, Any], job_ids: Sequence[str]) -> dict[str, Any]:
+    """A NEW state dict with `lastEventId` bumped to `max_event_id(job_ids)`. Pure — does
+    not persist anything. The caller MUST only call this (and then :func:`save_state`)
+    after the reflect insight has actually landed in the ledger; a run that fails between
+    recording and advancing simply re-selects the same job events next time, which is safe
+    (the echo guard + the model itself decide whether that yields the same lesson again)."""
+    new_last = max_event_id(job_ids)
+    if new_last is None:
+        return dict(state)
+    return {**state, "lastEventId": new_last}
+
+
+def latest_insight_text(project_dir: Path) -> str | None:
+    """The `data.text` of the most recent `insight` event in the project's ledger, or
+    `None` if there isn't one yet — the echo-guard baseline (Decision 5 step 5)."""
+    path = project_dir / _LEDGER_REL
+    if not path.is_file():
+        return None
+    latest: str | None = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("type") != "insight":
+            continue
+        data = event.get("data")
+        text = data.get("text") if isinstance(data, dict) else None
+        if isinstance(text, str):
+            latest = text
+    return latest
+
+
+_REFLECT_RESPONSE_RULE = (
+    "Respond with ONLY the one lesson's text — no preamble, no markdown, no write-back command."
+)
+
+
+def build_reflect_prompt(packet: dict[str, Any]) -> str:
+    """Assemble a plain-text model prompt from `recall reflect --json`'s packet: the
+    instruction, this job's events, and its semantic neighbours (Decision 5 step 4)."""
+    lines = [str(packet.get("instruction") or ""), "", "This job's events:"]
+    for item in packet.get("jobItems") or []:
+        lines.append(f"- [{item.get('id')}] ({item.get('tier')}) {item.get('text')}")
+    lines += ["", "What memory already knows that is relevant:"]
+    for n in packet.get("neighbors") or []:
+        lines.append(f"- [{n.get('id')}] ({n.get('source')}/{n.get('tier')}) {n.get('text')}")
+    lines += ["", _REFLECT_RESPONSE_RULE]
+    return "\n".join(lines) + "\n"
+
+
+def gate_lesson(text: str, latest_existing_insight: str | None) -> tuple[bool, str | None]:
+    """`(accepted, reason)` — the one-lesson gate (Decision 5 step 5): length in
+    `[MIN_LESSON, MAX_LESSON]`, and not byte-identical to the project's most recent existing
+    insight (a cheap "did the model just echo a neighbour" guard)."""
+    stripped = text.strip()
+    if not (MIN_LESSON <= len(stripped) <= MAX_LESSON):
+        return False, "lesson-length"
+    if latest_existing_insight is not None and stripped == latest_existing_insight.strip():
+        return False, "lesson-echoes-latest-insight"
+    return True, None

--- a/design-os/tests/test_command_heartbeat.py
+++ b/design-os/tests/test_command_heartbeat.py
@@ -287,3 +287,57 @@ def test_runner_raising_file_not_found_becomes_task_error(
     assert entry["status"] == "error"
     assert "ui binary vanished" in entry["detail"]
     assert not (tmp_path / "design" / ".heartbeat.lock").exists()  # released in finally
+
+
+# ── Case 11: `harvest`/`reflect` are known task types (spec 006 P5 Decision 1) — a config
+# naming them validates, while an unrelated made-up "learning-ish" type still fails. ──
+def test_harvest_is_a_known_task_type(runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_config(tmp_path, [{"id": "h", "type": "harvest", "interval": "12h"}])
+    monkeypatch.setitem(heartbeat_cmd.TASK_RUNNERS, "harvest", _stub_from({"failures": 0}))
+    _freeze(monkeypatch)
+
+    res = runner.invoke(app, ["heartbeat", "--dir", str(tmp_path), "--json"])
+
+    assert res.exit_code == 0
+    assert json.loads(res.stdout)["ok"] is True
+
+
+def test_reflect_is_a_known_task_type(runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_config(tmp_path, [{"id": "r", "type": "reflect", "interval": "24h"}])
+    monkeypatch.setitem(heartbeat_cmd.TASK_RUNNERS, "reflect", _stub_from({"failures": 0}))
+    _freeze(monkeypatch)
+
+    res = runner.invoke(app, ["heartbeat", "--dir", str(tmp_path), "--json"])
+
+    assert res.exit_code == 0
+    assert json.loads(res.stdout)["ok"] is True
+
+
+def test_an_unknown_learning_type_still_fails_bad_config(runner: CliRunner, tmp_path: Path) -> None:
+    _write_config(tmp_path, [{"id": "x", "type": "distill", "interval": "1d"}])
+
+    res = runner.invoke(app, ["heartbeat", "--dir", str(tmp_path), "--json"])
+
+    assert res.exit_code == 2
+    env = json.loads(res.stdout)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "BAD_CONFIG"
+
+
+# ── Case 12: spec AC5 in one assertion — `harvest` fires on the heartbeat with NO human
+# trigger (no `--force`, no `--task`, just a fresh due task), and its run is recorded. ──
+def test_harvest_task_runs_on_the_heartbeat_with_no_human_trigger(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(tmp_path, [{"id": "h", "type": "harvest", "interval": "12h"}])
+    monkeypatch.setitem(heartbeat_cmd.TASK_RUNNERS, "harvest", _stub_from({"failures": 0}))
+    _freeze(monkeypatch)
+
+    res = runner.invoke(app, ["heartbeat", "--dir", str(tmp_path), "--json"])
+
+    assert res.exit_code == 0
+    data = json.loads(res.stdout)["data"]
+    assert data["checked"] == 1
+    assert data["tasks"][0]["status"] == "baseline"
+    state = json.loads((tmp_path / "design" / "heartbeat-state.json").read_text())
+    assert state["tasks"]["h"]["nextRunAt"]

--- a/design-os/tests/test_heartbeat_runner_harvest.py
+++ b/design-os/tests/test_heartbeat_runner_harvest.py
@@ -1,0 +1,189 @@
+"""`heartbeat_runners_learning._run_harvest` — the heartbeat runner contract (spec 006 P5):
+never raises, `summary` carries ONLY `failures` (Key Insight 1 — a bigger harvest must never
+render as "worsened"), and every write lands in the PROJECT's ledger regardless of this
+process's own cwd (Key Insight 5). `_run_reflect` behavior is covered by `reflect_core`'s
+own pure-function tests plus this module's ledger-write path; this file focuses on harvest
+since it is the runner exercised end-to-end against a fake `ui` + fake model.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from design_os import heartbeat_core
+from design_os.commands.heartbeat_runners_learning import _run_harvest
+
+_REPORT_TEXT = (
+    "# Report\n\nRan the checks, all green.\n\n"
+    "Finding: widgets misalign under RTL layouts because negative padding does not "
+    "mirror, a durable cross-project lesson worth remembering for every future RTL "
+    "audit pass.\n"
+)
+_EVIDENCE = "widgets misalign under RTL layouts because negative padding does not mirror"
+_INSIGHT_TEXT = (
+    "Widgets misalign under RTL layouts because negative padding never mirrors "
+    "automatically, so RTL audits must check padding direction explicitly."
+)
+
+# Shell builtins only — `fake_bin` isolates PATH, so `memory record` is the only call this
+# stub needs to answer (mirrors tests/test_command_harvest.py's `_UI_STUB`).
+_UI_STUB = """\
+if [ "$1" = "memory" ] && [ "$2" = "record" ]; then
+  echo "$@" >> "$UI_LOG"
+  n=0
+  [ -f "$UI_COUNTER" ] && read -r n < "$UI_COUNTER"
+  n=$((n + 1))
+  printf '%s' "$n" > "$UI_COUNTER"
+  echo "{\\"ok\\": true, \\"command\\": \\"memory record\\", \\"data\\": {\\"id\\": \\"e$n\\", \\"eventCount\\": $n}}"
+  exit 0
+fi
+echo '{"ok": true, "command": "stub", "data": {"stub": true}}'
+exit 0
+"""
+
+
+def _project(tmp_path: Path, *, with_report: bool = True, report_name: str = "r.md", text: str = _REPORT_TEXT) -> Path:
+    project = tmp_path / "project"
+    (project / "design").mkdir(parents=True, exist_ok=True)
+    if with_report:
+        reports = project / "plans" / "p" / "reports"
+        reports.mkdir(parents=True, exist_ok=True)
+        (reports / report_name).write_text(text)
+    return project
+
+
+def _install_ui(fake_bin: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("UI_LOG", str(tmp_path / "ui.log"))
+    monkeypatch.setenv("UI_COUNTER", str(tmp_path / "ui.counter"))
+    fake_bin.make_stub("ui", _UI_STUB)
+
+
+def _install_model(fake_bin: Any, monkeypatch: pytest.MonkeyPatch, candidates: list[dict[str, Any]]) -> None:
+    payload = json.dumps({"v": 1, "candidates": candidates})
+    fake_bin.make_stub("modelcmd", f"echo '{payload}'\n")
+    monkeypatch.setenv("DESIGN_OS_MODEL_CMD", "modelcmd")
+
+
+def _insight_candidate(*, source: str = "plans/p/reports/r.md", text: str = _INSIGHT_TEXT, evidence: str = _EVIDENCE) -> dict[str, Any]:
+    return {"kind": "insight", "text": text, "evidence": evidence, "source": source,
+            "durable": True, "actionable": True, "confidence": 0.9}
+
+
+def test_missing_design_dir_skips_with_no_project(tmp_path: Path) -> None:
+    project = tmp_path / "no-design-here"
+    project.mkdir()
+
+    res = _run_harvest(project, {})
+
+    assert res == {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-project"}
+
+
+def test_runner_never_raises_when_the_project_dir_does_not_exist(tmp_path: Path) -> None:
+    res = _run_harvest(tmp_path / "does" / "not" / "exist", {})
+
+    assert res["status"] == "skipped"
+    assert res["skipReason"] == "no-project"
+
+
+def test_no_new_reports_skips_with_no_new_reports(tmp_path: Path) -> None:
+    project = _project(tmp_path, with_report=False)
+
+    res = _run_harvest(project, {})
+
+    assert res == {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-new-reports"}
+
+
+def test_no_model_adapter_skips_with_no_model_adapter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    project = _project(tmp_path)
+    monkeypatch.delenv("DESIGN_OS_MODEL_CMD", raising=False)
+
+    res = _run_harvest(project, {})
+
+    assert res["status"] == "skipped"
+    assert res["skipReason"] == "no-model-adapter"
+    assert list((project / "design" / "harvest-inbox").glob("*.md"))  # packet saved
+
+
+def test_a_model_failure_reports_error_and_one_failure(
+    tmp_path: Path, fake_bin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _project(tmp_path)
+    fake_bin.make_stub("modelcmd", "echo 'boom' 1>&2\nexit 1\n")
+    monkeypatch.setenv("DESIGN_OS_MODEL_CMD", "modelcmd")
+
+    res = _run_harvest(project, {})
+
+    assert res["status"] == "error"
+    assert res["summary"] == {"failures": 1}
+
+
+def test_harvest_runner_summary_carries_only_failures(
+    tmp_path: Path, fake_bin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _project(tmp_path)
+    _install_ui(fake_bin, monkeypatch, tmp_path)
+    _install_model(fake_bin, monkeypatch, [_insight_candidate()])
+
+    res = _run_harvest(project, {})
+
+    assert res["status"] == "ok"
+    assert set(res["summary"]) == {"failures"}
+    assert res["summary"]["failures"] == 0
+
+
+def test_a_bigger_harvest_is_not_reported_as_worsened(
+    tmp_path: Path, fake_bin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pins Key Insight 1: a harvest that recorded MORE candidates must never drive
+    `compare_summary` to "worsened" — the exact anti-regression trap the summary-only-
+    carries-`failures` contract (Decision 2) exists to prevent."""
+    project = _project(tmp_path, report_name="r1.md")
+    _install_ui(fake_bin, monkeypatch, tmp_path)
+    _install_model(fake_bin, monkeypatch, [_insight_candidate(source="plans/p/reports/r1.md")])
+
+    first = _run_harvest(project, {})
+    assert first["status"] == "ok"
+
+    # A second, bigger report lands — more candidates recorded this run than last.
+    (project / "plans" / "p" / "reports" / "r2.md").write_text(_REPORT_TEXT.replace("mirror,", "mirror twice,"))
+    _install_model(fake_bin, monkeypatch, [
+        _insight_candidate(source="plans/p/reports/r2.md"),
+        _insight_candidate(source="plans/p/reports/r2.md", text=_INSIGHT_TEXT.replace("explicitly.", "explicitly, always.")),
+    ])
+    second = _run_harvest(project, {})
+    assert second["status"] == "ok"
+
+    assert heartbeat_core.compare_summary(first["summary"], second["summary"]) == "ok"
+
+
+def test_harvest_runner_passes_the_project_dir_and_never_relies_on_cwd(
+    tmp_path: Path, fake_bin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _project(tmp_path)
+    log = tmp_path / "ui.log"
+    _install_ui(fake_bin, monkeypatch, tmp_path)
+    _install_model(fake_bin, monkeypatch, [_insight_candidate()])
+    other_cwd = tmp_path / "elsewhere"
+    other_cwd.mkdir()
+    prev = os.getcwd()
+    try:
+        os.chdir(other_cwd)
+        res = _run_harvest(project, {})
+    finally:
+        os.chdir(prev)
+
+    assert res["status"] == "ok"
+    # harvest_core.save_state is a direct Python write, keyed on project_dir explicitly —
+    # it landing under `project/design/`, never `other_cwd/design/`, pins Decision 3.
+    assert (project / "design" / "harvest-state.json").is_file()
+    assert not (other_cwd / "design").exists()
+    # Every `ui memory record` shell-out named `project` explicitly via `--dir`, regardless
+    # of this process's cwd (Key Insight 5) — the fake `ui`'s logged argv proves it.
+    log_text = log.read_text()
+    assert f"--dir {project}" in log_text
+    assert str(other_cwd) not in log_text

--- a/design-os/tests/test_reflect_core.py
+++ b/design-os/tests/test_reflect_core.py
@@ -1,0 +1,117 @@
+"""`reflect_core` — pure, no model, no subprocess (spec 006 P5 Decision 5)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from design_os import reflect_core
+
+_OK_LESSON = "x" * 60  # clears MIN_LESSON (40), clears MAX_LESSON (500)
+
+
+def _write_ledger(project: Path, events: list[dict[str, object]]) -> None:
+    (project / "design").mkdir(parents=True, exist_ok=True)
+    path = project / "design" / "memory.events.jsonl"
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+# ─── job-event selection ────────────────────────────────────────────────────────────
+
+def test_job_events_are_the_ids_since_the_cursor() -> None:
+    corpus = [{"id": "e1"}, {"id": "e2"}, {"id": "e3"}, {"id": "e4"}]
+
+    ids = reflect_core.select_job_events(corpus, cursor="e2")
+
+    assert ids == ["e3", "e4"]
+
+
+def test_job_events_with_no_cursor_returns_every_id() -> None:
+    corpus = [{"id": "e1"}, {"id": "e2"}]
+
+    ids = reflect_core.select_job_events(corpus, cursor=None)
+
+    assert ids == ["e1", "e2"]
+
+
+def test_fewer_than_min_events_yields_no_job() -> None:
+    ids = ["e1", "e2", "e3"]
+
+    assert reflect_core.has_enough_events(ids, min_events=5) is False
+    assert reflect_core.has_enough_events(ids + ["e4", "e5"], min_events=5) is True
+
+
+# ─── cursor advancement ─────────────────────────────────────────────────────────────
+
+def test_cursor_advances_only_after_the_insight_is_recorded(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / "design").mkdir()
+
+    state = reflect_core.load_state(project)
+    assert state["lastEventId"] is None
+
+    job_ids = reflect_core.select_job_events([{"id": "e1"}, {"id": "e2"}, {"id": "e3"}], state["lastEventId"])
+    reflect_core.gate_lesson(_OK_LESSON, None)  # selecting/gating alone must not touch state
+
+    assert reflect_core.load_state(project)["lastEventId"] is None
+
+    # Simulate: the runner recorded the insight, and only THEN advances + persists the cursor.
+    new_state = reflect_core.advance_cursor(state, job_ids)
+    reflect_core.save_state(project, new_state)
+
+    assert reflect_core.load_state(project)["lastEventId"] == "e3"
+
+
+def test_max_event_id_ignores_malformed_ids() -> None:
+    assert reflect_core.max_event_id(["e1", "not-an-id", "e10", "e2"]) == "e10"
+    assert reflect_core.max_event_id([]) is None
+
+
+# ─── the one-lesson gate ────────────────────────────────────────────────────────────
+
+def test_a_lesson_shorter_than_40_chars_is_dropped() -> None:
+    accepted, reason = reflect_core.gate_lesson("too short", None)
+
+    assert accepted is False
+    assert reason == "lesson-length"
+
+
+def test_a_lesson_longer_than_500_chars_is_dropped() -> None:
+    accepted, reason = reflect_core.gate_lesson("x" * 501, None)
+
+    assert accepted is False
+    assert reason == "lesson-length"
+
+
+def test_a_lesson_identical_to_the_latest_existing_insight_is_dropped() -> None:
+    accepted, reason = reflect_core.gate_lesson(_OK_LESSON, latest_existing_insight=_OK_LESSON)
+
+    assert accepted is False
+    assert reason == "lesson-echoes-latest-insight"
+
+
+def test_a_lesson_that_differs_from_the_latest_insight_is_accepted() -> None:
+    accepted, reason = reflect_core.gate_lesson(_OK_LESSON, latest_existing_insight="y" * 60)
+
+    assert accepted is True
+    assert reason is None
+
+
+def test_latest_insight_text_reads_the_most_recent_insight_event(tmp_path: Path) -> None:
+    _write_ledger(tmp_path, [
+        {"id": "e1", "type": "insight", "data": {"text": "first lesson"}},
+        {"id": "e2", "type": "lint_run", "data": {"check": "a11y-lint"}},
+        {"id": "e3", "type": "insight", "data": {"text": "latest lesson"}},
+    ])
+
+    assert reflect_core.latest_insight_text(tmp_path) == "latest lesson"
+
+
+def test_latest_insight_text_is_none_when_the_ledger_has_no_insight(tmp_path: Path) -> None:
+    _write_ledger(tmp_path, [{"id": "e1", "type": "lint_run", "data": {"check": "a11y-lint"}}])
+
+    assert reflect_core.latest_insight_text(tmp_path) is None
+
+
+def test_latest_insight_text_is_none_when_the_ledger_is_missing(tmp_path: Path) -> None:
+    assert reflect_core.latest_insight_text(tmp_path) is None

--- a/specs/006-living-loop/reports/p5-real-data-gate.md
+++ b/specs/006-living-loop/reports/p5-real-data-gate.md
@@ -1,0 +1,112 @@
+# P5 real-data gate — procedure + status
+
+**Status: NOT YET RUN.** Part B of phase-05 is owner-in-the-loop (Art III): the executor
+(Sonnet) implemented the `harvest`/`reflect` runners + tests (Part A, done — see the P5
+report in the session that produced this file) but did not execute a live harvest against
+either project below, since that requires `DESIGN_OS_MODEL_CMD` pointed at a real model and
+is explicitly reserved for the owner/Fable. This file is the exact procedure to run — fill
+in the tables as each step executes.
+
+## Resolved project paths
+
+`~/.ease-design/projects.json` (`loadRegistry`) currently lists only `brand`
+(`/Users/jang/Products/ease-design/brand`) — **VSF-PCP and platform-design-system are not
+registered**. Both exist on this machine with a `design/` directory (filesystem-confirmed,
+not registry-confirmed):
+
+| project | path |
+|---|---|
+| VSF-PCP | `/Users/jang/Products/VSF-PCP` |
+| platform-design-system | `/Users/jang/Products/platform-design-system` |
+
+Owner: confirm these are the correct, current paths before running the gate (they were
+located by directory name under `~/Products`, not pulled from the registry — per the phase's
+"do not guess a path" constraint, treat this as a filesystem finding to confirm, not a
+registry fact). No manual registration step is needed: `upsertRegistry` (memory-store.ts)
+writes `~/.ease-design/projects.json` as a side effect of the FIRST `ui memory record` call
+against a project — harvest's or reflect's first successful run on each project will add it.
+
+## Procedure (run once per project — `<p>` = the resolved path above)
+
+### 1. Baseline (record exact output in the table below, BEFORE anything else)
+
+```sh
+ui memory compile --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --dir <p> --json
+jq -r .type <p>/design/memory.events.jsonl | sort | uniq -c
+design-os librarian collect --dir <p> --json
+```
+
+If the baseline does NOT match "one ingest burst, ~2 mechanical types, 0 gaps, 0 insights,
+empty graph" (the audit finding that motivated spec 006 — memory
+`living-loop-fuel-line-finding`), **say so explicitly in this report** — the motivating
+evidence would be stale and the gate's meaning changes.
+
+### 2. Fuel the line
+
+Do a REAL slice of work with the fed binary — the lints/audit the project actually runs
+(e.g. `ui audit`, `ui ds a11y`, whatever that project's own workflow calls). **Do not
+synthesise runs to pad the ledger** — that is fixture data wearing a real project's clothes
+(Risk Assessment, phase-05).
+
+### 3. Harvest
+
+```sh
+design-os harvest --dir <p> --dry-run --json   # inspect first — candidates/dropped counts
+design-os harvest --dir <p> --json             # then live, once the dry-run looks right
+```
+
+Requires `DESIGN_OS_MODEL_CMD` set to a real model command (unset → the run degrades to
+`skipped`/`no-model-adapter`, exit 0, and writes the packet to `design/harvest-inbox/` for
+manual inspection instead — that is NOT a failed gate, just an unconfigured one; note which
+case occurred).
+
+### 4. Compile + inspect
+
+```sh
+ui memory compile --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --dir <p> --json
+jq -r .type <p>/design/memory.events.jsonl | sort | uniq -c
+```
+
+Look for `insights` with `seen > 1` in the compiled output (recurrence signal) — note
+whether any exist.
+
+### 5. Graduate
+
+```sh
+design-os librarian collect --dir <p> --json
+```
+
+Then run the librarian loop per `knowledge/librarian-loop.md` (fresh-judge veto chain) — it
+opens a PR. **The owner merges** (Decision 6 — graduation-merge autonomy stays owner-merge;
+unchanged from `librarian-loop.md` step 7, "Human gate — the invariant").
+
+### 6. Fill in this table + the verbatim lessons below, then commit this file
+
+| Metric | VSF-PCP before | after | platform-DS before | after |
+|---|---|---|---|---|
+| ledger events | TBD | TBD | TBD | TBD |
+| distinct event types | TBD | TBD | TBD | TBD |
+| graph insights (`seen > 1`) | TBD | TBD | TBD | TBD |
+| open gaps (`librarian collect`) | TBD | TBD | TBD | TBD |
+| librarian PRs opened / merged | TBD | TBD | TBD | TBD |
+| harvest: candidates → recorded → dropped (by reason) | TBD | TBD | TBD | TBD |
+
+**One real lesson that made it from a `plans/` report into the ledger** (verbatim):
+> TBD
+
+**One that the gate dropped and should not have** (verbatim, or "none" — but look for it):
+> TBD
+
+## Reflect's known blind spot (Decision 5, record here whether it mattered)
+
+Only `memory export-corpus` **embeddable** event types reach `reflect` —
+`insight`/`token_change`/`harvested`/`vibe_edit`/`variant_generated`. P1's
+`lint_run`/`autofix_applied`/`reconcile_applied`/`taste_vote` are invisible to `reflect` in
+v1. If the real-data run shows the lint stream carries a lesson `reflect` cannot see, note it
+here — opening `memory-corpus.shape()` to `lint_run` is a spec-007 decision, not a silent
+patch in 006.
+
+## After this runs
+
+Update memory `living-loop-fuel-line-finding` with the after-state, per phase-05's Next
+Steps: the audit that motivated spec 006 should end with its own answer.


### PR DESCRIPTION
## Summary
- Adds `harvest`/`reflect` due-scheduled heartbeat task types (`heartbeat_runners_learning.py`) so the P4 memory fuel line runs with no human trigger (spec 006 AC5), wired into `TASK_RUNNERS`/`_KNOWN_TYPES`.
- `summary` carries ONLY `failures` (Decision 2) — a bigger harvest is never reported as "worsened" by `heartbeat_core.compare_summary` (Key Insight 1).
- Fixes the P1 cwd trap (Key Insight 5) in the four pre-existing runners (`ds-a11y`, `specimen`, `audit-pages`, `figma-audit`) so a heartbeat-triggered write always lands in the project's own ledger, not this process's cwd.
- Adds `reflect_core.py` (pure): the `export-corpus` cursor, job-event selection, echo-guard baseline, and the one-lesson gate (Decision 5).
- Writes `specs/006-living-loop/reports/p5-real-data-gate.md` — the exact procedure for the owner/Fable to run the real-data gate (Art III) on VSF-PCP and platform-design-system. **Not executed by this PR** — it requires `DESIGN_OS_MODEL_CMD` pointed at a real model, explicitly reserved for the owner.
- `heartbeat_runners.py`, `heartbeat.py`, `heartbeat_runners_learning.py` all stay under the 200-line module cap; `reflect_core.py` is 151 lines.

## Test plan
- [x] `uv run pytest -q` in `design-os/` — 239 passed
- [x] New tests: `test_reflect_core.py` (12), `test_heartbeat_runner_harvest.py` (8), 4 new cases appended to `test_command_heartbeat.py`
- [x] Root gates: `npm run typecheck`, `npm run lint`, `npm run build`, `npm test` (1963 passed) — all green
- [x] `ui knowledge check` — 0 findings
- [ ] Real-data gate on VSF-PCP / platform-design-system — owner/Fable, per `specs/006-living-loop/reports/p5-real-data-gate.md`