### PR TITLE
feat(design-os): the road — /ui:learn onboards a real codebase (spec 009 P4)

### DIFF
--- a/specs/009-code-road/phase-04-the-road.md
+++ b/specs/009-code-road/phase-04-the-road.md
@@ -153,16 +153,30 @@ Per project, in `reports/p4-real-data-gate.md`:
 
 | | dana-desktop | traicaybentre | hvs |
 |---|---|---|---|
-| `ui scan` → UI found? truncated? | | | |
-| tokens compiled (primitive / semantic / modes) | | | |
-| components registered | | | |
-| `ds status` exit | | | |
-| `ds context --strict --with-theme` exit | | | |
-| **what the road got wrong** | | | |
+| `ui scan` → UI found? truncated? | `src/desktop-ui/components` found (157 files); `truncated:true`, `visited:4000/4000` | `src/components` found (27 files); `truncated:true`, `visited:2967` | `components/ui` (3 files) + `docs/product/hvs-design-system/components` (23 files) found; `truncated:false`, `visited:464` |
+| tokens compiled (primitive / semantic / modes) | 186 / 228 / 3 (dark, classic, light) — 15 unverified (fonts/shadows/transitions, composite) | 17 / 0 / 0 — 2 unverified | 13 / 7 / 0 — 7 unverified (fonts/easing/shadows, composite) |
+| components registered | 1 (`Control/Button`) | 1 (`Social/ShareButtons`) | 1 (`Control/LocationSelector`) |
+| `ds status` exit | 0 (generation 1→2) | 0 (generation 1→2) | 0 (generation 1→2) |
+| `ds context --strict --with-theme` exit | 0 | 0 | 0 |
+| **what the road got wrong** | see below — the `BAD_TOKEN` finding (applies to all three) | most components are one-off marketing sections, not variant-prop primitives — D1/D2 only had one real candidate (`ShareButtons`'s `placement` prop) in 27 files | `docs/product/hvs-design-system/` is a stale demo/preview tree with its own `ButtonPrimary.css` etc. — a less careful read could mistake it for the real DS instead of `app/globals.css` |
+
+**The one thing the road got wrong (all three projects, same root cause):** `ui registry
+register`'s `BAD_TOKEN` (`registry-store.ts`, `TOKEN_PATTERN`) validates only that a `--tokens`
+value matches `^[a-z][a-z0-9.-]*$` — it does **not** check the value against the project's
+compiled token set. `color.this-token-does-not-exist-anywhere` registers successfully (verified
+live, isolated from all three project runs). This phase's own Key Insight 6 and hard constraints
+describe `BAD_TOKEN` as refusing "any invented token" — that is not what the code does today; it
+refuses malformed *syntax*, not an *invented path*. Per the "never touch `validateComponentRecord`'s
+strictness" constraint this was not changed here — reported per Art V/Insight 7, not patched.
+See `reports/p4-real-data-gate.md` for the full reproduction and discussion.
 
 Plus, verbatim: **one component record the road produced**, and **one thing it got wrong** —
 or "none", but look. Also run **EaseUI** (no root `package.json`, 2 UI roots, 4220 entries vs a
-4000 cap) and report; not a gate condition.
+4000 cap) and report; not a gate condition. **Result**: `framework: null` (no root
+`package.json` to detect one — confirmed), `truncated:true` at exactly `visited:4000`
+(the cap), `componentDirs` surfaced `app/src/components/ui` (12 files) but not a second
+root under `frontpage/` (that tree's `components/` dir has no `ui`/`widgets`/`components`-named
+subfolder within the walk budget) — full detail in `reports/p4-real-data-gate.md`.
 
 ## Success Criteria
 

--- a/specs/009-code-road/phase-04-the-road.md
+++ b/specs/009-code-road/phase-04-the-road.md
@@ -158,17 +158,23 @@ Per project, in `reports/p4-real-data-gate.md`:
 | components registered | 1 (`Control/Button`) | 1 (`Social/ShareButtons`) | 1 (`Control/LocationSelector`) |
 | `ds status` exit | 0 (generation 1→2) | 0 (generation 1→2) | 0 (generation 1→2) |
 | `ds context --strict --with-theme` exit | 0 | 0 | 0 |
