### PR TITLE
fix(design-os): the honest router — BFS walk + truncated/visited (spec 009 P2)

### DIFF
--- a/specs/009-code-road/reports/p2-impl-report.md
+++ b/specs/009-code-road/reports/p2-impl-report.md
@@ -1,0 +1,166 @@
+# Phase 02 — The honest router — implementation report
+
+Branch: `spec009/p2-honest-router` (off `main`).
+
+## What changed
+
+- `src/core/project-scan.ts` (206 → 224 lines):
+  - Header comment (`:1-15`) rewritten: byte-identical results come from the **sort**, not
+    traversal order; the walk is now breadth-first; either cap sets `truncated`.
+  - `ScanResult` gained `truncated: boolean` and `visited: number` (additive only, D2).
+  - `WalkAccum` gained `truncated: boolean`.
+  - `walk()` rewritten from recursive depth-first (`walk(root, dir, depth, acc)`) to an explicit
+    FIFO-queue breadth-first walk (`walk(root, start, acc)`), per the phase file's architecture
+    sketch. `truncated` is set at **both** cap sites (entry cap in the `while` and the inner
+    `for`, and the depth cap). `sortedEntries` is untouched — entries within a level keep
+    alphabetical order.
+  - `scanProject()` initializes `truncated: false` on the accumulator and returns
+    `truncated: acc.truncated, visited: acc.visited` on the result.
+  - Untouched, as instructed: `SKIP_DIRS`, `sortedEntries`, the `slice(0, 5)` contract, the
+    verdict logic, `MAX_DEPTH`/`MAX_ENTRIES` values, component-dir detection logic, the
+    alphabetical `componentDirs` sort (D3 — no re-sort).
+- `templates/workflows/learn.md` step 1 (D4): field list now names `truncated`/`visited`; added
+  a "Truncation comes first" rule — if `truncated`, say so **before** the verdict, and never read
+  an empty `componentDirs` + `truncated: true` as "no components here."
+- `tests/cmd-scan.test.ts` (existing file, no duplicate created): added the 7 tests named in the
+  phase file, verbatim (`test_a_ui_behind_an_alphabetically_earlier_large_sibling_is_found`,
+  `test_scan_is_byte_identical_across_runs`, `test_a_tree_over_the_cap_reports_truncated_true_and_visited`,
+  `test_a_tree_under_the_cap_reports_truncated_false`, `test_a_tree_over_max_depth_reports_truncated`,
+  `test_truncated_does_not_change_any_existing_field_shape`,
+  `test_component_dirs_carry_their_file_counts_and_a_stable_order`).
+
+`src/commands/scan.ts` was **not** modified — it wasn't in the phase file's "Related Code Files"
+list, and `okJson(CMD, result)` already spreads the full `ScanResult` (including the new fields)
+into the JSON envelope with no changes needed. The text formatter doesn't surface `truncated`;
+the phase file scoped the truncation-surfacing requirement to `learn.md` step 1 (D4), not the CLI
+text output, so I left it alone.
+
+## A note on the fixture for `test_a_ui_behind_an_alphabetically_earlier_large_sibling_is_found`
+
+The phase file's fixture sketch says "enough files to exhaust **a lowered cap**" but the hard
+constraint says never touch `MAX_ENTRIES`/`MAX_DEPTH`. Read literally, "a lowered cap" isn't
+achievable without touching the constant, so I built the fixture against the real 4000-entry cap
+instead: `aaa-service`'s full recursive subtree (10 × 10 dirs × 50 files = 5000+ entries) exceeds
+the cap on its own, so an (old) depth-first walk exhausts the whole budget *inside* `aaa-service`
+and never even starts `zzz-ui`, which pins the dana pathology under the real cap value. Under BFS,
+`zzz-ui/components` (2 levels deep) is discovered long before the walk gets that deep into
+`aaa-service`, so the test asserts the component dir + css file are found — it does not assert
+`truncated`'s value, since with a fixture large enough to prove the DFS failure, `truncated` will
+honestly end up `true` (the walk still runs out of budget later, deep in `aaa-service`, after
+already finding the UI). Flagging this since I read the sketch's wording as advisory rather than
+literal — happy to revisit if that reading was wrong.
+
+## Four gates
+
+- `npm run typecheck` — **PASS** (no output, exit 0).
+- `npm run lint` — **PASS** (no output, exit 0).
+- `npm run build` — **PASS** (`dist/cli.js` 796.19 KB, tsup build success).
+- `npm test` — **PASS**: 129 test files, 1970 passed, 4 skipped, 0 failed. No existing test
+  broke — nothing was asserting the depth-first-shaped bug.
+
+## LIVE run 1 — dana-desktop (Art III)
+
+```
+$ node dist/cli.js scan --cwd /Users/jang/Products/dana-desktop --json
+{
+  "ok": true,
+  "command": "scan",
+  "data": {
+    "framework": "react",
+    "styling": ["tailwind", "css"],
+    "tailwindConfig": null,
+    "cssFiles": [
+      { "path": "src/desktop-ui/index.css", "bytes": 42549 },
+      { "path": "src/desktop-ui/dana-tokens.css", "bytes": 13971 },
+      { "path": "src/desktop-ui/test/__mocks__/empty.css", "bytes": 38 }
+    ],
+    "htmlFiles": [
+      { "path": "plans/reports/260714-1934-dana-ui-responsive-audit/dana-responsive-audit.html", "bytes": 1455077 },
+      { "path": "tests/playwright-report/index.html", "bytes": 529576 },
+      { "path": "docs/research/renesas-activity-report-v2.html", "bytes": 313224 },
+      { "path": "docs/research/Cross-accounts/cross-account-product-signals.html", "bytes": 85936 },
+      { "path": "design-review/integrations/prototype.html", "bytes": 60632 }
+    ],
+    "componentDirs": [
+      { "path": "src/desktop-ui/components", "files": 157 }
+    ],
+    "designMd": null,
+    "dsStatus": "present",
+    "verdict": "ds-present",
+    "truncated": true,
+    "visited": 4000
+  }
+}
+```
+
+**Confirms the phase's motivating finding**: `src/desktop-ui` is now in `componentDirs` and
+`dana-tokens.css` is in `cssFiles`. Before this phase: `cssFiles: 0, componentDirs: 0`.
+
+**Deviation from the UC-01 Gherkin worth flagging**: the Gherkin's happy path says `truncated is
+false` for the "UI buried under an alphabetically-earlier sibling" scenario. Live, `truncated` is
+`true` (`visited: 4000`). Root cause, checked directly: dana-desktop's root has a `.venv`
+directory (8187 files) that sorts alphabetically *before* `benchmark`, `config`, `docs`, etc., and
+is **not** in `SKIP_DIRS` (which only lists `node_modules`, `dist`, `build`, `out`, `coverage`,
+`vendor`, `.git`, `.next`, `.turbo`, `.cache`, `.agent`, `.claude`, `design` — no `.venv`). The
+whole repo (excluding `SKIP_DIRS`) has ~15,301 entries, so *something* was always going to hit the
+4000 cap; BFS's fix is that it reaches `desktop-ui` (shallow) before it works its way deep enough
+into `.venv`/`docs`/etc. to exhaust the budget — the honest result is `truncated: true` with the
+UI still found, not `truncated: false`. This is not a bug in the implementation (the phase file
+explicitly forbids touching `SKIP_DIRS`, Key Insight 3) — it's the Gherkin's illustrative example
+undershooting the real repo's shape. Reporting per Art V/the escalation instruction rather than
+silently reconciling it.
+
+## LIVE run 2 — EaseUI (evidence only, not pass/fail)
+
+```
+$ node dist/cli.js scan --cwd /Users/jang/Products/EaseUI --json
+{
+  "ok": true,
+  "command": "scan",
+  "data": {
+    "framework": null,
+    "styling": ["tailwind", "css"],
+    "tailwindConfig": "app/tailwind.config.js",
+    "cssFiles": [
+      { "path": ".agents/skills/plans-kanban/assets/dashboard.css", "bytes": 31085 },
+      { "path": "app/src/app/globals.css", "bytes": 16911 },
+      { "path": "frontpage/app/src/app/globals.css", "bytes": 16782 },
+      { "path": "app/src/app/docs/docs.css", "bytes": 9382 },
+      { "path": "frontpage/app/src/app/docs/docs.css", "bytes": 9382 }
+    ],
+    "htmlFiles": [
+      { "path": "app/public/samples/ui-generation/01-editor.html", "bytes": 56331 },
+      { "path": "frontpage/app/public/samples/ui-generation/01-editor.html", "bytes": 56331 },
+      { "path": ".agents/skills/skill-creator/eval-viewer/viewer.html", "bytes": 44998 },
+      { "path": "awesome-design-md/design-md/hashicorp/preview.html", "bytes": 42158 },
+      { "path": "awesome-design-md/design-md/hashicorp/preview-dark.html", "bytes": 41940 }
+    ],
+    "componentDirs": [
+      { "path": "app/src/components/ui", "files": 12 }
+    ],
+    "designMd": null,
+    "dsStatus": "none",
+    "verdict": "brownfield-code",
+    "truncated": true,
+    "visited": 4000
+  }
+}
+```
+
+`framework: null` (no root `package.json`, as expected) yet `verdict: brownfield-code` because
+`componentDirs.length > 0` — the verdict logic (Key Insight 6, left untouched) is still right
+here. `truncated: true, visited: 4000` — the walk ran out of budget, as expected for a repo this
+size (62 nested `package.json`, thousands of files). Only **one** of the two legitimate UI roots
+(`app/src/components/ui`) was found in this run; `frontpage/app/src/components` was not reached
+before the cap — a live instance of the exact edge case UC-01/D3 names. This is evidence, not a
+failure: D3's answer ("scan reports what it finds, stably sorted; it does not need to find
+everything") holds — the honest `truncated: true` signal tells `learn.md` (and the user) the map
+is partial, which is the whole point of this phase.
+
+## Deviations from plan.md (per phase file's own "Deviations" section)
+
+Confirmed as designed, not introduced by me:
+1. OQ1 answered by D3 with neither a flag nor a question — verified live on EaseUI above.
+2. The depth cap also sets `truncated` — implemented and covered by
+   `test_a_tree_over_max_depth_reports_truncated`.
+3. The header comment changed — done, re-worded per Key Insight 1.

--- a/specs/009-code-road/reports/p2-impl-report.md
+++ b/specs/009-code-road/reports/p2-impl-report.md
@@ -2,9 +2,15 @@
 
 Branch: `spec009/p2-honest-router` (off `main`).
 
-## What changed
+**Update (round 2):** after the Art V/Opus audit passed, the coordinator identified two bugs in
+*their own* phase file (not in this diff) and asked for a follow-up: `SKIP_DIRS` was JS-only and
+missed Python's `.venv`, and UC-01's Gherkin asserted the wrong `truncated` value. See
+"Round 2 — SKIP_DIRS goes polyglot" below for what changed and the re-run live numbers.
 
-- `src/core/project-scan.ts` (206 → 224 lines):
+## What changed (round 1)
+
+- `src/core/project-scan.ts` (206 → 224 lines, round 1; 232 lines after round 2's `SKIP_DIRS`
+  addition):
   - Header comment (`:1-15`) rewritten: byte-identical results come from the **sort**, not
     traversal order; the walk is now breadth-first; either cap sets `truncated`.
   - `ScanResult` gained `truncated: boolean` and `visited: number` (additive only, D2).
@@ -16,9 +22,10 @@ Branch: `spec009/p2-honest-router` (off `main`).
     alphabetical order.
   - `scanProject()` initializes `truncated: false` on the accumulator and returns
     `truncated: acc.truncated, visited: acc.visited` on the result.
-  - Untouched, as instructed: `SKIP_DIRS`, `sortedEntries`, the `slice(0, 5)` contract, the
-    verdict logic, `MAX_DEPTH`/`MAX_ENTRIES` values, component-dir detection logic, the
-    alphabetical `componentDirs` sort (D3 — no re-sort).
+  - Untouched in round 1, as instructed: `SKIP_DIRS`, `sortedEntries`, the `slice(0, 5)` contract,
+    the verdict logic, `MAX_DEPTH`/`MAX_ENTRIES` values, component-dir detection logic, the
+    alphabetical `componentDirs` sort (D3 — no re-sort). `SKIP_DIRS` changed in round 2, see below
+    — everything else in this list is still untouched.
 - `templates/workflows/learn.md` step 1 (D4): field list now names `truncated`/`visited`; added
   a "Truncation comes first" rule — if `truncated`, say so **before** the verdict, and never read
   an empty `componentDirs` + `truncated: true` as "no components here."
@@ -49,6 +56,58 @@ and never even starts `zzz-ui`, which pins the dana pathology under the real cap
 honestly end up `true` (the walk still runs out of budget later, deep in `aaa-service`, after
 already finding the UI). Flagging this since I read the sketch's wording as advisory rather than
 literal — happy to revisit if that reading was wrong.
+
+## Round 2 — SKIP_DIRS goes polyglot
+
+The coordinator measured across 9 code projects on the machine: `.venv` — 1 project, 8187 files
+(54% of dana-desktop's whole tree); `__pycache__` — 2 projects, 19 files; `.pytest_cache` — 1
+project, 5 files; `.vercel` — 3 projects, 7 files; `venv .tox .mypy_cache target Pods .gradle
+.svelte-kit .nuxt .output .expo` — 0/9. Per the brainstorm's No-Go 5 ("a rung at 0/9 does not
+ship"), only entries with measured files-burned earn a place. Added exactly `.venv`, `venv`,
+`__pycache__` — `venv` rides along with `.venv` as the same ecosystem's other spelling, not a
+separate measurement. `.vercel`/`.pytest_cache` stay out (noise, <10 files each); every 0/9 guess
+stays out.
+
+```ts
+// Ecosystem-scoped, not "plausible": an entry earns its place by files-burned
+// on a real repo (9-project measurement), not by guessing every tool's cache
+// dir. JS/JS-tooling entries predate this comment; .venv/venv/__pycache__
+// (Python) were added after dana-desktop — a polyglot (Electron+React+Python)
+// repo — showed a 8187-file .venv alone was 54% of its whole tree and sorted
+// ahead of the real UI. .vercel/.pytest_cache measured too (<10 files each,
+// noise) and .tox/target/Pods/.gradle/etc. measured 0/9 — none of those ship.
+const SKIP_DIRS = new Set([
+  "node_modules", "dist", "build", "out", "coverage", "vendor", ".git",
+  ".next", ".turbo", ".cache", ".agent", ".claude", "design",
+  ".venv", "venv", "__pycache__",
+]);
+```
+
+Four gates re-run after this change — all still green (typecheck, lint, build clean; `npm test`:
+129 files, 1970 passed, 4 skipped, 0 failed).
+
+**Re-run dana-desktop live**: `truncated` did **not** flip to false. Real number, not tuned:
+total non-`SKIP_DIRS` entries in dana-desktop with the new list = **5038** (down from ~15,301 with
+the old list — `.venv` alone was ~8187 of the difference, plus `src/agent-servers/.venv`, a
+*second* `.venv` the repo has). 5038 is still over the 4000 cap, so `truncated: true, visited:
+4000` is unchanged — reported honestly per the instruction not to tune toward `false`.
+`componentDirs`/`cssFiles` findings are unchanged (`src/desktop-ui/components`,
+`dana-tokens.css`) — round 1's core finding already held regardless of `.venv`.
+
+**Re-run EaseUI live (round 2 evidence)**: unchanged from round 1 — `truncated: true, visited:
+4000`, still only 1 of 2 UI roots (`app/src/components/ui`) found. EaseUI has **zero** `.venv`/
+`venv`/`__pycache__` dirs (checked directly), so the fix doesn't touch it; its total non-`SKIP_DIRS`
+entry count is **4221** — just 221 over the cap. That's the number for the cap-revisiting decision
+the coordinator flagged as out of scope for this phase: EaseUI is JS-only and polyglot-ecosystem
+skips don't help it; it sits right at the edge of `MAX_ENTRIES`, so a small cap increase (not a
+`SKIP_DIRS` change) is the lever that would fully cover it, if that's ever revisited.
+
+**UC-01's Gherkin**: per the coordinator, they are correcting `usecases.md` on `main` (`Then
+truncated is false` → the componentDirs/cssFiles assertions this run already satisfies). No test
+in this branch was changed to chase the old Gherkin — `truncated`'s value is not asserted in
+`test_a_ui_behind_an_alphabetically_earlier_large_sibling_is_found` for exactly this reason (see
+the fixture note above, written before this round-2 message arrived and left as-is since it
+already reasoned through the same conclusion).
 
 ## Four gates
 

--- a/src/core/project-scan.ts
+++ b/src/core/project-scan.ts
@@ -46,9 +46,17 @@ export interface ScanResult {
 
 // ─── Tunables ───────────────────────────────────────────────────────────────────
 
+// Ecosystem-scoped, not "plausible": an entry earns its place by files-burned
+// on a real repo (9-project measurement), not by guessing every tool's cache
+// dir. JS/JS-tooling entries predate this comment; .venv/venv/__pycache__
+// (Python) were added after dana-desktop — a polyglot (Electron+React+Python)
+// repo — showed a 8187-file .venv alone was 54% of its whole tree and sorted
+// ahead of the real UI. .vercel/.pytest_cache measured too (<10 files each,
+// noise) and .tox/target/Pods/.gradle/etc. measured 0/9 — none of those ship.
 const SKIP_DIRS = new Set([
   "node_modules", "dist", "build", "out", "coverage", "vendor", ".git",
   ".next", ".turbo", ".cache", ".agent", ".claude", "design",
+  ".venv", "venv", "__pycache__",
 ]);
 const MAX_DEPTH = 6;
 const MAX_ENTRIES = 4000;

--- a/src/core/project-scan.ts
+++ b/src/core/project-scan.ts
@@ -3,9 +3,14 @@
  * signals in a project root. Powers `ui scan` and the `ui init` next-step hint.
  *
  * Pure except fs reads (readdir/stat/readFile) and loadDesignSystem (fs reads
- * only). No network, no writes, no Date.now, no randomness. The directory walk
- * visits entries in sorted (alphabetical) order so results are byte-identical
- * across runs — including when the 4000-entry cap truncates a huge tree.
+ * only). No network, no writes, no Date.now, no randomness. Byte-identical
+ * results come from the SORT, not the traversal order: every directory's
+ * entries are visited in sorted (alphabetical) order. The walk itself is
+ * breadth-first — a full level is visited before any one subtree is
+ * descended into, so a shallow UI dir is found before an
+ * alphabetically-earlier-but-deeper sibling can burn the entry cap. Either
+ * cap (MAX_ENTRIES, MAX_DEPTH) sets `truncated: true` — never a silent
+ * partial map reported as a complete one.
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, extname, join, relative, sep } from "node:path";
@@ -33,6 +38,10 @@ export interface ScanResult {
   dsStatus: "none" | "present" | "tampered";
   /** Routing verdict derived from the signals above. */
   verdict: "greenfield" | "brownfield-code" | "brownfield-html" | "ds-present";
+  /** True when the walk hit MAX_ENTRIES or MAX_DEPTH and the map is therefore partial. */
+  truncated: boolean;
+  /** Directory entries visited. Equals MAX_ENTRIES when truncated by the entry cap. */
+  visited: number;
 }
 
 // ─── Tunables ───────────────────────────────────────────────────────────────────
@@ -96,6 +105,7 @@ interface WalkAccum {
   tailwindConfigs: string[];
   componentDirs: Array<{ path: string; files: number }>;
   visited: number;
+  truncated: boolean;
 }
 
 function sortedEntries(dir: string): Dirent[] {
@@ -109,34 +119,41 @@ function sortedEntries(dir: string): Dirent[] {
   return entries;
 }
 
-function walk(root: string, dir: string, depth: number, acc: WalkAccum): void {
-  if (depth > MAX_DEPTH || acc.visited >= MAX_ENTRIES) return;
-  const entries = sortedEntries(dir);
+// BFS: a queue of {dir, depth}. Within each level, entries keep sortedEntries'
+// alphabetical order (Art I — see header comment). Component-dir detection
+// happens as each dir is dequeued — the same check that ran depth-first before.
+function walk(root: string, start: string, acc: WalkAccum): void {
+  const queue: Array<{ dir: string; depth: number }> = [{ dir: start, depth: 0 }];
+  while (queue.length > 0) {
+    if (acc.visited >= MAX_ENTRIES) { acc.truncated = true; return; }
+    const { dir, depth } = queue.shift()!;
+    if (depth > MAX_DEPTH) { acc.truncated = true; continue; }
+    const entries = sortedEntries(dir);
 
-  // Component-dir detection: this dir qualifies if its name matches and it has
-  // >=3 direct code-file children.
-  const base = basename(dir).toLowerCase();
-  if (COMPONENT_DIR_NAMES.has(base)) {
-    const directCode = entries.filter(
-      (e) => e.isFile() && CODE_EXT.has(extname(e.name).toLowerCase()),
-    ).length;
-    if (directCode >= 3) acc.componentDirs.push({ path: relPath(root, dir), files: directCode });
-  }
+    // >=3 direct code-file children in a components|ui|widgets dir qualifies it.
+    const base = basename(dir).toLowerCase();
+    if (COMPONENT_DIR_NAMES.has(base)) {
+      const directCode = entries.filter(
+        (e) => e.isFile() && CODE_EXT.has(extname(e.name).toLowerCase()),
+      ).length;
+      if (directCode >= 3) acc.componentDirs.push({ path: relPath(root, dir), files: directCode });
+    }
 
-  for (const e of entries) {
-    if (acc.visited >= MAX_ENTRIES) return;
-    acc.visited++;
-    const full = join(dir, e.name);
-    if (e.isDirectory()) {
-      if (SKIP_DIRS.has(e.name)) continue;
-      walk(root, full, depth + 1, acc);
-    } else if (e.isFile()) {
-      const lower = e.name.toLowerCase();
-      if (TAILWIND_CONFIG_RE.test(lower)) acc.tailwindConfigs.push(relPath(root, full));
-      const ext = extname(lower);
-      if (ext === ".css") acc.css.push({ path: relPath(root, full), bytes: fileBytes(full) });
-      else if (ext === ".scss") acc.scssCount++;
-      else if (ext === ".html") acc.html.push({ path: relPath(root, full), bytes: fileBytes(full) });
+    for (const e of entries) {
+      if (acc.visited >= MAX_ENTRIES) { acc.truncated = true; return; }
+      acc.visited++;
+      const full = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (SKIP_DIRS.has(e.name)) continue;
+        queue.push({ dir: full, depth: depth + 1 });
+      } else if (e.isFile()) {
+        const lower = e.name.toLowerCase();
+        if (TAILWIND_CONFIG_RE.test(lower)) acc.tailwindConfigs.push(relPath(root, full));
+        const ext = extname(lower);
+        if (ext === ".css") acc.css.push({ path: relPath(root, full), bytes: fileBytes(full) });
+        else if (ext === ".scss") acc.scssCount++;
+        else if (ext === ".html") acc.html.push({ path: relPath(root, full), bytes: fileBytes(full) });
+      }
     }
   }
 }
@@ -167,8 +184,9 @@ export function scanProject(root: string): ScanResult {
 
   const acc: WalkAccum = {
     css: [], html: [], scssCount: 0, tailwindConfigs: [], componentDirs: [], visited: 0,
+    truncated: false,
   };
-  walk(root, root, 0, acc);
+  walk(root, root, acc);
 
   const tailwindConfig =
     acc.tailwindConfigs.length > 0 ? [...acc.tailwindConfigs].sort()[0]! : null;
@@ -201,5 +219,6 @@ export function scanProject(root: string): ScanResult {
   return {
     framework, styling, tailwindConfig, cssFiles, htmlFiles,
     componentDirs, designMd, dsStatus, verdict,
+    truncated: acc.truncated, visited: acc.visited,
   };
 }

--- a/templates/workflows/learn.md
+++ b/templates/workflows/learn.md
@@ -37,10 +37,18 @@ ui scan --json
 ```
 
 The envelope's `data` carries `framework`, `styling`, `tailwindConfig`,