-| **what the road got wrong** | see below — the `BAD_TOKEN` finding (applies to all three) | most components are one-off marketing sections, not variant-prop primitives — D1/D2 only had one real candidate (`ShareButtons`'s `placement` prop) in 27 files | `docs/product/hvs-design-system/` is a stale demo/preview tree with its own `ButtonPrimary.css` etc. — a less careful read could mistake it for the real DS instead of `app/globals.css` |
+| **what the road got wrong** | see below — the `BAD_TOKEN` finding, **since fixed** (applies to all three) | most components are one-off marketing sections, not variant-prop primitives — D1/D2 only had one real candidate (`ShareButtons`'s `placement` prop) in 27 files | `docs/product/hvs-design-system/` is a stale demo/preview tree with its own `ButtonPrimary.css` etc. — flagged as a P2 `project-scan.ts` follow-up, not fixed here |
 
-**The one thing the road got wrong (all three projects, same root cause):** `ui registry
-register`'s `BAD_TOKEN` (`registry-store.ts`, `TOKEN_PATTERN`) validates only that a `--tokens`
-value matches `^[a-z][a-z0-9.-]*$` — it does **not** check the value against the project's
-compiled token set. `color.this-token-does-not-exist-anywhere` registers successfully (verified
-live, isolated from all three project runs). This phase's own Key Insight 6 and hard constraints
-describe `BAD_TOKEN` as refusing "any invented token" — that is not what the code does today; it
-refuses malformed *syntax*, not an *invented path*. Per the "never touch `validateComponentRecord`'s
-strictness" constraint this was not changed here — reported per Art V/Insight 7, not patched.
-See `reports/p4-real-data-gate.md` for the full reproduction and discussion.
+**The one thing the road got wrong (all three projects, same root cause) — FIXED in this phase:**
+`ui registry register`'s `BAD_TOKEN` (`registry-store.ts`, `TOKEN_PATTERN`) validated only that a
+`--tokens` value matched `^[a-z][a-z0-9.-]*$` — it did **not** check the value against the
+project's compiled token set. `color.this-token-does-not-exist-anywhere` registered successfully
+(verified live, isolated from all three project runs). The original phase briefing's Key Insight
+6 and hard constraints described `BAD_TOKEN` as refusing "any invented token" — that was a
+misread of the code (owner-confirmed), not what the code did. **Owner decision: fix it, reusing
+P1's `loadDesignSystemForReseal` (Art IV)** — new small module `src/core/registry-token-check.ts`
+(`assertTokensExist`) called once from `registry.ts`'s existing Save step: DS present → every
+`tokensUsed` path must resolve in the compiled tree (two-level `category.name`, base-mode
+resolution only — modes are `$extensions` on a token, not separate tokens); no DS (standalone
+`--file` registry) → format-only, unchanged. `registry.ts` stays at 330/330. Re-ran the
+three-project gate after the fix — **all three real components still pass**; the stricter check
+changed nothing about them because every `tokensUsed` entry was genuinely traced, not invented.
+See `reports/p4-real-data-gate.md` §3 addendum for the full reproduction, fix, and re-verification.
 
 Plus, verbatim: **one component record the road produced**, and **one thing it got wrong** —
 or "none", but look. Also run **EaseUI** (no root `package.json`, 2 UI roots, 4220 entries vs a

--- a/specs/009-code-road/reports/p4-real-data-gate.md
+++ b/specs/009-code-road/reports/p4-real-data-gate.md
@@ -1,0 +1,236 @@
+# P4 — The road: real-data gate (Art III)
+
+Executor: Sonnet. Branch `spec009/p4-the-road` off `spec009/p3-vocabulary`.
+
+This is the evidence artifact for spec 009 Phase 4. It reports what changed, then the
+end-to-end run on three real projects chosen for spread, plus a non-gating EaseUI run.
+
+---
+
+## 1. What changed (the four edits)
+
+1. **D5** — `templates/workflows/extract.md` Inputs now accept **either** a single HTML
+   artifact **or** the 3–5 sampled source files `learn.md` §3a already mandates for a code
+   project. Step 1 ("Read the source") now has an explicit "Code input" branch. This was the
+   one sentence that made the road unreachable for every code project (Key Insight 1).
+2. **D3** — `states` is confirmed dead in this session's own live data too (0/1 registered
+   records across all three projects populate it — see §2). `src/core/registry-store.ts` adds
+   `statesToVariants()`; `src/commands/registry.ts`'s `runRegister` now folds `--states` values
+   into `--variants` as `State=<PascalCase>` instead of writing the record's own `states` field.
+   The flag's enum validation (`BAD_STATE`) is unchanged — verified live (see §3, the invalid-state
+   probe). `extract.md` and `learn.md` §3b say plainly that the doctrine described a field the
+   system never adopted.
+3. **D1/D2/D4** — `learn.md`'s Code route gained a real "Step 3d — Component record shape for a
+   code source" section: one record per component (D1), axis names taken verbatim from the
+   source's own prop names (D2), markup as an HTML specimen sheet traced to real source class
+   strings, never rendered (D4). All three live registrations below follow it.
+4. **`learn.md`'s code route** — was one line into `extract.md`; now states the three
+   code-specific decisions extract.md's generic steps do not derive on their own (see step 3d
+   text). The CSS-custom-properties branch (P3's C0 path) and the plain-extract branch both now
+   point at it instead of a bare "register the component" instruction.
+
+`registry.ts`: 324/330 lines (a dedupe helper for the repeated `RegistryError`→`CommandResult`
+catch pattern paid for the states/variants merge without growing the file). Four gates green,
+`npm test` 135 files / 2046 tests passed, `ui knowledge check` clean — all confirmed before this
+report was written.
+
+---
+
+## 2. The gate — three real projects, chosen for spread
+
+All three copied to a scratch dir first (`rsync -a --exclude node_modules --exclude .git
+--exclude dist ...`); nothing was written into the originals. dana-desktop's copy had a
+pre-existing `design/` from an earlier dogfood session (visible in
+`~/.claude/.../memory/`'s own history) — deleted from the *copy only* so the gate ran against
+UC-06's actual precondition ("clean checkout, no `design/`").
+
+| | dana-desktop | traicaybentre | hvs |
+|---|---|---|---|
+| `ui scan` → UI found? truncated? | `src/desktop-ui/components` (157 files); `truncated:true`, `visited:4000/4000` | `src/components` (27 files); `truncated:true`, `visited:2967` | `components/ui` (3) + `docs/product/hvs-design-system/components` (23); `truncated:false`, `visited:464` |
+| tokens compiled (primitive / semantic / modes) | 186 / 228 / 3 (`mode.dark`, `mode.classic`, `mode.light`) — 15 unverified | 17 / 0 / 0 — 2 unverified | 13 / 7 / 0 — 7 unverified |
+| unverified examples | `--font-mono`, `--shadow-lg`, `--transition-fast` (composite/unmappable — correctly excluded, not GUESS-filled) | 2 composite values | `--font-display`, `--hvs-ease`, `--shadow-brand` (composite) |
+| components registered | 1 — `Control/Button` | 1 — `Social/ShareButtons` | 1 — `Control/LocationSelector` |
+| `ds status --json` exit | **0** (generation 1 → 2 after register) | **0** (generation 1 → 2) | **0** (generation 1 → 2) |
+| `ds context --strict --with-theme` exit | **0** | **0** | **0** |
+| what the road got wrong (project-specific) | see §3 — the `BAD_TOKEN` finding, discovered here | most of the 27 components are one-off marketing sections (`hero-section.tsx`, `footer.tsx`, …), not variant-prop primitives — only one real D1/D2 candidate (`ShareButtons`'s `placement` prop) surfaced in the whole sampled set | `docs/product/hvs-design-system/` is a stale demo/preview tree with its own component CSS (`ButtonPrimary.css`, forced `.state-hover`/`.state-active` classes) sitting right next to the real `app/globals.css` — a less careful read could learn the demo instead of the product |
+
+**learn.md's own quality gate — the phase's success criterion — is satisfied on all three:**
+*"when the source was code, ≥1 component is registered"* (true, ×3) **and** *"`ds status` must
+exit 0"* (true, ×3). Per Key Insight/UC-06 this pair of sentences could not both be true on
+`main` before this phase.
+
+### Component discovery notes
+
+- **dana-desktop**: `src/desktop-ui/components/Button.tsx` — a genuine variant-prop primitive
+  (`variant`/`size`/`radius`, 8×3×3). This is the project the spec's own decisions (D1–D4) were
+  derived from, so it is the closest to a confirming run rather than an independent test — the
+  other two projects are the real test of generality.
+- **traicaybentre**: mostly a Next.js marketing site — `src/components/` holds section
+  components (`hero-section.tsx`, `faq-section.tsx`, `footer.tsx`, …) with no variant props at
+  all. `share-buttons.tsx` was the one component with a real source-declared prop axis
+  (`placement?: "top" | "bottom"`). This is itself informative: `extract.md` step 2's aim of
+  "5–30 candidates... weighted toward what the user actually reuses" assumes a component-library
+  style codebase; a marketing site's reusable surface is thin. The registry ends with 1 correct
+  record rather than a strained one.
+- **hvs**: `components/ui/pill-group.tsx` had an *interaction* state (selected/idle) but no
+  named prop for it — D2 explicitly requires the axis name to come from the source's own prop,
+  and there is no such prop here, so it was skipped in favor of `location-selector.tsx`, which
+  declares a real `variant?: "default" | "compact"` prop.
+- Both `traicaybentre` and `hvs` have `.claude/worktrees/*` subdirectories containing duplicate
+  copies of the whole tree (13 in traicaybentre, 3 in hvs). `ui scan`'s `SKIP_DIRS` already
+  excludes `.claude` (`project-scan.ts:58`), so this did **not** distort the live scan results
+  above — but it likely explains why this phase's own project descriptions ("999 components,
+  340 css" for traicaybentre; "4 tailwind configs" for hvs) look much larger than the single
+  real tree (traicaybentre: 64 `.tsx`/`.jsx` files under `src/`, 1 real `globals.css`; hvs: 1
+  real `tailwind.config.ts` outside `.claude/`). Not a defect in this phase's work — just a
+  methodology note for whoever re-measures a real-project survey count in the future: exclude
+  `.claude/worktrees/` or count will overstate genuine surface area.
+
+---
+
+## 3. One thing the road got wrong (verbatim reproduction)
+
+**`ui registry register`'s `BAD_TOKEN` does not check that a `--tokens` value resolves against
+the project's compiled token set — only that it matches the path-format regex.**
+
+This phase's own spec (Key Insight 6, and the "HARD CONSTRAINTS" briefing this executor received)
+states: *"`BAD_TOKEN` (`registry-store.ts:167`) refusing an invented token is this phase's entire
+safety story... Do not weaken it."* The live run surprised this expectation (Key Insight 7:
+"suspect the assertion before the code"):
+
+```
+$ ui registry register "Probe/Invented" --category action --markup control-button.html \
+    --tokens "color.this-token-does-not-exist-anywhere" --file bad-token-probe-registry.json --json
+{
+  "ok": true,
+  "data": { "component": { "name": "Probe/Invented", "tokensUsed": ["color.this-token-does-not-exist-anywhere"], ... } }
+}
+```
+
+Exit 0. No refusal. Reading `src/core/registry-store.ts`'s `validateComponentRecord`:
+
+```ts
+for (const t of r["tokensUsed"] as unknown[]) {
+    if (typeof t !== "string" || !TOKEN_PATTERN.test(t)) {
+      throw new RegistryError("BAD_TOKEN", `invalid token path '${String(t)}' — must match ^[a-z][a-z0-9.-]*$ ...`);
+    }
+}
+```
+
+`TOKEN_PATTERN = /^[a-z][a-z0-9.-]*$/` is a **syntax** check — lowercase, dot/hyphen-separated —
+with no knowledge of what the project actually compiled. `color.this-token-does-not-exist-anywhere`
+satisfies the regex, so it is accepted. The existing test that was meant to cover this
+(`tests/cmd-registry.test.ts`, *"refusing a bad token leaves the seal intact"*) only ever probed
+`"NOT A VALID TOKEN"` — uppercase, with spaces — which fails the *regex*, not an existence check.
+That test is real and still passes; it was simply never asked the question this phase's own
+safety claim depends on. This is exactly the shape of Key Insight 7's warning: a green test can
+certify the wrong property.
+
+**Disposition**: not fixed in this phase. The task's hard constraints explicitly say never to
+touch `validateComponentRecord`'s strictness, and an existence-check against the compiled token
+set is a real design decision (what counts as "the compiled set" — base mode only? every mode?
+does it need the tokens file path threaded through `registry.ts`, which currently never reads
+tokens at all?) that deserves its own resolved decision, not an improvisation inside this report.
+Reported per Art V / this spec's own "STOP AND REPORT" precedent (P1's line-budget lie, P2's
+Gherkin wish, P3's naming rule) rather than patched. **The road still worked in all three
+live runs above** because the host model (this session) traced every `tokensUsed` entry to a
+real compiled path by hand, as D4 requires — the gap is that the kernel does not yet enforce
+what the doctrine assumes it enforces.
+
+---
+
+## 4. Verbatim: one component record the road produced
+
+`ui registry lookup "Control/Button" --file design/component-registry.json --json` on the
+dana-desktop copy, after the live run in §2:
+
+```json
+{
+  "name": "Control/Button",
+  "category": "action",
+  "tokensUsed": [
+    "color.color-accent-strong",
+    "color.color-on-accent",
+    "color.color-danger-strong",
+    "color.color-on-danger",
+    "dimension.text-caption",
+    "dimension.text-control"
+  ],
+  "variants": [
+    "Variant=Primary", "Variant=Blue", "Variant=AccentSoft", "Variant=Secondary",
+    "Variant=Outline", "Variant=Ghost", "Variant=Danger", "Variant=Link",
+    "Size=Xs", "Size=Sm", "Size=Md",
+    "Radius=Sm", "Radius=Lg", "Radius=None",
+    "State=Hover", "State=Focus", "State=Disabled"
+  ],
+  "description": "Dana's primary button primitive: 8 variants x 3 sizes x 3 radii, plus loading/icon slots",
+  "scope": "local"
+}
+```
+
+(`markup` omitted here for length — 5,616 chars, the HTML specimen sheet built from
+`Button.tsx`'s `variantClasses`/`sizeClasses`/`radiusClasses` maps verbatim; see
+`templates/workflows/learn.md` step 3d for the rule that produced it.) Notes on this record
+against the phase's own decisions:
+
+- **D1 held**: one record, not 72 (8 variants × 3 sizes × 3 radii).
+- **D2 held**: `Variant=`, `Size=`, `Radius=` are dana's own prop names (`variant`, `size`,
+  `radius`), PascalCased — not renamed to a house term.
+- **D3 held live**: `--states hover,focus,disabled` produced `State=Hover`, `State=Focus`,
+  `State=Disabled` inside `variants`; the record has **no** `states` key at all (confirmed by
+  its absence above — `validateComponentRecord` only emits the field when present in the raw
+  input, and `runRegister` never sets it any more).
+- **`color.color-accent-strong`** (not `color.accent-strong`) is **not** a bug — it is spec 009
+  P3's own D6 (`css-token-ingest.ts:29-38`): dana's `index.css` declares `--color-accent-strong`
+  literally (a Tailwind `@theme` re-export of the bare `--gray-*` scale), so the verbatim leaf
+  keeps the source's own name. Checked this before treating it as a finding — it is expected P3
+  behaviour, not a new defect.
+
+---
+
+## 5. EaseUI (not a gate condition — evidence for a later decision)
+
+```
+$ ui scan --cwd EaseUI --json
+framework: null
+tailwindConfig: "app/tailwind.config.js"
+componentDirs: [{"path": "app/src/components/ui", "files": 12}]
+dsStatus: "none"  verdict: "brownfield-code"
+truncated: true   visited: 4000
+```
+
+- **`framework: null`** confirmed — no root `package.json` (`app/package.json`,
+  `frontpage/app/package.json`, `figma-plugin/package.json`, `ebook/package.json` all exist as
+  nested manifests; the scanner's framework detection reads only the root).
+- **`truncated: true` at exactly `visited: 4000`** — the walk hit `MAX_ENTRIES` and reported it
+  honestly (`ok:true`, non-empty `componentDirs`, `truncated:true` — the correct combination per
+  UC-02, not the "empty + false" failure mode).
+- **Only one of the two legitimate UI roots surfaced in `componentDirs`.** `cssFiles` shows BFS
+  did reach both `app/src/app/globals.css` and `frontpage/app/src/app/globals.css`, so the
+  `frontpage/` subtree was walked — but `frontpage/app/src/components/` contains only an
+  `icons/` subfolder, not a `ui`/`widgets`/`components`-named directory with ≥3 code files
+  (`project-scan.ts`'s `COMPONENT_DIR_NAMES` + `directCode >= 3` gate), so nothing under
+  `frontpage/` qualified as a `componentDirs` entry within the budget. This is not a truncation
+  artifact in this specific case — the directory shape genuinely does not match — but on a
+  larger monorepo the same "found the CSS, missed the component root" split could recur from
+  truncation alone. Worth a future decision (`usecases.md` §7 Q2 is exactly this open question);
+  not resolved here per this phase's scope (D6/UC-06 names only the three gate projects).
+
+---
+
+## Status
+
+**Status:** DONE
+**Summary:** D5 (dual-input `extract.md`), D3 (`--states` → `variants` via `statesToVariants`),
+and D1/D2/D4 (learn.md's real code route) implemented; four gates + 2046 tests + `ui knowledge
+check` green. Gate ran end-to-end on dana-desktop, traicaybentre, hvs (copies) — all three:
+≥1 component registered, `ds status` exit 0, `ds context --strict --with-theme` exit 0.
+`learn.md`'s own quality gate is satisfiable on real code for the first time. EaseUI run reported
+as evidence (not gating). One real finding: `registry register`'s `BAD_TOKEN` is a path-format
+check, not an existence check against the compiled token set — reported, not patched (see §3).
+**Concerns/Blockers:** The BAD_TOKEN gap (§3) is a real safety-story shortfall this phase
+discovered but was constrained from fixing (touching `validateComponentRecord`'s strictness was
+explicitly out of scope). Recommend a follow-up decision: should `registry register` read the
+project's compiled tokens and refuse a path that doesn't resolve? That needs its own resolved
+design (which mode(s) count, how `registry.ts` gets the tokens file without growing past its
+line budget) rather than being improvised inside this phase.

--- a/specs/009-code-road/reports/p4-real-data-gate.md
+++ b/specs/009-code-road/reports/p4-real-data-gate.md
@@ -29,10 +29,12 @@ end-to-end run on three real projects chosen for spread, plus a non-gating EaseU
    text). The CSS-custom-properties branch (P3's C0 path) and the plain-extract branch both now
    point at it instead of a bare "register the component" instruction.
 
-`registry.ts`: 324/330 lines (a dedupe helper for the repeated `RegistryError`→`CommandResult`
-catch pattern paid for the states/variants merge without growing the file). Four gates green,
-`npm test` 135 files / 2046 tests passed, `ui knowledge check` clean — all confirmed before this
-report was written.
+5. **BAD_TOKEN existence check** (owner-correction, added after the first pass of this report —
+   see §3's addendum) — `src/core/registry-token-check.ts` (new, small module) + one call site
+   in `registry.ts`'s Save step. `registry.ts`: **330/330 lines exactly** (a dedupe helper for
+   the repeated `RegistryError`→`CommandResult` catch pattern paid for the states/variants merge
+   *and* this addition without growing past budget). Four gates green, `npm test` 136 files /
+   2056 tests passed, `ui knowledge check` clean — all confirmed before this report was written.
 
 ---
 
@@ -52,7 +54,7 @@ UC-06's actual precondition ("clean checkout, no `design/`").
 | components registered | 1 — `Control/Button` | 1 — `Social/ShareButtons` | 1 — `Control/LocationSelector` |
 | `ds status --json` exit | **0** (generation 1 → 2 after register) | **0** (generation 1 → 2) | **0** (generation 1 → 2) |
 | `ds context --strict --with-theme` exit | **0** | **0** | **0** |
-| what the road got wrong (project-specific) | see §3 — the `BAD_TOKEN` finding, discovered here | most of the 27 components are one-off marketing sections (`hero-section.tsx`, `footer.tsx`, …), not variant-prop primitives — only one real D1/D2 candidate (`ShareButtons`'s `placement` prop) surfaced in the whole sampled set | `docs/product/hvs-design-system/` is a stale demo/preview tree with its own component CSS (`ButtonPrimary.css`, forced `.state-hover`/`.state-active` classes) sitting right next to the real `app/globals.css` — a less careful read could learn the demo instead of the product |
+| what the road got wrong (project-specific) | see §3 — the `BAD_TOKEN` finding, discovered here, since fixed (addendum) | most of the 27 components are one-off marketing sections (`hero-section.tsx`, `footer.tsx`, …), not variant-prop primitives — only one real D1/D2 candidate (`ShareButtons`'s `placement` prop) surfaced in the whole sampled set | `docs/product/hvs-design-system/` is a stale demo/preview tree with its own component CSS (`ButtonPrimary.css`, forced `.state-hover`/`.state-active` classes) sitting right next to the real `app/globals.css` — a less careful read could learn the demo instead of the product. **Not this phase's fix** — flagged for P2's `project-scan.ts` (see below) |
 
 **learn.md's own quality gate — the phase's success criterion — is satisfied on all three:**
 *"when the source was code, ≥1 component is registered"* (true, ×3) **and** *"`ds status` must
@@ -76,6 +78,20 @@ exit 0"* (true, ×3). Per Key Insight/UC-06 this pair of sentences could not bot
   named prop for it — D2 explicitly requires the axis name to come from the source's own prop,
   and there is no such prop here, so it was skipped in favor of `location-selector.tsx`, which
   declares a real `variant?: "default" | "compact"` prop.
+  - **Follow-up flagged, NOT fixed here** (owner's call): `docs/product/hvs-design-system/` — a
+    stale demo/preview tree, 7× bigger than the real `components/ui` — is real and valuable, but
+    the owner counted the corpus before this report proposed a general "detect stale/demo trees"
+    class and found no such class is warranted:
+    ```
+    docs      3/11 · 95 UI files → hvs(48) EaseUI(43) gravityhive(4)
+    examples  1/11 ·  3 files    → VSF-PCP(3)
+    demo · demos · preview · playground · sandbox · storybook · fixtures · .bak · -old · deprecated → 0
+    ```
+    Every plausible name pattern is zero except `docs/`. The honest, narrow rule is **"the
+    product's UI does not live under `docs/`"** — one more `SKIP_DIRS` entry, the same shape as
+    P2's `.venv` fix (`project-scan.ts:58-59`). `project-scan.ts` is P2's file and P2 is already
+    in review (#78) — **not this phase's file to touch.** Recorded here as the follow-up per the
+    owner's instruction, with the counts above; left undone.
 - Both `traicaybentre` and `hvs` have `.claude/worktrees/*` subdirectories containing duplicate
   copies of the whole tree (13 in traicaybentre, 3 in hvs). `ui scan`'s `SKIP_DIRS` already
   excludes `.claude` (`project-scan.ts:58`), so this did **not** distort the live scan results
@@ -126,16 +142,67 @@ That test is real and still passes; it was simply never asked the question this 
 safety claim depends on. This is exactly the shape of Key Insight 7's warning: a green test can
 certify the wrong property.
 
-**Disposition**: not fixed in this phase. The task's hard constraints explicitly say never to
-touch `validateComponentRecord`'s strictness, and an existence-check against the compiled token
-set is a real design decision (what counts as "the compiled set" — base mode only? every mode?
-does it need the tokens file path threaded through `registry.ts`, which currently never reads
-tokens at all?) that deserves its own resolved decision, not an improvisation inside this report.
-Reported per Art V / this spec's own "STOP AND REPORT" precedent (P1's line-budget lie, P2's
-Gherkin wish, P3's naming rule) rather than patched. **The road still worked in all three
-live runs above** because the host model (this session) traced every `tokensUsed` entry to a
-real compiled path by hand, as D4 requires — the gap is that the kernel does not yet enforce
-what the doctrine assumes it enforces.
+**Disposition (original)**: not fixed at first pass. The task's hard constraints as given said
+never to touch `validateComponentRecord`'s strictness, so this was reported per Art V / this
+spec's own "STOP AND REPORT" precedent (P1's line-budget lie, P2's Gherkin wish, P3's naming
+rule) rather than patched.
+
+### Addendum — owner-corrected and fixed in this phase
+
+The owner re-verified the finding live, confirmed the misread was in the ORIGINAL phase
+briefing (Key Insight 6 / the "never weaken it" constraint were both written believing
+`BAD_TOKEN` already checked existence), and made the call: **P4 closes it**, reusing P1's
+existing shape rather than inventing one (Art IV).
+
+- **New module `src/core/registry-token-check.ts`** (kept out of `registry.ts` — the file was
+  already at budget): `tokenExistsInTree(tokens, path)` — two-level `category.name` lookup,
+  the same convention `ds-change-token-impl.ts` already enforces; `assertTokensExist(tokensUsed,
+  tokens)` — no-op when `tokens` is `undefined` (the standalone-registry case, e.g.
+  `ingest-figma-ds`'s `--file` target — format-only, unchanged), else throws `RegistryError`
+  `BAD_TOKEN` on the first path that does not resolve, with a message that says **"does not
+  exist"**, never "must match" — the two failures now read differently. Modes are `$extensions`
+  ON a token, not tokens of their own, so resolving in the base tree is the whole test — the
+  "which modes count?" question in the original disposition dissolves.
+- **`registry.ts`** — `runRegister`'s existing Save step already calls
+  `loadDesignSystemForReseal(dsPaths)` once (P1); it now also calls `assertTokensExist(record.
+  tokensUsed, ds?.tokens)` there, before deciding reseal vs. plain save, so a refusal happens
+  before any write. No second DS load, no growth beyond budget: **330/330 lines exactly.**
+- **Verified live** (isolated probe, not touching a gate project): with a sealed DS present,
+  `--tokens color.color-accent-strong,color.totally-invented-xyz` now refuses —
+
+  ```
+  {"ok": false, "error": {"code": "BAD_TOKEN",
+    "message": "token 'color.totally-invented-xyz' does not exist in the compiled design
+      system — the path is well-formed but unknown, not malformed. Check 'ui ds context
+      --format json' for a real path."}}
+  ```
+
+  registry file byte-unchanged after the refusal. The original standalone-registry probe
+  (`--file` with no manifest) still accepts the same invented path, unchanged — confirmed with
+  a dedicated test (`tests/cmd-registry.test.ts`).
+- **Re-ran the three-project gate against the fix** (owner's instruction: if a real component
+  now fails, that is a finding to report, not a reason to relax the check). Re-registered all
+  three components verbatim (`--force`) under the corrected binary:
+
+  | | dana-desktop `Control/Button` | traicaybentre `Social/ShareButtons` | hvs `Control/LocationSelector` |
+  |---|---|---|---|
+  | register exit under the fix | **0** | **0** | **0** |
+  | `ds status` exit after | **0** (generation 3) | **0** (generation 3) | **0** (generation 3) |
+  | `ds context --strict --with-theme` exit | **0** | **0** | **0** |
+
+  **All three real components still pass.** No relaxation was needed — every `tokensUsed` entry
+  traced in §2/§4 was a genuinely real compiled path, so the stricter check changes nothing
+  about the three gate results; it only closes the hole a fabricated path could have used.
+- **Tests**: `tests/registry-token-check.test.ts` (new, pure unit tests over an in-memory
+  `TokenTree`) pins `tokenExistsInTree`/`assertTokensExist`. `tests/cmd-registry.test.ts` gained
+  three CLI-level cases in the "sealed DS integration" block: the invented-token refusal with
+  the distinct message, a genuinely-resolving token being accepted, and the standalone-registry
+  path still being format-only. `tests/registry-store.test.ts`'s test was reworded from
+  "documents a known gap" to "pins that `validateComponentRecord` is format-only **by design**"
+  — it was never the gap; `registry.ts` calling it plus the new module together are the fix.
+
+**Current status**: closed. `registry register`'s existence check (DS present) + format check
+(always) together are what P4's Key Insight 6 originally described.
 
 ---
 
@@ -222,15 +289,16 @@ truncated: true   visited: 4000
 
 **Status:** DONE
 **Summary:** D5 (dual-input `extract.md`), D3 (`--states` → `variants` via `statesToVariants`),
-and D1/D2/D4 (learn.md's real code route) implemented; four gates + 2046 tests + `ui knowledge
-check` green. Gate ran end-to-end on dana-desktop, traicaybentre, hvs (copies) — all three:
-≥1 component registered, `ds status` exit 0, `ds context --strict --with-theme` exit 0.
-`learn.md`'s own quality gate is satisfiable on real code for the first time. EaseUI run reported
-as evidence (not gating). One real finding: `registry register`'s `BAD_TOKEN` is a path-format
-check, not an existence check against the compiled token set — reported, not patched (see §3).
-**Concerns/Blockers:** The BAD_TOKEN gap (§3) is a real safety-story shortfall this phase
-discovered but was constrained from fixing (touching `validateComponentRecord`'s strictness was
-explicitly out of scope). Recommend a follow-up decision: should `registry register` read the
-project's compiled tokens and refuse a path that doesn't resolve? That needs its own resolved
-design (which mode(s) count, how `registry.ts` gets the tokens file without growing past its
-line budget) rather than being improvised inside this phase.
+D1/D2/D4 (learn.md's real code route), **and the BAD_TOKEN existence check** (owner-corrected
+follow-up, `registry-token-check.ts`) all implemented; four gates + 2056 tests + `ui knowledge
+check` green; `registry.ts` at 330/330 lines exactly. Gate ran end-to-end on dana-desktop,
+traicaybentre, hvs (copies), **then re-ran after the BAD_TOKEN fix** — all three, both times:
+≥1 component registered, `ds status` exit 0, `ds context --strict --with-theme` exit 0, and no
+real component was relaxed-for by the stricter check. `learn.md`'s own quality gate is
+satisfiable on real code for the first time. EaseUI run reported as evidence (not gating). The
+`docs/`-as-demo-tree observation is recorded as a follow-up for P2's `project-scan.ts` (§2, with
+the owner's corpus counts) and deliberately left undone — not this phase's file.
+**Concerns/Blockers:** none outstanding for this phase. The BAD_TOKEN gap is closed (see §3
+addendum) and re-verified live against all three gate projects with no regression. The
+`docs/` `SKIP_DIRS` follow-up is explicitly deferred to P2 (#78), per the owner's instruction —
+not a blocker on this phase, just an open item for whoever picks up P2 next.

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -22,6 +22,7 @@ import {
   registerComponent,
   lookupComponent,
   listComponents,
+  statesToVariants,
 } from "../core/registry-store.js";
 import { pathsForDir } from "../core/design-system.js";
 import { reseal, loadDesignSystemForReseal } from "../core/ds-reseal.js";
@@ -57,6 +58,8 @@ Token paths:
 
 States enum:
   default, hover, active, focus, disabled
+  (each observed state folds into --variants as "State=<PascalCase>" — e.g.
+  "hover" -> "State=Hover"; the record's own "states" field is never written)
 
 Error codes:
   BAD_ARG            Missing subcommand, positional, or required flag
@@ -94,6 +97,12 @@ function splitComma(raw: string | undefined): string[] {
   return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
 }
 
+/** Convert a caught RegistryError into a CommandResult; rethrow anything else. */
+function asResult(useJson: boolean, sub: string, e: unknown): CommandResult {
+  if (e instanceof RegistryError) return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
+  throw e;
+}
+
 // ─── Subcommand: register ─────────────────────────────────────────────────────
 
 function runRegister(parsed: ParsedArgs): CommandResult {
@@ -128,10 +137,17 @@ function runRegister(parsed: ParsedArgs): CommandResult {
   try {
     markup = readMarkup(markupArg);
   } catch (e) {
-    if (e instanceof RegistryError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
-    }
-    throw e;
+    return asResult(useJson, sub, e);
+  }
+
+  // --variants + --states merge (spec 009 D3): a `State=X` entry per observed state folds
+  // into `variants`; the record's `states` field is never populated (statesToVariants
+  // throws BAD_STATE on an enum miss, same contract --states always had).
+  let variants: string[];
+  try {
+    variants = [...splitComma(flagString(parsed, "variants")), ...statesToVariants(splitComma(flagString(parsed, "states")))];
+  } catch (e) {
+    return asResult(useJson, sub, e);
   }
 
   // Build + validate record
@@ -140,12 +156,7 @@ function runRegister(parsed: ParsedArgs): CommandResult {
     category,
     markup,
     tokensUsed: splitComma(flagString(parsed, "tokens")),
-    ...(flagString(parsed, "variants") !== undefined && {
-      variants: splitComma(flagString(parsed, "variants")),
-    }),
-    ...(flagString(parsed, "states") !== undefined && {
-      states: splitComma(flagString(parsed, "states")),
-    }),
+    ...(variants.length > 0 && { variants }),
     ...(flagString(parsed, "description") !== undefined && {
       description: flagString(parsed, "description"),
     }),
@@ -155,10 +166,7 @@ function runRegister(parsed: ParsedArgs): CommandResult {
   try {
     record = validateComponentRecord(rawRecord);
   } catch (e) {
-    if (e instanceof RegistryError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
-    }
-    throw e;
+    return asResult(useJson, sub, e);
   }
 
   // Load or create registry
@@ -168,10 +176,8 @@ function runRegister(parsed: ParsedArgs): CommandResult {
   } catch (e) {
     if (e instanceof RegistryError && e.code === "REGISTRY_NOT_FOUND") {
       reg = createEmptyRegistry();
-    } else if (e instanceof RegistryError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
     } else {
-      throw e;
+      return asResult(useJson, sub, e);
     }
   }
 
@@ -180,10 +186,7 @@ function runRegister(parsed: ParsedArgs): CommandResult {
   try {
     result = registerComponent(reg, record, force);
   } catch (e) {
-    if (e instanceof RegistryError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
-    }
-    throw e;
+    return asResult(useJson, sub, e);
   }
 
   // Save — reseal on a sealed DS, else the plain unsealed write (spec 009 P1).
@@ -237,10 +240,7 @@ function runLookup(parsed: ParsedArgs): CommandResult {
   try {
     reg = loadRegistry(registryPath);
   } catch (e) {
-    if (e instanceof RegistryError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
-    }
-    throw e;
+    return asResult(useJson, sub, e);
   }
 
   const component = lookupComponent(reg, name);
@@ -272,10 +272,7 @@ function runList(parsed: ParsedArgs): CommandResult {
   try {
     reg = loadRegistry(registryPath);
   } catch (e) {
-    if (e instanceof RegistryError) {
-      return useJson ? errJson(sub, e.code, e.message) : errText(`ui: ${e.message}\n`);
-    }
-    throw e;
+    return asResult(useJson, sub, e);
   }
 
   const components = listComponents(reg, categoryFilter);

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -26,6 +26,7 @@ import {
 } from "../core/registry-store.js";
 import { pathsForDir } from "../core/design-system.js";
 import { reseal, loadDesignSystemForReseal } from "../core/ds-reseal.js";
+import { assertTokensExist } from "../core/registry-token-check.js";
 
 const CMD = "registry";
 const DEFAULT_REGISTRY_PATH = "./design/component-registry.json";
@@ -65,7 +66,7 @@ Error codes:
   BAD_ARG            Missing subcommand, positional, or required flag
   BAD_NAME           Name does not match Category/Variant pattern
   BAD_STATE          A --states value not in the enum
-  BAD_TOKEN          A --tokens value fails the token-path pattern
+  BAD_TOKEN          Bad --tokens format, OR (DS present) unresolvable path — distinct msgs
   NAME_EXISTS        register of existing name without --force
   NOT_FOUND          lookup of absent name
   FILE_NOT_FOUND     --markup file does not exist
@@ -189,10 +190,13 @@ function runRegister(parsed: ParsedArgs): CommandResult {
     return asResult(useJson, sub, e);
   }
 
-  // Save — reseal on a sealed DS, else the plain unsealed write (spec 009 P1).
+  // Save — reseal on a sealed DS, else the plain unsealed write (spec 009 P1). DS present ->
+  // tokensUsed must also resolve in its compiled tree, not just match the format regex
+  // (spec 009 P4 owner-correction — BAD_TOKEN was format-only; see registry-token-check.ts).
   const dsPaths = pathsForDir(dirname(registryPath));
   try {
     const ds = loadDesignSystemForReseal(dsPaths);
+    assertTokensExist(record.tokensUsed, ds?.tokens);
     if (ds !== undefined) {
       reseal({
         ds, paths: dsPaths, registry: result.registry, nowIso: new Date().toISOString(),

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -307,7 +307,7 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
           { name: "markup", type: "string", required: true, summary: "Markup source file, or '-' for stdin" },
           { name: "tokens", type: "string", summary: "Comma-separated token paths the component uses" },
           { name: "variants", type: "string", summary: "Comma-separated variant names" },
-          { name: "states", type: "string", values: ["default", "hover", "active", "focus", "disabled"], summary: "Comma-separated states (each from the enum)" },
+          { name: "states", type: "string", values: ["default", "hover", "active", "focus", "disabled"], summary: "Comma-separated states (each from the enum); folded into --variants as State=X, not into the record's own states field" },
           { name: "description", type: "string", summary: "Free-text component description" },
           { name: "force", type: "boolean", summary: "Overwrite an existing component" },
           { name: "file", type: "string", summary: "Registry file path (default ./design/component-registry.json)" },

--- a/src/core/registry-store.ts
+++ b/src/core/registry-store.ts
@@ -75,6 +75,29 @@ const NAME_PATTERN = /^[A-Z][A-Za-z]+\/[A-Z][A-Za-z]+$/;
 const TOKEN_PATTERN = /^[a-z][a-z0-9.-]*$/;
 const VALID_STATES = new Set<string>(["default", "hover", "active", "focus", "disabled"]);
 
+/**
+ * `--states` → `State=X` variant entries (spec 009 D3).
+ *
+ * The record's `states` field is dead: 0/537 populated in platform-design-system, 0/27 in
+ * the `ds init` kit. The only place it was ever mandated was the workflow doctrine
+ * (`extract.md`, `learn.md` §3b) — no emitter ever wrote it. States travel as `State=X`
+ * inside `variants`, kit-identical to `Tone=`/`Size=`. `--states` keeps validating against
+ * the same enum (a scripted caller's contract does not change) but its values now land
+ * here instead of in `states`.
+ * @throws RegistryError("BAD_STATE") on a value outside the enum.
+ */
+export function statesToVariants(states: string[]): string[] {
+  return states.map((s) => {
+    if (!VALID_STATES.has(s)) {
+      throw new RegistryError(
+        "BAD_STATE",
+        `invalid state '${s}' — must be one of: default, hover, active, focus, disabled`,
+      );
+    }
+    return `State=${s.charAt(0).toUpperCase()}${s.slice(1)}`;
+  });
+}
+
 /** Keys permitted at the registry root object (mirrors schema additionalProperties:false). */
 const REGISTRY_ROOT_KEYS = new Set(["version", "components"]);
 

--- a/src/core/registry-token-check.ts
+++ b/src/core/registry-token-check.ts
@@ -1,0 +1,45 @@
+/**
+ * `tokensUsed` EXISTENCE check (spec 009 P4, owner-correction) — Art IV: fixed at the
+ * shared layer registry.ts already imports (ds-reseal.ts's loadDesignSystemForReseal),
+ * not invented fresh.
+ *
+ * `registry-store.ts`'s `TOKEN_PATTERN` only ever checked *format*
+ * (`^[a-z][a-z0-9.-]*$`) — a real live run registered `color.this-token-does-not-exist-
+ * anywhere` with no refusal (`reports/p4-real-data-gate.md` §3). This module is the
+ * existence half: when a sealed DS is present, every `tokensUsed` path must resolve in its
+ * compiled tree. Two-level schema (`category.name`), the same convention
+ * `ds-change-token-impl.ts` already enforces. Modes live as `$extensions` ON a token, not
+ * as tokens of their own, so resolving in the base tree (no mode-branching) is the whole
+ * test — a token that exists only under a mode does not exist as a *different* path.
+ *
+ * A standalone registry (no manifest next to it — e.g. `ingest-figma-ds`'s `--file`
+ * target) has no tree to check against: format-only, unchanged, same as before this fix.
+ */
+import { RegistryError } from "./registry-store.js";
+import type { TokenTree } from "./token-model.js";
+
+/** True if `path` (e.g. `"color.primary"`) resolves to a real leaf in `tokens`. */
+export function tokenExistsInTree(tokens: TokenTree, path: string): boolean {
+  const dot = path.indexOf(".");
+  if (dot === -1) return false;
+  return tokens[path.slice(0, dot)]?.[path.slice(dot + 1)] !== undefined;
+}
+
+/**
+ * Refuse the first `tokensUsed` entry that does not resolve in `tokens`. No-op when
+ * `tokens` is `undefined` (no DS to check against — format-only, per the module doc).
+ * @throws RegistryError("BAD_TOKEN") — message says "does not exist", never "malformed":
+ * that failure already surfaced from `TOKEN_PATTERN` before this runs.
+ */
+export function assertTokensExist(tokensUsed: readonly string[], tokens: TokenTree | undefined): void {
+  if (tokens === undefined) return;
+  for (const path of tokensUsed) {
+    if (!tokenExistsInTree(tokens, path)) {
+      throw new RegistryError(
+        "BAD_TOKEN",
+        `token '${path}' does not exist in the compiled design system — the path is well-formed ` +
+          "but unknown, not malformed. Check 'ui ds context --format json' for a real path.",
+      );
+    }
+  }
+}

--- a/templates/workflows/extract.md
+++ b/templates/workflows/extract.md
@@ -6,8 +6,10 @@ description: "Extract a design system from existing HTML. Use when the user prov
 
 ## Title
 
-`/ui:extract <file.html>` — **extract a design system from existing HTML**. Read
-a single HTML artifact, infer its underlying design language (tokens + reusable
+`/ui:extract <file.html>` — **extract a design system from existing HTML or
+source code**. Read a single HTML artifact — or the 3–5 representative source
+files a code project supplies (component files + stylesheets, sampled per
+`learn.md` §3a) — infer its underlying design language (tokens + reusable
 components), and write that language back into the project's design-system
 store as a real, enforceable SSOT.
 
@@ -25,6 +27,9 @@ Use `/ui:extract` when:
 - The project has no DS yet — `/ui:extract` will compile a brand-new one.
 - The project has a DS but the user wants to *replace* it with one derived
   from the supplied HTML (explicit `--force` on `ui ds init` step 4).
+- The project is a **code repo** (React/Vue/Svelte/etc.) with no representative
+  HTML file — `/ui:learn`'s code route (`learn.md` step 3) samples 3–5 source
+  files and hands them here directly (spec 009 P4, D5).
 
 ---
 
@@ -32,7 +37,7 @@ Use `/ui:extract` when:
 
 | Input | Source | Required | Notes |
 |---|---|---|---|
-| `<file.html>` | path argument | yes | A single HTML artifact. Multi-file extraction is out of scope for v1; if the user has multiple HTML files, ask them to pick the most representative one. |
+| `<file.html>` **or** 3–5 source files | path argument(s) | yes | **Either** a single HTML artifact **or** the 3–5 representative source files `learn.md` §3a already samples for a code project (component files + their paired stylesheets). Everything from step 1 on reads the input as one or more files to walk together — there is no HTML-only restriction downstream (spec 009 P4, D5: this row was the sentence that closed the road to every code project). |
 | Project DS state | `design/ds.manifest.json` (via `ui ds status`) | yes | Determines whether step 4 calls `ui ds init` fresh or `ui ds init --force` to replace an existing system. |
 | Token taxonomy | `knowledge/token-taxonomy.md` | yes | Defines the DTCG primitive / semantic two-tier model the extracted tokens must conform to. |
 | Color science | `knowledge/color-science.md` | yes | Defines how to bucket observed hex values into the 11-stop OKLCH scale and how to map them to semantic roles. |
@@ -43,12 +48,21 @@ Use `/ui:extract` when:
 
 ## Steps
 
-### 1. Read the source HTML
+### 1. Read the source
 
-Load `<file.html>` from disk. Hold the full markup in working memory. If the
-file exceeds ~80k characters, strip runs of base64 image data before analysis
-(they tell you nothing about tokens or components). Do not strip CSS, classes,
-or inline style attributes — those are the extraction signal.
+**HTML input**: Load `<file.html>` from disk. Hold the full markup in working
+memory. If the file exceeds ~80k characters, strip runs of base64 image data
+before analysis (they tell you nothing about tokens or components). Do not
+strip CSS, classes, or inline style attributes — those are the extraction
+signal.
+
+**Code input** (3–5 sampled source files, per `learn.md` §3a and its code-route
+decisions D1/D2/D4): load every sampled file — component source
+(`.tsx`/`.jsx`/`.vue`/`.svelte`) and its paired stylesheet — and hold them all
+in working memory together. Steps 2–9 below treat "the document" as the union
+of every sampled file; a class string or component export repeated across
+files is the same repetition signal step 2 already looks for inside one HTML
+page.
 
 ### 2. Discover candidate components
 
@@ -175,7 +189,12 @@ config for `:hover`, `:focus`, `:focus-visible`, and `:active` rules, plus every
 `transition` and `animation` / `@keyframes` declaration. For each component you
 register (step 8), pass the subset you *actually observed* to
 `ui registry register … --states <observed>` — only states with evidence, never
-a fabricated one. Separately, distil the motion signature into a one-line
+a fabricated one. **The kernel folds each observed state into `variants` as
+`State=<PascalCase>` (e.g. `State=Hover`); the record's separate `states` field
+stays unset** (spec 009 D3 — measured 0/537 populated in platform-design-system
+and 0/27 in the `ds init` kit, so the doctrine here now describes where states
+actually live instead of a field no emitter ever wrote). Separately, distil the
+motion signature into a one-line
 **Motion identity** note in the summary (e.g. "150ms ease-out hovers, 2px lift
 on cards, no entrance animation") — it is the interaction fingerprint later
 generation must match. Where the source has no observable interaction states
@@ -333,7 +352,9 @@ Where:
   variation if any).
 - `--states` is the subset of `{default, hover, active, focus, disabled}`
   observed in the source. Static HTML usually only shows `default`; record
-  what you see, don't fabricate.
+  what you see, don't fabricate. The flag still validates against this enum,
+  but each value now lands in `variants` as `State=<PascalCase>` — not in the
+  record's `states` field, which the kernel leaves unset (spec 009 D3).
 
 The registry file is auto-created on the first `register` if it doesn't
 already exist (step 6 created an empty one via `ui ds init`).

--- a/templates/workflows/learn.md
+++ b/templates/workflows/learn.md
@@ -121,8 +121,9 @@ Follow the flow for the chosen source; **do not** restate its steps here.
        and documented, exactly like the Figma C0 path above.
     4. Continue to step 3a for component sampling — the vocabulary is done;
        only components still need `extract.md`'s registration steps
-       (`templates/workflows/extract.md` step 8 onward), not its token steps
-       (4–7, which this C0 path replaces for the values it could extract).
+       (`templates/workflows/extract.md` step 8 onward, driven by **step 3d**'s
+       record-shape rules below), not its token steps (4–7, which this C0 path
+       replaces for the values it could extract).
     - **Record, don't fix:** if the same primitive family is duplicated
       per-theme as parallel hardcoded ramps instead of one semantic layer over
       shared primitives (`knowledge/token-taxonomy.md`'s named DON'T), note it
@@ -130,7 +131,9 @@ Follow the flow for the chosen source; **do not** restate its steps here.
   - **No CSS custom properties** (pure Tailwind utility classes, inline
     styles, CSS-in-JS with no `--*` declarations) → the C0 compiler has
     nothing to read. Follow `templates/workflows/extract.md` against the
-    representative files chosen in step 3a instead.
+    representative files chosen in step 3a instead — its Inputs accept this
+    sampled set directly (spec 009 D5) — and apply **step 3d**'s record-shape
+    rules when registering each component.
 - **URL** → follow `templates/workflows/from-url.md` with the user's URL.
 - **Figma** → branch on what the target IS:
   - **A design SYSTEM / library** (the user points at a file whose value is its
@@ -201,6 +204,12 @@ Harvest interaction states (`:hover` / `:focus` / `:active`) and motion
 Motion identity note — following the **"Interaction-state evidence"** section of
 `templates/workflows/extract.md` (canonical). Register only states you actually
 observed via `ui registry register … --states <observed>`; never invent one.
+**The `states` field on a registry record is dead** — measured 0/537 populated
+in platform-design-system and 0/27 in the `ds init` kit; the only place it was
+ever mandated was this doctrine. `--states` still takes the same comma list and
+still refuses an unobserved or invalid value, but the kernel now folds each one
+into `variants` as `State=<PascalCase>` (kit-identical to `Tone=`/`Size=`) and
+leaves `states` unset (spec 009 D3).
 
 #### Step 3c — Evidence grade (SOURCE-grade only)
 
@@ -208,6 +217,44 @@ Admit only values that trace to deterministic extraction; a value the model
 merely remembers or infers is GUESS-grade — exclude it and list it under
 "unverified". Apply the **"Evidence grade"** section of
 `templates/workflows/extract.md` (canonical); `/ui:learn` adds no separate rule.
+
+#### Step 3d — Component record shape for a code source (D1/D2/D4)
+
+A code source needs three decisions an HTML page never raises, and they are
+RESOLVED — do not re-derive them (spec 009 D1/D2/D4, from measuring dana +
+platform-design-system + the `ds init` kit):
+
+1. **One record per component, not per variant** (D1). A component's variant ×
+   size × radius matrix is **one** registry entry — dana's `Button` (8 tones ×
+   3 sizes × 3 radii = 72 combinations) is `Control/Button`, not 72 records.
+   The matrix lives inside that one record's `variants` array. Name it
+   `Category/Component` (`registry-store.ts:74`'s `NAME_PATTERN`,
+   PascalCase/PascalCase) — code-authored components are exactly what that
+   pattern exists for, per `figma-ds-registry.ts:9-14`'s own header (Figma
+   inventory is a *different* door, by design; never route a code component
+   through it).
+2. **Axis names are the source's own prop names, PascalCased** (D2). If the
+   component declares a prop literally named `variant`, the axis is
+   `Variant=` (`variant="primary"` → `Variant=Primary`); a `size` prop is
+   `Size=`. Do **not** re-interpret a prop name into a house term — dana's
+   `variant` stays `Variant`, it never becomes `Tone`. If a prop name collides
+   with `State` (step 3b), the source's own name wins; record the collision
+   in the summary.
+3. **`markup` is an HTML specimen sheet traced to real class strings** (D4).
+   HTML is the design (owner decree, 2026-07-17): `/ui:generate` emits
+   self-contained HTML and does not know frameworks exist — developers port
+   it. A specimen sheet (kit-style: a wrapper + rows showing the variant
+   matrix) is the honest equivalent for a code source, with one hard rule:
+   every cell must trace to a class string the source actually declares —
+   dana's `variantClasses.primary` in `Button.tsx` is right there, copy it
+   verbatim. A cell you cannot trace, you do not draw; list it under
+   "unverified" (step 3c). **Never render the component** to obtain markup —
+   no jsdom, no testing-library, no dev server, even though dana has the
+   toolchain to do exactly that — rendering a user's code is a No-Go
+   (`brainstorm.md` §7).
+
+With these three settled, `extract.md`'s steps 2–3 (discovery + canonical
+naming) and step 8 (register) run unchanged against the sampled files.
 
 ### Step 4 — Compile and verify
 
@@ -253,13 +300,15 @@ Emit a compact readiness report in exactly this shape:
 
 ```
 ✓ learned from <source> (<n> files sampled)
-✓ design system: <k> tokens · <m> components registered (<s> with states) · persona <slug>
+✓ design system: <k> tokens · <m> components registered (<s> with observed states) · persona <slug>
 → try: /ui:generate "<suggested intent from the product's domain>"
 ```
 
 Derive the counts from `ui ds context --format json` and `ui registry list
 --json`; draw the suggested intent from the product's own domain (inferred from
-the sampled content), not a generic example.
+the sampled content), not a generic example. `<s>` counts records whose
+`variants` array contains a `State=*` entry (spec 009 D3) — **not** the
+record's own `states` field, which stays unset.
 
 ## Outputs
 

--- a/tests/cmd-registry.test.ts
+++ b/tests/cmd-registry.test.ts
@@ -312,6 +312,57 @@ describe("ui registry register — sealed DS integration (spec 009 P1)", () => {
     expect(readFileSync(registryPath, "utf8")).toBe(before);
     expect(() => loadDesignSystem(pathsForDir(join(tmp, "design")))).not.toThrow();
   });
+
+  // spec 009 P4 owner-correction: BAD_TOKEN was format-only (reports/p4-real-data-gate.md
+  // §3) — a well-formed but INVENTED path registered cleanly. registry.ts now also checks
+  // existence against the loaded DS's compiled tree (registry-token-check.ts) before saving.
+  it("a well-formed but nonexistent token is refused when a DS is present — existence, not format", () => {
+    const tmp = initDs();
+    const registryPath = join(tmp, "design", "component-registry.json");
+    const before = readFileSync(registryPath, "utf8");
+    const r = captureRun([
+      "registry", "register", "Button/Primary",
+      "--category", "action", "--markup", fix("registry-markup.html"),
+      "--tokens", "color.this-token-does-not-exist-anywhere",
+      "--file", registryPath, "--json",
+    ]);
+    expect(r.code).toBe(1);
+    const json = JSON.parse(r.out) as { error: { code: string; message: string } };
+    expect(json.error.code).toBe("BAD_TOKEN");
+    // Distinct message from the format failure above — "does not exist", never "must match".
+    expect(json.error.message).toMatch(/does not exist/);
+    expect(json.error.message).not.toMatch(/must match/);
+    expect(readFileSync(registryPath, "utf8")).toBe(before);
+  });
+
+  it("a token that genuinely resolves in the compiled DS is accepted", () => {
+    const tmp = initDs();
+    const registryPath = join(tmp, "design", "component-registry.json");
+    const ds = loadDesignSystem(pathsForDir(join(tmp, "design")));
+    const category = Object.keys(ds.tokens)[0]!;
+    const name = Object.keys(ds.tokens[category]!)[0]!;
+    const realPath = `${category}.${name}`;
+    const r = captureRun([
+      "registry", "register", "Button/Primary",
+      "--category", "action", "--markup", fix("registry-markup.html"),
+      "--tokens", realPath,
+      "--file", registryPath, "--json",
+    ]);
+    expect(r.code).toBe(0);
+    const json = JSON.parse(r.out) as { data: { component: { tokensUsed: string[] } } };
+    expect(json.data.component.tokensUsed).toEqual([realPath]);
+  });
+
+  it("a standalone registry (no DS next to --file) still accepts a nonexistent-but-well-formed token — format-only, unchanged", () => {
+    const p = tmpPath();
+    const r = captureRun([
+      "registry", "register", "Button/Primary",
+      "--category", "action", "--markup", fix("registry-markup.html"),
+      "--tokens", "color.this-token-does-not-exist-anywhere",
+      "--file", p, "--json",
+    ]);
+    expect(r.code).toBe(0);
+  });
 });
 
 // ─── lookup ───────────────────────────────────────────────────────────────────

--- a/tests/cmd-registry.test.ts
+++ b/tests/cmd-registry.test.ts
@@ -184,6 +184,77 @@ describe("ui registry register", () => {
 
 });
 
+// ─── register — --states folds into --variants, not the dead `states` field ───
+// (spec 009 P4, D3: 0/537 platform-design-system + 0/27 kit records ever populated
+// `states`; it lives as `State=X` inside `variants`, kit-identical to Tone=/Size=.)
+
+describe("ui registry register — --states → variants (spec 009 D3)", () => {
+  it("test_states_flag_writes_state_axes_into_variants", () => {
+    const p = tmpPath();
+    const { code, out } = captureRun([
+      "registry", "register", "Button/Primary",
+      "--category", "action",
+      "--markup", fix("registry-markup.html"),
+      "--states", "hover,focus",
+      "--file", p, "--json",
+    ]);
+    expect(code).toBe(0);
+    const json = JSON.parse(out) as {
+      data: { component: { variants?: string[]; states?: string[] } };
+    };
+    expect(json.data.component.variants).toEqual(["State=Hover", "State=Focus"]);
+    expect(json.data.component.states).toBeUndefined();
+  });
+
+  it("merges --variants and --states into one array, states appended after variants", () => {
+    const p = tmpPath();
+    const { out } = captureRun([
+      "registry", "register", "Button/Primary",
+      "--category", "action",
+      "--markup", fix("registry-markup.html"),
+      "--variants", "Variant=Primary,Size=Xs",
+      "--states", "default,active",
+      "--file", p, "--json",
+    ]);
+    const json = JSON.parse(out) as { data: { component: { variants?: string[] } } };
+    expect(json.data.component.variants).toEqual([
+      "Variant=Primary", "Size=Xs", "State=Default", "State=Active",
+    ]);
+  });
+
+  it("invalid --states value still refuses with BAD_STATE (enum unchanged)", () => {
+    const p = tmpPath();
+    const { code, out } = captureRun([
+      "registry", "register", "Button/Primary",
+      "--category", "action",
+      "--markup", fix("registry-markup.html"),
+      "--states", "smashed",
+      "--file", p, "--json",
+    ]);
+    expect(code).toBe(1);
+    const json = JSON.parse(out) as { error: { code: string } };
+    expect(json.error.code).toBe("BAD_STATE");
+    expect(existsSync(p)).toBe(false);
+  });
+
+  it("test_a_component_records_axes_from_its_own_prop_names (D2) — --variants passes source-named axes through verbatim, no reinterpretation", () => {
+    const p = tmpPath();
+    const { out } = captureRun([
+      "registry", "register", "Control/Button",
+      "--category", "action",
+      "--markup", fix("registry-markup.html"),
+      // dana's own prop name is literally "variant" — the axis must stay
+      // "Variant=", never rewritten to a house term like "Tone=".
+      "--variants", "Variant=Primary,Variant=AccentSoft,Size=Xs,Radius=Sm",
+      "--file", p, "--json",
+    ]);
+    const json = JSON.parse(out) as { data: { component: { variants?: string[] } } };
+    expect(json.data.component.variants).toEqual([
+      "Variant=Primary", "Variant=AccentSoft", "Size=Xs", "Radius=Sm",
+    ]);
+  });
+});
+
 // ─── register — sealed DS integration (spec 009 P1) ────────────────────────────
 
 describe("ui registry register — sealed DS integration (spec 009 P1)", () => {

--- a/tests/registry-store.test.ts
+++ b/tests/registry-store.test.ts
@@ -104,14 +104,13 @@ describe("validateComponentRecord", () => {
     ).toThrow(expect.objectContaining({ code: "BAD_STATE" }));
   });
 
-  // Spec 009 P4 real-data finding (reports/p4-real-data-gate.md §3): BAD_TOKEN checks the
-  // path's FORMAT only, not that it resolves against a compiled token set — a well-formed
-  // but nonexistent path is accepted. This test documents today's actual behaviour so a
-  // future change (in either direction — tightening to an existence check, or a regression
-  // that further loosens the format check) shows up as a diff here rather than silently.
-  // Do not "fix" this test to expect a throw without also resolving the design questions in
-  // §3 of that report (which mode(s) count, how the checker gets the compiled tokens).
-  it("a syntactically valid but nonexistent token path is NOT refused (known gap, P4 finding)", () => {
+  // validateComponentRecord is a pure function with no DS access — it can only ever check
+  // --tokens FORMAT (spec 009 P4 real-data finding, reports/p4-real-data-gate.md §3, fixed
+  // by the owner in the same phase: registry.ts now ALSO calls
+  // registry-token-check.ts's assertTokensExist against the loaded DS before saving —
+  // see tests/cmd-registry.test.ts's "sealed DS integration" describe block for that half).
+  // This test pins that this function's job stops at format, by design — it is not the gap.
+  it("accepts a syntactically valid token path regardless of whether it resolves anywhere (format-only, by design — see registry-token-check.ts for the existence half)", () => {
     const rec = validateComponentRecord(
       validRecord({ tokensUsed: ["color.this-token-does-not-exist-anywhere"] }),
     );

--- a/tests/registry-store.test.ts
+++ b/tests/registry-store.test.ts
@@ -104,6 +104,20 @@ describe("validateComponentRecord", () => {
     ).toThrow(expect.objectContaining({ code: "BAD_STATE" }));
   });
 
+  // Spec 009 P4 real-data finding (reports/p4-real-data-gate.md §3): BAD_TOKEN checks the
+  // path's FORMAT only, not that it resolves against a compiled token set — a well-formed
+  // but nonexistent path is accepted. This test documents today's actual behaviour so a
+  // future change (in either direction — tightening to an existence check, or a regression
+  // that further loosens the format check) shows up as a diff here rather than silently.
+  // Do not "fix" this test to expect a throw without also resolving the design questions in
+  // §3 of that report (which mode(s) count, how the checker gets the compiled tokens).
+  it("a syntactically valid but nonexistent token path is NOT refused (known gap, P4 finding)", () => {
+    const rec = validateComponentRecord(
+      validRecord({ tokensUsed: ["color.this-token-does-not-exist-anywhere"] }),
+    );
+    expect(rec.tokensUsed).toEqual(["color.this-token-does-not-exist-anywhere"]);
+  });
+
   it("throws BAD_ARG when name is missing", () => {
     expect(() => validateComponentRecord({ category: "action", markup: "", tokensUsed: [] })).toThrow(
       expect.objectContaining({ code: "BAD_ARG" }),

--- a/tests/registry-store.test.ts
+++ b/tests/registry-store.test.ts
@@ -10,6 +10,7 @@ import {
   registerComponent,
   lookupComponent,
   listComponents,
+  statesToVariants,
   RegistryError,
 } from "../src/core/registry-store.js";
 import type { ComponentRecord, Registry } from "../src/core/registry-store.js";
@@ -452,6 +453,34 @@ describe("listComponents", () => {
   it("does not mutate the original registry", () => {
     listComponents(reg, "action");
     expect(reg.components).toHaveLength(3);
+  });
+});
+
+// ─── statesToVariants (spec 009 D3) ────────────────────────────────────────────
+
+describe("statesToVariants", () => {
+  it("PascalCases each valid state into a State=X variant entry", () => {
+    expect(statesToVariants(["hover", "focus"])).toEqual(["State=Hover", "State=Focus"]);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(statesToVariants([])).toEqual([]);
+  });
+
+  it("covers the full enum", () => {
+    expect(statesToVariants(["default", "hover", "active", "focus", "disabled"])).toEqual([
+      "State=Default", "State=Hover", "State=Active", "State=Focus", "State=Disabled",
+    ]);
+  });
+
+  it("throws RegistryError('BAD_STATE') on a value outside the enum", () => {
+    expect(() => statesToVariants(["smashed"])).toThrow(RegistryError);
+    try {
+      statesToVariants(["smashed"]);
+    } catch (e) {
+      expect(e).toBeInstanceOf(RegistryError);
+      expect((e as RegistryError).code).toBe("BAD_STATE");
+    }
   });
 });
 

--- a/tests/registry-token-check.test.ts
+++ b/tests/registry-token-check.test.ts
@@ -1,0 +1,61 @@
+/**
+ * registry-token-check.ts — the existence half of BAD_TOKEN (spec 009 P4 owner-correction).
+ * Pure unit tests over an in-memory TokenTree; no filesystem, no CLI.
+ */
+import { describe, expect, it } from "vitest";
+import { tokenExistsInTree, assertTokensExist } from "../src/core/registry-token-check.js";
+import { RegistryError } from "../src/core/registry-store.js";
+import type { TokenTree } from "../src/core/token-model.js";
+
+const TREE: TokenTree = {
+  color: {
+    primary: { $value: "#000000", $type: "color" },
+    "accent-strong": { $value: "{color.primary}", $type: "color" },
+  },
+  dimension: {
+    "text-caption": { $value: "12px", $type: "dimension" },
+  },
+};
+
+describe("tokenExistsInTree", () => {
+  it("true for a real category.name path", () => {
+    expect(tokenExistsInTree(TREE, "color.primary")).toBe(true);
+    expect(tokenExistsInTree(TREE, "color.accent-strong")).toBe(true);
+    expect(tokenExistsInTree(TREE, "dimension.text-caption")).toBe(true);
+  });
+
+  it("false for a well-formed path that does not resolve", () => {
+    expect(tokenExistsInTree(TREE, "color.this-token-does-not-exist-anywhere")).toBe(false);
+    expect(tokenExistsInTree(TREE, "shadow.card")).toBe(false);
+  });
+
+  it("false for a path with no dot at all (structurally can't resolve)", () => {
+    expect(tokenExistsInTree(TREE, "color")).toBe(false);
+  });
+});
+
+describe("assertTokensExist", () => {
+  it("no-op (does not throw) when tokens is undefined — the standalone-registry case", () => {
+    expect(() =>
+      assertTokensExist(["color.anything-invented"], undefined),
+    ).not.toThrow();
+  });
+
+  it("does not throw when every path resolves", () => {
+    expect(() =>
+      assertTokensExist(["color.primary", "dimension.text-caption"], TREE),
+    ).not.toThrow();
+  });
+
+  it("throws RegistryError('BAD_TOKEN') naming the first unresolved path, message says 'does not exist'", () => {
+    try {
+      assertTokensExist(["color.primary", "color.invented-one"], TREE);
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RegistryError);
+      expect((e as RegistryError).code).toBe("BAD_TOKEN");
+      expect((e as RegistryError).message).toContain("color.invented-one");
+      expect((e as RegistryError).message).toMatch(/does not exist/);
+    }
+  });
+});

--- a/tests/workflow-doctrine.test.ts
+++ b/tests/workflow-doctrine.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Workflow doctrine checks — the Art II pairing for spec 009 D3.
+ *
+ * `states` on a ComponentRecord is a dead field: 0/537 populated in
+ * platform-design-system, 0/27 in the `ds init` kit. The only place it was ever
+ * mandated was workflow prose (`extract.md`, `learn.md`) telling the host model to
+ * populate `--states` as a first-class record field. This test is the check that
+ * fails if that doctrine regresses — a standard needs an emitter AND a linter
+ * (constitution Art II); `registry.ts`/`registry-store.ts` are the emitter side
+ * (`statesToVariants`), this is the linter side for the prose that could
+ * re-introduce the mandate.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const WORKFLOWS_DIR = join(REPO_ROOT, "templates", "workflows");
+
+/**
+ * A workflow "mandates" the dead field when it tells the host model to write a
+ * bare `states:` key onto a component record (the pre-D3 doctrine), as opposed
+ * to documenting that `--states` folds into `variants` as `State=X` (the
+ * corrected doctrine, which mentions "states" freely — this check only rejects
+ * the specific dead-field framing, not the word).
+ */
+const DEAD_FIELD_MANDATE = /\bstates\s*:\s*<|record'?s?\s+`?states`?\s+field\s+(?:is|must be)\s+populated|write\s+(?:a\s+)?`?states`?\s+field/i;
+
+describe("workflow doctrine — no workflow mandates the dead `states` field (spec 009 D3)", () => {
+  const files = readdirSync(WORKFLOWS_DIR).filter((f) => f.endsWith(".md"));
+
+  it("scans every templates/workflows/*.md file (sanity: extract.md and learn.md are present)", () => {
+    expect(files).toContain("extract.md");
+    expect(files).toContain("learn.md");
+  });
+
+  for (const file of files) {
+    it(`${file} does not mandate a bare 'states:' record field`, () => {
+      const content = readFileSync(join(WORKFLOWS_DIR, file), "utf8");
+      expect(DEAD_FIELD_MANDATE.test(content)).toBe(false);
+    });
+  }
+
+  it("extract.md documents that --states folds into variants as State=X, not the states field", () => {
+    const content = readFileSync(join(WORKFLOWS_DIR, "extract.md"), "utf8");
+    expect(content).toMatch(/State=<PascalCase>/);
+    expect(content).toMatch(/states.*field.*(?:unset|never)|(?:unset|never).*states.*field/is);
+  });
+
+  it("learn.md §3b documents the same correction", () => {
+    const content = readFileSync(join(WORKFLOWS_DIR, "learn.md"), "utf8");
+    expect(content).toMatch(/`states`\s+field on a registry record is dead/);
+  });
+});


### PR DESCRIPTION
The last phase of spec 009. The brownfield-code road opens, and it is proven on three real projects.

## The blocker was one sentence

`extract.md`'s Inputs read: *"A single HTML artifact. Multi-file extraction is out of scope for v1."* And `learn.md` routed **Code → extract.md**. A React app has no representative HTML — dana's only `.html` files are SPA shells. **The road had no valid input, by rule.** Everything else in this spec was plumbing that one rule made unreachable.

## What ships

- **D5** — `extract.md` accepts either one HTML artifact or the 3–5 sampled source files `learn.md` §3a already mandates.
- **D3** — `states` was a **dead field**: non-empty in **0/537** of platform-design-system's records and **0/27** of the `ds init` kit. Only the doctrine mandated it. `--states` now folds into `variants` as `State=X`. *The doctrine was describing a field the system never adopted.*
- **D1/D2** — one record per component (dana's Button = 8 tones × 3 sizes × 3 radii is **one** record, not 72); axis names verbatim from the source's own prop names (dana's prop is literally `variant` → `Variant=Primary`, never mapped to `Tone=`).
- **`learn.md`** gains a real code route.

## The gate — three real projects, on copies (Art III)

| | dana-desktop | traicaybentre | hvs |
|---|---|---|---|
| scan | `src/desktop-ui/components` (157) · truncated | `src/components` (27) · truncated | `components/ui` (3) **+ `docs/product/hvs-design-system/components` (23)** |
| registered | `Control/Button` | `Social/ShareButtons` | `Control/LocationSelector` |
| `ds status` / `ds context --strict` | exit 0 | exit 0 | exit 0 |

**`learn.md`'s own quality gate is satisfiable for the first time** — *"when the source was code, ≥1 component is registered"* **and** *"`ds status` must exit 0"* could not both be true on `main` before this spec.

### What the road got wrong — reported, not swept

- **traicaybentre**: 27 component files, but most are one-off marketing sections (`hero-section.tsx`, `footer.tsx`) — **only one had a real variant prop.** A marketing site has no component library to learn; the road assumes reusable primitives exist.
- **hvs**: `docs/product/hvs-design-system/` is a **stale demo tree with its own component CSS**, sitting next to the real `app/globals.css` — and it is **7× bigger** (23 files vs 3). Nothing distinguishes a product from its own stale demo. Follow-up measured and recorded: `docs` holds UI files in **3/11** projects (95 files: hvs 48, EaseUI 43, gravityhive 4) while `demo`/`demos`/`preview`/`playground`/`sandbox`/`storybook`/`fixtures`/`.bak`/`-old`/`deprecated` are **all zero**. So there is no "stale-tree" class to detect — the honest rule is *the product's UI does not live under `docs/`*, one more `SKIP_DIRS` entry. Left for a separate PR; `project-scan.ts` is #78's file.
- **EaseUI** (non-gating evidence): `framework: null` at root (62 nested `package.json`), truncated at the 4000 cap, only one of its two legitimate UI roots surfaced.

## The finding that mattered most — and the spec was wrong, not the code

**`BAD_TOKEN` only validated the token path's *format*, never its existence.** `--tokens color.this-token-does-not-exist-anywhere` registered cleanly, exit 0 — live-verified.

This spec's own text called `BAD_TOKEN` *"the whole safety story"* and *"what makes host-model-reads safe without a parser."* It rested on a check that did not exist: `TOKEN_PATTERN.test(t)` is a regex whose own error message says *"must match `^[a-z][a-z0-9.-]*$`"*. The constraint the phase file gave the implementer — *never touch `validateComponentRecord`'s strictness* — had been written to protect a misread.

The implementer **stopped and reported instead of improvising**, which is the only reason we know.

**Fixed here.** `registry-token-check.ts` (45 lines) reuses the `loadDesignSystemForReseal` call P1 already makes at `registry.ts:198` — one load, not two. DS present → every `tokensUsed` entry must resolve in the compiled tree, refused with a message that **distinguishes unknown from malformed**. No DS (standalone `--file`, what `ingest-figma-ds` writes) → format-only, as before. `registry.ts` at 330/330; the check is 2 lines at the call site.

**Re-ran the gate against the fix**: all three projects re-register cleanly. **No relaxation needed** — every `tokensUsed` entry in the original run was genuinely traced to the source. The model never invented one; the guard simply did not exist to prove it.

Four gates green, `ui knowledge check` clean, 136 files / 2056 tests.

Spec: `specs/009-code-road/phase-04-the-road.md` · Evidence: `specs/009-code-road/reports/p4-real-data-gate.md`