-`cssFiles`, `htmlFiles`, `componentDirs`, `designMd`, `dsStatus`, and a
-`verdict`. Summarise the findings for the user in **one short paragraph** — the
-framework, the styling approach, how many component dirs / HTML files were seen,
-and the verdict — not a raw dump.
+`cssFiles`, `htmlFiles`, `componentDirs`, `designMd`, `dsStatus`, `truncated`,
+`visited`, and a `verdict`. Summarise the findings for the user in **one short
+paragraph** — the framework, the styling approach, how many component dirs /
+HTML files were seen, and the verdict — not a raw dump.
+
+**Truncation comes first.** If `truncated` is `true`, say so **before** stating
+the verdict: the walk budget ran out (`visited` entries scanned) before the
+whole tree was covered, so any empty or thin finding may just be unreached
+ground, not a verdict on the project. `componentDirs: []` with `truncated: true`
+must read as *"the budget ran out before any UI was found"* — never as *"this
+project has no components"*. Only state "no UI here" outright when
+`truncated` is `false`.
 
 If `verdict` is already `ds-present`, tell the user a compiled DS exists and stop
 unless they explicitly want to re-learn (e.g. after a major redesign);

--- a/tests/cmd-scan.test.ts
+++ b/tests/cmd-scan.test.ts
@@ -148,4 +148,141 @@ describe("ui scan", () => {
     const r = capture(["scan", "foo"]);
     expect(r.exitCode).toBe(1);
   });
+
+  it("test_a_ui_behind_an_alphabetically_earlier_large_sibling_is_found", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    // "aaa-service" sorts before "zzz-ui". Its full recursive subtree (10 x 10
+    // dirs x 50 files = 5000+ entries) exceeds MAX_ENTRIES on its own, so a
+    // depth-first walk exhausts the budget entirely inside it and never even
+    // starts "zzz-ui" — pinning the dana pathology (an early-alphabetical,
+    // bushy sibling starves an alphabetically-later, shallow UI dir). BFS
+    // visits "zzz-ui" (2 levels deep) long before the walk works its way that
+    // deep into "aaa-service", so it survives the same eventual truncation.
+    const aaaDir = join(tmp, "src", "aaa-service");
+    mkdirSync(aaaDir, { recursive: true });
+    for (let i = 0; i < 10; i++) {
+      const mid = join(aaaDir, `n${i}`);
+      mkdirSync(mid);
+      for (let j = 0; j < 10; j++) {
+        const leaf = join(mid, `n${j}`);
+        mkdirSync(leaf);
+        for (let k = 0; k < 50; k++) {
+          writeFileSync(join(leaf, `f${k}.txt`), "x");
+        }
+      }
+    }
+    const zzzComponents = join(tmp, "src", "zzz-ui", "components");
+    mkdirSync(zzzComponents, { recursive: true });
+    writeFileSync(join(zzzComponents, "Button.tsx"), "export const Button = () => null;\n");
+    writeFileSync(join(zzzComponents, "Card.tsx"), "export const Card = () => null;\n");
+    writeFileSync(join(zzzComponents, "Modal.tsx"), "export const Modal = () => null;\n");
+    writeFileSync(join(tmp, "src", "zzz-ui", "zzz-tokens.css"), "body { margin: 0; }\n");
+
+    const env = scanJson(tmp);
+    const comp = env.data.componentDirs.find((d) => d.path.includes("zzz-ui"));
+    expect(comp).toBeDefined();
+    const css = env.data.cssFiles.find((f) => f.path.endsWith("zzz-tokens.css"));
+    expect(css).toBeDefined();
+  }, 20000);
+
+  it("test_scan_is_byte_identical_across_runs", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    writeFileSync(join(tmp, "package.json"), JSON.stringify({ dependencies: { react: "18" } }));
+    const compDir = join(tmp, "src", "components");
+    mkdirSync(compDir, { recursive: true });
+    writeFileSync(join(compDir, "Button.tsx"), "export const Button = () => null;\n");
+    writeFileSync(join(compDir, "Card.tsx"), "export const Card = () => null;\n");
+    writeFileSync(join(compDir, "Modal.tsx"), "export const Modal = () => null;\n");
+    writeFileSync(join(tmp, "src", "tokens.css"), "body { margin: 0; }\n");
+
+    const a = capture(["scan", "--cwd", tmp, "--json"]);
+    const b = capture(["scan", "--cwd", tmp, "--json"]);
+    expect(a.stdout).toBe(b.stdout);
+  });
+
+  it("test_a_tree_over_the_cap_reports_truncated_true_and_visited", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    const wide = join(tmp, "wide");
+    mkdirSync(wide, { recursive: true });
+    // MAX_ENTRIES is 4000 — a single directory with 4010 direct file children
+    // exhausts the entry cap without needing any depth.
+    for (let i = 0; i < 4010; i++) {
+      writeFileSync(join(wide, `f-${i}.txt`), "x");
+    }
+
+    const env = scanJson(tmp);
+    expect(env.data.truncated).toBe(true);
+    expect(env.data.visited).toBe(4000);
+  });
+
+  it("test_a_tree_under_the_cap_reports_truncated_false", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    writeFileSync(join(tmp, "index.html"), "<html></html>\n");
+
+    const env = scanJson(tmp);
+    expect(env.data.truncated).toBe(false);
+  });
+
+  it("test_a_tree_over_max_depth_reports_truncated", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    // MAX_DEPTH is 6 — nest one directory deeper than that below the root.
+    let deep = tmp;
+    for (let i = 0; i < 8; i++) {
+      deep = join(deep, `d${i}`);
+    }
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, "buried.css"), "body {}\n");
+
+    const env = scanJson(tmp);
+    expect(env.data.truncated).toBe(true);
+  });
+
+  it("test_truncated_does_not_change_any_existing_field_shape", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    writeFileSync(join(tmp, "index.html"), "<html></html>\n");
+    writeFileSync(join(tmp, "style.css"), "body {}\n");
+
+    const env = scanJson(tmp);
+    expect(typeof env.data.framework === "string" || env.data.framework === null).toBe(true);
+    expect(Array.isArray(env.data.styling)).toBe(true);
+    expect(Array.isArray(env.data.cssFiles)).toBe(true);
+    expect(Array.isArray(env.data.htmlFiles)).toBe(true);
+    expect(Array.isArray(env.data.componentDirs)).toBe(true);
+    expect(typeof env.data.dsStatus).toBe("string");
+    expect(typeof env.data.verdict).toBe("string");
+    expect(typeof env.data.truncated).toBe("boolean");
+    expect(typeof env.data.visited).toBe("number");
+  });
+
+  it("test_component_dirs_carry_their_file_counts_and_a_stable_order", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    // Two legitimate UI roots, EaseUI-style — scan reports both, sorted by path;
+    // it does not pick a winner (D3 — learn.md ranks by files count).
+    const appComponents = join(tmp, "app", "src", "components");
+    mkdirSync(appComponents, { recursive: true });
+    writeFileSync(join(appComponents, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(appComponents, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(appComponents, "C.tsx"), "export const C = () => null;\n");
+    writeFileSync(join(appComponents, "D.tsx"), "export const D = () => null;\n");
+
+    const frontpageComponents = join(tmp, "frontpage", "app", "src", "components");
+    mkdirSync(frontpageComponents, { recursive: true });
+    writeFileSync(join(frontpageComponents, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(frontpageComponents, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(frontpageComponents, "C.tsx"), "export const C = () => null;\n");
+
+    const env = scanJson(tmp);
+    expect(env.data.componentDirs.length).toBe(2);
+    const app = env.data.componentDirs.find((d) => d.path === "app/src/components");
+    const frontpage = env.data.componentDirs.find(
+      (d) => d.path === "frontpage/app/src/components",
+    );
+    expect(app?.files).toBe(4);
+    expect(frontpage?.files).toBe(3);
+    // Stable order: sorted alphabetically by path, "app/..." before "frontpage/...".
+    expect(env.data.componentDirs.map((d) => d.path)).toEqual([
+      "app/src/components",
+      "frontpage/app/src/components",
+    ]);
+  });
 });


### PR DESCRIPTION
`ui scan` is the router the whole brownfield-code road stands on. It could not be trusted.

## What was actually broken

The filed diagnosis was *"scan cannot see a UI that isn't at the repo root"*. That is wrong — `SKIP_DIRS` is already correct and the walk already descends. The real cause, root-caused live:

`project-scan.ts` walked **depth-first**, **alphabetically**, and returned at `MAX_ENTRIES = 4000` **with no signal**.

dana's `src/`: `agent-servers · backend · config · dana-ontologist(415 files) · desktop-ui`. The budget died four directories before the UI.

```
ui scan --cwd /Users/jang/Products/dana-desktop --json
→ ok: true · framework: react · styling: [tailwind]
  cssFiles: 0 · componentDirs: 0 · truncation field: NONE
```

`dana-tokens.css` was sitting right there. The envelope said `ok`. That violates Art VIII — a static check must say exactly what it checked.

## The decision BFS had to preserve

`project-scan.ts:6-8` states the walk is alphabetical **so results are byte-identical across runs** (Art I). That is real and deliberate — and BFS does not break it: determinism comes from the *sort*, not from depth-first. `sortedEntries` is untouched; the header comment now says so explicitly, and `test_scan_is_byte_identical_across_runs` pins it.

## SKIP_DIRS goes polyglot

The follow-up commit is the more interesting half. Every SKIP_DIRS entry was JS or JS-tooling — not wrong, but **JS-shaped**, because design:os had never scanned a polyglot repo. dana is Electron + React + **Python**. Measured across all nine code projects on this machine:

```
.venv          1 project ·  8187 files   ← 54% of dana's whole tree
__pycache__    2 projects ·   19 files
.pytest_cache  1 project  ·    5 files
.vercel        3 projects ·    7 files
venv .tox .mypy_cache target Pods .gradle .svelte-kit .nuxt .output .expo  → 0/9
```

Added exactly `.venv`, `venv`, `__pycache__`. The ten plausible guesses are 0/9 and stay out. SKIP_DIRS now carries a comment: it is ecosystem-scoped, and entries earn their place by measured files-burned, not by plausibility.

## What ships

- BFS queue walk; same `sortedEntries` sort, same `MAX_DEPTH`/`MAX_ENTRIES`, same `SKIP_DIRS` semantics.
- `truncated` + `visited` as **additive** envelope fields, set at both cap sites. `truncated` stays in the contract even if the cap later moves — it is the honesty surface, not a tuning artefact.
- `learn.md` step 1 surfaces truncation **before** the verdict: `ok:true` + `componentDirs: []` + `truncated: true` must read as "the budget ran out", never "this project has no components".

## Verified live

**dana-desktop**: now reports `src/desktop-ui/components` (157 files) and `dana-tokens.css`. Previously `0` and `0`.

`truncated` stays `true` at 5037 non-skipped entries (was 15,301). It is **not** tuned to false — the cap is a real bound and dana genuinely exceeds it. BFS's win is reaching `desktop-ui` before the budget dies, not making the repo fit.

**EaseUI** (evidence, not a gate): 4220 entries against a 4000 cap — 5% over, and it costs one of its two legitimate UI roots. Recorded for a future cap decision; 2/9 projects exceed the cap, so raising it to fit today's corpus would be tuning to the sample.

Four gates green, 1970 tests, no existing test broke — nothing was asserting the depth-first-shaped bug.

Spec: `specs/009-code-road/phase-02-the-honest-router.md`