### PR TITLE
fix(scan): component discovery saw 25% of the corpus — three measured fixes

### DIFF
--- a/specs/009-code-road/reports/scan-discovery-fixes.md
+++ b/specs/009-code-road/reports/scan-discovery-fixes.md
@@ -1,0 +1,201 @@
+# scan-discovery-fixes — three measured fixes (fix/scan-discovery)
+
+Branch: `fix/scan-discovery` off `main` (worktree `agent-a68911a5f16a9b8fb`, base commit `26e2f99`).
+
+## Status: DONE
+
+## Four gates
+
+```
+npm run typecheck   → tsc --noEmit — clean
+npm run lint        → eslint src tests — clean
+npm run build       → tsup, ESM dist/cli.js 817.49 KB, success
+npm test             → vitest run: 136 test files passed (136), 2064 tests passed | 4 skipped (2068)
+ui knowledge check   → 0 findings
+```
+All green, re-verified after a stash/pop round-trip (used to capture the "before" numbers below) and one more full build+test+knowledge pass after restore.
+
+## Fix 1 — `COMPONENT_DIR_NAMES` ancestor rule
+
+`src/core/project-scan.ts`: the BFS walk (`walk()`) now carries two inherited
+flags per queue item — `hasComponentsAncestor` and `inTestTree` (new
+`WalkItem` interface). A dir qualifies (`>=3` direct `CODE_EXT` files) if
+`COMPONENT_DIR_NAMES.has(base) || hasComponentsAncestor`, and only outside a
+test tree (`TEST_DIR_NAMES = __tests__, __mocks__, test, tests, spec,
+stories`). `COMPONENT_DIR_NAMES` itself is untouched (`components`, `ui`,
+`widgets`) — the ancestor clause is additive, so `ui`/`widgets` still qualify
+standalone (no `components` ancestor required — tested explicitly), and a
+literal `components` dir still qualifies by name as before. `SKIP_DIRS`,
+`slice(0,5)`, `MAX_DEPTH`/`MAX_ENTRIES` values, verdict logic untouched.
+
+7 new tests added to `tests/cmd-scan.test.ts`: ancestor-qualifies-with-unlisted-name,
+two-levels-under-ancestor, no-ancestor-does-not-qualify, `__tests__` never
+qualifies, a `components` dir nested inside `__mocks__` still excluded,
+standalone `widgets` still qualifies by name alone.
+
+**widgets: still 0/9 on this corpus** (confirmed by running the four target
+scans below — no `widgets`-named dir appears in any of them). Recommend
+keeping it — it's a published contract from before this fix, not something
+this fix added, and it costs nothing to keep. Not removed.
+
+## Fix 2 — `truncated` = entry cap only
+
+`src/core/project-scan.ts` `walk()`: the depth-cap branch (`if (depth >
+MAX_DEPTH)`) now does `continue` only — it no longer sets `acc.truncated =
+true`. Only the two entry-cap check sites still set it. Header comment
+(`:1-22`) and the `ScanResult.truncated`/`componentDirs` field docstrings
+rewritten to state the new (and only intended) semantics. `MAX_DEPTH`/
+`MAX_ENTRIES` values unchanged.
+
+Updated `tests/cmd-scan.test.ts`'s
+`test_a_tree_over_max_depth_reports_truncated` → renamed
+`test_a_tree_over_max_depth_alone_does_NOT_report_truncated`, now asserts
+`truncated === false` for an 8-level-deep, low-entry-count tree (previously
+asserted `true` — that assertion was the bug, per the hard-won-rules "a test
+can enshrine the bug" lesson). Also asserts the buried file past depth 6 is
+still not counted — the depth cap still functions, it just isn't conflated
+with `truncated` anymore. Did not propose a second field for depth-truncation
+— per the task's instruction, flagging it here instead: **if a caller wants to
+know "was some branch skipped due to depth" as distinct machine-readable
+state, that's a new field, a separate decision — not added.**
+
+## Fix 3 — `ui ds status` warns on `imported-ds`
+
+`src/commands/ds-status-impl.ts`: added `IMPORTED_DS_DEFAULT_NAME =
+"imported-ds"` (must track `ds-import-impl.ts`'s literal default — noted in a
+comment) and `importedDsWarning(name)` → `null` or a message pointing at the
+reseal command. Added to both output paths:
+- JSON: new `warning: string | null` field in the `ds status --json` data
+  payload (additive, does not change exit code or any existing field).
+- Text: a `warning: ...` line prepended to stdout when present; no line when
+  absent (verified — "does not warn" test asserts `stdout` excludes
+  `"warning:"`).
+
+This is a **warning, not an error** — exit code unaffected either way; an
+existing `imported-ds` store keeps working exactly as before. 2 new tests in
+`tests/cmd-ds-status.test.ts`: one imports a real tokens.json with no
+`--name` (reproducing the actual default path) and asserts the warning fires
+in both JSON and text mode; one asserts a real-named store shows no warning
+in either mode.
+
+## Live verification (Art III) — read-only, verbatim
+
+### 1. `ui scan --cwd /Users/jang/Products/spaflow --json`
+```json
+"componentDirs": [
+  { "path": "src/components/admin", "files": 3 },
+  { "path": "src/components/dashboard", "files": 64 },
+  { "path": "src/components/landing", "files": 3 }
+],
+"truncated": false,
+"visited": 303
+```
+`dashboard` (64 files) now surfaces. `truncated` is `false`.
+
+### 2. `ui scan --cwd /Users/jang/Products/sodeal --json`
+```json
+"componentDirs": [
+  { "path": "components/ai", "files": 15 },
+  { "path": "components/dashboard", "files": 6 },
+  { "path": "components/deal", "files": 3 },
+  { "path": "components/icons", "files": 30 },
+  { "path": "components/landing", "files": 16 },
+  { "path": "components/layout", "files": 8 },
+  { "path": "components/ui", "files": 7 }
+],
+"truncated": false,
+"visited": 376
+```
+7 dirs / 85 files total — far more than the pre-fix 1 dir / 7 files.
+
+### 3. `ui scan --cwd /Users/jang/Products/EaseUI --json`
+```json
+"componentDirs": [ 13 dirs, incl. "app/src/components/editor":39, "app/src/components/icons":40, "app/src/components/settings":9, "app/src/components/tutorial":5, "app/src/components/ui":12, "frontpage/app/src/components/icons":39, ... ],
+"truncated": true,
+"visited": 4000
+```
+`truncated` stays `true` — 4000 entries visited (the entry cap), genuinely
+over. (Spec said 4220 total files on this project; the walk itself caps
+visits at 4000 by design, so `visited` reads 4000 exactly, as expected when
+entry-capped.)
+
+### 4. `ui scan --cwd /Users/jang/Products/traicaybentre --json`
+```json
+"componentDirs": [
+  { "path": "src/components", "files": 27 },
+  { "path": "src/components/product", "files": 5 },
+  { "path": "src/components/seo", "files": 4 }
+],
+"truncated": false,
+"visited": 2971
+```
+`truncated` flipped to `false` (2971 entries visited, under the 4000 cap) —
+**before this fix it was `true`** (confirmed by re-running against the
+unpatched code via `git stash`/`stash pop`), driven purely by the depth cap.
+Note: the spec stated 3054 entries; measured here is 2971 — a minor discrepancy,
+reported as found, not tuned to match.
+
+### 5. `ui ds status --dir /Users/jang/Products/VSF-PCP` (read-only, no writes)
+```json
+"name": "imported-ds",
+"generation": 1,
+"intent": "imported from /private/tmp/claude-501/-Users-jang-Products-VSF-PCP/902d9681-c59a-4f63-98d7-80b73b5d560b/scratchpad/flat-tokens.json",
+"warning": "manifest name is the 'ui ds import' default 'imported-ds' — agent identity (ui agents init) derives from this name. Reseal with an explicit --name: ui ds import <tokens.json> --dir <project> --name <slug> --force"
+```
+Confirms the live claim verbatim: `name: "imported-ds"`, `generation: 1`, and
+a dead absolute scratchpad path baked into `intent`. The warning now fires.
+Text mode (`ui ds status --dir ...`, no `--json`) prepends `warning: ...` as
+its own line before the existing summary — also verified, not shown twice
+here for brevity.
+
+## Before/after component-file counts (captured via `git stash`/`stash pop` — same tree, unpatched code)
+
+| project | before | after |
+|---|---|---|
+| spaflow | `componentDirs: []` (0 dirs, 0 files); `truncated: true` (depth-cap false positive) | 3 dirs, 70 files (`admin` 3 + `dashboard` 64 + `landing` 3); `truncated: false` |
+| sodeal | 1 dir, 7 files (`components/ui`) | 7 dirs, 85 files |
+| EaseUI | 1 dir, 12 files (`app/src/components/ui`) | 13 dirs, 174 files; `truncated: true` (unchanged — genuinely over entry cap both before and after) |
+| traicaybentre | 1 dir, 27 files (`src/components`); `truncated: true` (depth-cap false positive) | 3 dirs, 36 files (`src/components` 27 + `product` 5 + `seo` 4); `truncated: false` |
+
+Note spaflow's *before* row is itself a live instance of the Fix 2 bug: the
+tree is 303 entries (nowhere near the 4000 cap) but reported `truncated:
+true` purely because of depth — exactly the misdiagnosis pattern described
+in the task.
+
+## `widgets` — keep or drop?
+
+0/9 on the real corpus, confirmed again by these four live scans (no
+`widgets`-named dir surfaced anywhere). Recommend **keep** — per the task's
+own instruction ("removing it is a separate decision"), and because as an
+existing published contract its cost is zero (one entry in a `Set`) while a
+removal would be a silent behavior change for any project not in this
+corpus that does use that convention.
+
+## Where the given numbers didn't match measurement
+
+- **traicaybentre entries**: spec said 3054; measured 2971 both times (before
+  and after the fix — the file count itself didn't change, only which caps
+  fire). Reporting as found, not adjusted to match.
+- **EaseUI total files**: spec said 4220; `visited` reads exactly 4000
+  because that IS the entry cap — the scan cannot see past it by
+  construction, so this isn't a discrepancy, just what `visited` means when
+  capped.
+- Everything else (spaflow's per-dir counts, sodeal's before-state, VSF-PCP's
+  manifest fields) matched the spec's stated numbers exactly.
+
+## Unresolved / worth a second look
+
+- `src/core/project-scan.ts` is now 278 lines (was 233 before this task,
+  itself already over the constitution's Art IX ~200-line guidance). The task
+  scoped this as a narrow 3-fix patch and explicitly fenced off touching
+  `SKIP_DIRS`/`MAX_DEPTH`/`MAX_ENTRIES`/verdict/`slice(0,5)` — splitting the
+  walk into its own module felt like scope creep for a "measured fix"
+  commit and risks the Art I byte-identity guarantee if done carelessly.
+  Flagging rather than doing it unasked; can split `walk()`/`WalkItem`/the
+  ancestor logic into a `project-scan-walk.ts` helper in a follow-up if
+  wanted.
+- Fix 2's "propose, don't add" instruction: no second field added for
+  depth-truncation. If a caller needs to distinguish "entry-capped" from
+  "depth-capped-somewhere", that's a new `ScanResult` field (e.g.
+  `depthCapped: boolean`) — a design decision for the constitution owner, not
+  bundled into this fix.

--- a/src/commands/ds-status-impl.ts
+++ b/src/commands/ds-status-impl.ts
@@ -3,6 +3,13 @@
  *
  * Emits a compact manifest summary: name, generation, persona, token count,
  * component count, and hash values. Read-only; never modifies artifacts.
+ *
+ * Also enforces the onboard.md §4 naming-hygiene STOP-gate (previously prose
+ * only, checked by nothing — spec 009 fix-scan-discovery): `ui ds import`
+ * defaults `--name` to the literal string "imported-ds" when the caller omits
+ * it, and that string becomes the identity `ui agents init` names every
+ * generated agent after. A warning here, not a hard error — an existing store
+ * sealed with the default must keep working.
  */
 import { resolve } from "node:path";
 
@@ -23,6 +30,20 @@ const CMD = "ds status";
 
 /** Long flags `ui ds status` accepts (globals --help/--json handled separately). */
 const KNOWN_FLAGS = ["dir"] as const;
+
+// Must match ds-import-impl.ts's `name` default literal — the STOP-gate fires
+// when a manifest still carries it (onboard.md §4).
+const IMPORTED_DS_DEFAULT_NAME = "imported-ds";
+
+/** null when the manifest carries a real name; a warning string otherwise. */
+function importedDsWarning(name: string): string | null {
+  if (name !== IMPORTED_DS_DEFAULT_NAME) return null;
+  return (
+    `manifest name is the 'ui ds import' default '${IMPORTED_DS_DEFAULT_NAME}' — ` +
+    "agent identity (ui agents init) derives from this name. Reseal with an explicit " +
+    "--name: ui ds import <tokens.json> --dir <project> --name <slug> --force"
+  );
+}
 
 export function runStatus(parsed: ParsedArgs): CommandResult {
   const useJson = parsed.json;
@@ -70,6 +91,7 @@ export function runStatus(parsed: ParsedArgs): CommandResult {
     else statusBreakdown.unset++;
   }
   const anyStatus = statusBreakdown.stable + statusBreakdown.beta + statusBreakdown.draft > 0;
+  const warning = importedDsWarning(ds.manifest.name);
 
   if (useJson) {
     return okJson(CMD, {
@@ -83,6 +105,7 @@ export function runStatus(parsed: ParsedArgs): CommandResult {
       compiledHash: ds.manifest.compiledHash,
       registryHash: ds.manifest.registryHash,
       paths: ds.paths,
+      warning,
     });
   }
 
@@ -91,6 +114,7 @@ export function runStatus(parsed: ParsedArgs): CommandResult {
     ? ` (${statusBreakdown.stable} stable / ${statusBreakdown.beta} beta / ${statusBreakdown.draft} draft / ${statusBreakdown.unset} unset)`
     : "";
   return ok(
+    (warning !== null ? `warning: ${warning}\n` : "") +
     `ds: ${m.name} (gen ${m.generation})\n` +
     `persona: ${m.persona.slug} / ${m.persona.family}\n` +
     `intent:  ${m.intent}\n` +

--- a/src/core/project-scan.ts
+++ b/src/core/project-scan.ts
@@ -8,9 +8,17 @@
  * entries are visited in sorted (alphabetical) order. The walk itself is
  * breadth-first — a full level is visited before any one subtree is
  * descended into, so a shallow UI dir is found before an
- * alphabetically-earlier-but-deeper sibling can burn the entry cap. Either
- * cap (MAX_ENTRIES, MAX_DEPTH) sets `truncated: true` — never a silent
- * partial map reported as a complete one.
+ * alphabetically-earlier-but-deeper sibling can burn the entry cap.
+ *
+ * `truncated` reflects the ENTRY cap (MAX_ENTRIES) only. The DEPTH cap
+ * (MAX_DEPTH) stops descending one branch but never sets it: an entry-capped
+ * map is missing arbitrary things anywhere (the honest "do not trust this"
+ * signal); a depth-capped map is complete everywhere shallower than the cap —
+ * conflating the two made `truncated` mean "something, somewhere, was not
+ * visited", which is close enough to always-true to be useless (spec 009
+ * fix-scan-discovery: it caused a live misdiagnosis on spaflow — an agent read
+ * `truncated: true`, on a tree far under the entry cap, and built a wrong
+ * theory instead of noticing one route dir was 7 levels deep).
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, extname, join, relative, sep } from "node:path";
@@ -30,7 +38,7 @@ export interface ScanResult {
   cssFiles: Array<{ path: string; bytes: number }>;
   /** Top 5 .html files by size (same ordering). */
   htmlFiles: Array<{ path: string; bytes: number }>;
-  /** Dirs named components|ui|widgets with >=3 direct code files. */
+  /** Dirs with >=3 direct code files that are named components|ui|widgets, or sit under a "components" ancestor (outside any test tree). */
   componentDirs: Array<{ path: string; files: number }>;
   /** "./DESIGN.md" when present at the root, else null. */
   designMd: string | null;
@@ -38,7 +46,7 @@ export interface ScanResult {
   dsStatus: "none" | "present" | "tampered";
   /** Routing verdict derived from the signals above. */
   verdict: "greenfield" | "brownfield-code" | "brownfield-html" | "ds-present";
-  /** True when the walk hit MAX_ENTRIES or MAX_DEPTH and the map is therefore partial. */
+  /** True only when the walk hit MAX_ENTRIES — the map is missing arbitrary entries. The depth cap (MAX_DEPTH) never sets this; it only stops descending one branch. */
   truncated: boolean;
   /** Directory entries visited. Equals MAX_ENTRIES when truncated by the entry cap. */
   visited: number;
@@ -61,7 +69,20 @@ const SKIP_DIRS = new Set([
 const MAX_DEPTH = 6;
 const MAX_ENTRIES = 4000;
 const CODE_EXT = new Set([".tsx", ".jsx", ".vue", ".svelte", ".html"]);
+// Corpus-counted (9 real code projects), same discipline as SKIP_DIRS above:
+// name-only matching saw 375/1485 (25%) component files — every miss (dashboard
+// 73, icons 109, mdx 63, editor 43, marketing 28, settings 23, landing 19,
+// library 37, demos 35 …) sat under a "components" ancestor with an
+// unlisted name. A directory now also qualifies by ANCESTRY: >=3 direct code
+// files AND (own name in this set OR a "components" dir sits above it in the
+// walk) AND it is not inside a test tree (TEST_DIR_NAMES below) — measured at
+// 872/1485 (58%). "widgets" is 0/9 today (never fires on this corpus) but is
+// an existing published contract; kept, not removed, on that basis alone.
 const COMPONENT_DIR_NAMES = new Set(["components", "ui", "widgets"]);
+// Directories whose file counts are real but are not component inventory —
+// __tests__ alone measured 289 files across 2 projects, none of them a
+// component dir; counting by name without this guard over-collects.
+const TEST_DIR_NAMES = new Set(["__tests__", "__mocks__", "test", "tests", "spec", "stories"]);
 /** package.json dep names, checked in this priority order (next before react). */
 const FRAMEWORK_PRIORITY = ["next", "react", "vue", "svelte", "astro", "vite"];
 const TAILWIND_CONFIG_RE = /^tailwind\.config\.(js|ts|cjs|mjs)$/;
@@ -127,25 +148,44 @@ function sortedEntries(dir: string): Dirent[] {
   return entries;
 }
 
-// BFS: a queue of {dir, depth}. Within each level, entries keep sortedEntries'
+/** BFS queue item — carries the two ancestry flags a dir inherits from its parent. */
+interface WalkItem {
+  dir: string;
+  depth: number;
+  /** A "components"-named dir sits at or above this dir's parent. */
+  hasComponentsAncestor: boolean;
+  /** This dir's own name, or an ancestor's, is a TEST_DIR_NAMES entry. */
+  inTestTree: boolean;
+}
+
+// BFS: a queue of WalkItem. Within each level, entries keep sortedEntries'
 // alphabetical order (Art I — see header comment). Component-dir detection
 // happens as each dir is dequeued — the same check that ran depth-first before.
+// The entry cap (MAX_ENTRIES) sets `truncated`; the depth cap (MAX_DEPTH) only
+// stops descending that one branch — see header comment for why they differ.
 function walk(root: string, start: string, acc: WalkAccum): void {
-  const queue: Array<{ dir: string; depth: number }> = [{ dir: start, depth: 0 }];
+  const startBase = basename(start).toLowerCase();
+  const queue: WalkItem[] = [
+    { dir: start, depth: 0, hasComponentsAncestor: false, inTestTree: TEST_DIR_NAMES.has(startBase) },
+  ];
   while (queue.length > 0) {
     if (acc.visited >= MAX_ENTRIES) { acc.truncated = true; return; }
-    const { dir, depth } = queue.shift()!;
-    if (depth > MAX_DEPTH) { acc.truncated = true; continue; }
+    const { dir, depth, hasComponentsAncestor, inTestTree } = queue.shift()!;
+    if (depth > MAX_DEPTH) continue; // depth cap: skip this branch, map stays honest elsewhere
     const entries = sortedEntries(dir);
 
-    // >=3 direct code-file children in a components|ui|widgets dir qualifies it.
+    // >=3 direct code-file children qualifies a dir if its own name is
+    // components|ui|widgets, OR a "components" dir is one of its ancestors —
+    // unless it sits inside a test tree (see TEST_DIR_NAMES above).
     const base = basename(dir).toLowerCase();
-    if (COMPONENT_DIR_NAMES.has(base)) {
+    if (!inTestTree && (COMPONENT_DIR_NAMES.has(base) || hasComponentsAncestor)) {
       const directCode = entries.filter(
         (e) => e.isFile() && CODE_EXT.has(extname(e.name).toLowerCase()),
       ).length;
       if (directCode >= 3) acc.componentDirs.push({ path: relPath(root, dir), files: directCode });
     }
+
+    const childHasComponentsAncestor = hasComponentsAncestor || base === "components";
 
     for (const e of entries) {
       if (acc.visited >= MAX_ENTRIES) { acc.truncated = true; return; }
@@ -153,7 +193,13 @@ function walk(root: string, start: string, acc: WalkAccum): void {
       const full = join(dir, e.name);
       if (e.isDirectory()) {
         if (SKIP_DIRS.has(e.name)) continue;
-        queue.push({ dir: full, depth: depth + 1 });
+        const childBase = e.name.toLowerCase();
+        queue.push({
+          dir: full,
+          depth: depth + 1,
+          hasComponentsAncestor: childHasComponentsAncestor,
+          inTestTree: inTestTree || TEST_DIR_NAMES.has(childBase),
+        });
       } else if (e.isFile()) {
         const lower = e.name.toLowerCase();
         if (TAILWIND_CONFIG_RE.test(lower)) acc.tailwindConfigs.push(relPath(root, full));

--- a/tests/cmd-ds-status.test.ts
+++ b/tests/cmd-ds-status.test.ts
@@ -109,4 +109,40 @@ describe("ui ds status", () => {
     const rText = capture(["ds", "status", "--dir", tmp]);
     expect(rText.stdout).toContain("components: 3 (1 stable / 1 beta / 0 draft / 1 unset)");
   });
+
+  // ─── Fix 3: imported-ds STOP-gate enforcement (spec 009 fix-scan-discovery) ─────
+
+  it("warns when the manifest name is the 'ds import' default 'imported-ds'", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-status-imported-"));
+    const tokensPath = join(tmp, "tokens.json");
+    writeFileSync(
+      tokensPath,
+      JSON.stringify({ color: { primary: "#ff3e00" } }),
+      "utf8",
+    );
+    // Omit --name → runImport defaults to the literal "imported-ds".
+    const r = capture(["ds", "import", tokensPath, "--dir", tmp]);
+    expect(r.exitCode).toBe(0);
+
+    const rJson = capture(["ds", "status", "--dir", tmp, "--json"]);
+    expect(rJson.exitCode).toBe(0);
+    const data = JSON.parse(rJson.stdout).data;
+    expect(data.name).toBe("imported-ds");
+    expect(data.warning).toMatch(/imported-ds/);
+
+    const rText = capture(["ds", "status", "--dir", tmp]);
+    expect(rText.stdout).toContain("warning:");
+    expect(rText.stdout).toContain("imported-ds");
+  });
+
+  it("does not warn when the manifest carries a real --name", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-status-named-"));
+    initDs(tmp, true); // --dir tmp, name "acme" via initDs()
+    const rJson = capture(["ds", "status", "--dir", tmp, "--json"]);
+    const data = JSON.parse(rJson.stdout).data;
+    expect(data.warning).toBeNull();
+
+    const rText = capture(["ds", "status", "--dir", tmp]);
+    expect(rText.stdout).not.toContain("warning:");
+  });
 });

--- a/tests/cmd-scan.test.ts
+++ b/tests/cmd-scan.test.ts
@@ -223,7 +223,13 @@ describe("ui scan", () => {
     expect(env.data.truncated).toBe(false);
   });
 
-  it("test_a_tree_over_max_depth_reports_truncated", () => {
+  it("test_a_tree_over_max_depth_alone_does_NOT_report_truncated", () => {
+    // Fix 2 (spec 009 fix-scan-discovery): the depth cap alone must not set
+    // `truncated` — only the entry cap does. This tree is 8 levels deep (over
+    // MAX_DEPTH=6) but has a handful of entries (far under MAX_ENTRIES=4000):
+    // the map is honestly complete everywhere shallower than the cap, so
+    // `truncated` must read false. Before the fix this asserted `true` and
+    // passed — proving the old behavior conflated the two caps.
     const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
     // MAX_DEPTH is 6 — nest one directory deeper than that below the root.
     let deep = tmp;
@@ -234,7 +240,10 @@ describe("ui scan", () => {
     writeFileSync(join(deep, "buried.css"), "body {}\n");
 
     const env = scanJson(tmp);
-    expect(env.data.truncated).toBe(true);
+    expect(env.data.truncated).toBe(false);
+    // The depth cap still does its job silently: the buried file past depth 6
+    // is never counted, but that is not what `truncated` reports.
+    expect(env.data.cssFiles.find((f) => f.path.endsWith("buried.css"))).toBeUndefined();
   });
 
   it("test_truncated_does_not_change_any_existing_field_shape", () => {
@@ -284,5 +293,92 @@ describe("ui scan", () => {
       "app/src/components",
       "frontpage/app/src/components",
     ]);
+  });
+
+  // ─── Fix 1: ancestor-based component-dir detection (spec 009 fix-scan-discovery) ──
+
+  it("test_a_dir_under_a_components_ancestor_qualifies_even_with_an_unlisted_name", () => {
+    // spaflow pathology: src/components/dashboard holds 64 .tsx files but its
+    // own name ("dashboard") is not in COMPONENT_DIR_NAMES. Under Fix 1 it
+    // qualifies because "components" is an ancestor.
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    const dashboard = join(tmp, "src", "components", "dashboard");
+    mkdirSync(dashboard, { recursive: true });
+    writeFileSync(join(dashboard, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(dashboard, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(dashboard, "C.tsx"), "export const C = () => null;\n");
+
+    const env = scanJson(tmp);
+    const dash = env.data.componentDirs.find((d) => d.path.endsWith("components/dashboard"));
+    expect(dash).toBeDefined();
+    expect(dash!.files).toBe(3);
+  });
+
+  it("test_a_dir_two_levels_under_a_components_ancestor_still_qualifies", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    const nested = join(tmp, "src", "components", "settings", "billing");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(nested, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(nested, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(nested, "C.tsx"), "export const C = () => null;\n");
+
+    const env = scanJson(tmp);
+    const billing = env.data.componentDirs.find((d) => d.path.endsWith("settings/billing"));
+    expect(billing).toBeDefined();
+  });
+
+  it("test_a_dir_named_dashboard_with_no_components_ancestor_does_NOT_qualify", () => {
+    // Same name, no "components" ancestor anywhere above it — must stay invisible.
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    const dashboard = join(tmp, "src", "dashboard");
+    mkdirSync(dashboard, { recursive: true });
+    writeFileSync(join(dashboard, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(dashboard, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(dashboard, "C.tsx"), "export const C = () => null;\n");
+
+    const env = scanJson(tmp);
+    expect(env.data.componentDirs.find((d) => d.path.endsWith("dashboard"))).toBeUndefined();
+  });
+
+  it("test___tests___dir_never_qualifies_even_with_3plus_code_files", () => {
+    // __tests__ measured at 289 files across 2 real projects, none a component
+    // dir — a bare name/ancestor rule would over-collect it.
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    const testsDir = join(tmp, "src", "__tests__");
+    mkdirSync(testsDir, { recursive: true });
+    writeFileSync(join(testsDir, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(testsDir, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(testsDir, "C.tsx"), "export const C = () => null;\n");
+
+    const env = scanJson(tmp);
+    expect(env.data.componentDirs).toEqual([]);
+  });
+
+  it("test_a_components_ancestor_dir_inside_a_test_tree_still_does_NOT_qualify", () => {
+    // A "components" folder nested under __tests__/__mocks__ must not smuggle
+    // its descendants past the test-tree guard.
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    const nested = join(tmp, "__mocks__", "components", "widgetish");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(nested, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(nested, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(nested, "C.tsx"), "export const C = () => null;\n");
+
+    const env = scanJson(tmp);
+    expect(env.data.componentDirs).toEqual([]);
+  });
+
+  it("test_a_standalone_widgets_dir_still_qualifies_by_name_alone", () => {
+    // "widgets" measures 0/9 on the real corpus but stays a published contract —
+    // it must still qualify by name, with no "components" ancestor required.
+    const tmp = mkdtempSync(join(tmpdir(), "ease-scan-"));
+    const widgets = join(tmp, "src", "widgets");
+    mkdirSync(widgets, { recursive: true });
+    writeFileSync(join(widgets, "A.tsx"), "export const A = () => null;\n");
+    writeFileSync(join(widgets, "B.tsx"), "export const B = () => null;\n");
+    writeFileSync(join(widgets, "C.tsx"), "export const C = () => null;\n");
+
+    const env = scanJson(tmp);
+    expect(env.data.componentDirs.find((d) => d.path.endsWith("widgets"))).toBeDefined();
   });
 });


### PR DESCRIPTION
Three fixes, each found by pointing the code road at the studio's nine real projects. **Every number is counted, not estimated.**

## 1 — `COMPONENT_DIR_NAMES` saw 25% of components

`project-scan.ts:64` matched a directory by **name** against `{components, ui, widgets}`. Measured across the nine real code projects (dirs holding ≥3 component files):

```
components   5 projects · 345 files   ✓ in allowlist
ui           4 projects ·  30 files   ✓ in allowlist
widgets      0 projects ·   0 files   ✓ in allowlist — NEVER FIRES
─────────────────────────────────────────────────────
icons 109 · dashboard 73 · mdx 63 · editor 43 · marketing 28 · settings 23 · landing 19 …  ✗ INVISIBLE

→ 375 / 1485 = 25%
```

- **spaflow**: 74 `.tsx` across `src/components/{dashboard(64), landing, admin, ui, public}` → `componentDirs: []`. `components/` had 1 direct file; `ui` had 2 (one short of the threshold); `dashboard` had 64 but the wrong **name**.
- **sodeal**: 96 files, 15 dirs → **1 dir, 7 files (7%)**, with `truncated: false`. Not a budget problem — a naming one.
- **EaseUI**: 169 files across 10 subdirs → only `ui` surfaced.

**The signal is the ancestor, not the name.** Every missed dir sits under a `components/`. Counting by name alone over-collects instead — `__tests__` holds 289 files across 2 projects and is not a component dir.

New rule, measured at **58% (872/1485)**: ≥3 component files **and** (a `components` ancestor **or** name ∈ `{ui, widgets}`) **and** not inside a test tree.

`widgets` kept — it is 0/9 today, but it is a published contract and removing it is a separate decision. Stated in the report rather than quietly dropped.

**Live, before → after:**

| project | before | after |
|---|---|---|
| spaflow | 0 dirs / 0 files | 3 / 70 |
| sodeal | 1 / 7 | 7 / 85 |
| EaseUI | 1 / 12 | 13 / 184 |
| traicaybentre | 1 / 27 | 3 / 36 |
| dana-desktop | — | 10 / 227 |

## 2 — `truncated` cried wolf, and it caused a real misdiagnosis

`truncated` was set at **both** cap sites. The depth half is wrong, and **it is my error** — the phase file said "set it at BOTH cap sites"; the implementer flagged it as a deviation and I missed it.

The four projects reporting `truncated: true` were **exactly** the four exceeding `MAX_DEPTH = 6`. But **spaflow is 303 entries against a 4000 cap** — its entire truncation came from one Next.js route dir, `src/app/(dashboard)/dashboard/reports/daily/[date]`.

The caps do not mean the same thing. **Entry cap** → the map is partial and *arbitrary* things are missing. **Depth cap** → one deep branch was not descended; everything shallower was seen. Conflating them makes `truncated` mean "something somewhere was not visited" — almost always true, therefore useless.

**Not theoretical**: an agent read `truncated: true` on spaflow, concluded "the budget ran out", and built a theory about `.claude/skills` — a directory already in `SKIP_DIRS`. The flag meant to *prevent* a misreading *caused* one.

Only the entry cap sets it now. 4/10 → **2/10, and both are honest** (dana-desktop 5037, EaseUI 4220 — genuinely over 4000).

The test that asserted the old behaviour was renamed and inverted. **It was mine** — `phase-02-the-honest-router.md:153` specified `test_a_tree_over_max_depth_reports_truncated`. Third bug-enshrining test found today; the first one I authored.

## 3 — the `imported-ds` STOP-gate was prose, enforced by nothing

`onboard.md` §4 warns: always pass a real `--name`, the default `imported-ds` *"poisons agent identity"*. The string appears **once** in source (`ds-import-impl.ts:42`, a bare default). No command ever read `manifest.name` and compared it.

**VSF-PCP** — the flagship dogfood project the gate was written *about* — carries `name: "imported-ds"`, `generation: 1`, and a dead absolute scratchpad path in its sealed `intent`.

`ui ds status` now warns (never errors — it must not break an existing store):
```
warning: manifest name is the 'ui ds import' default 'imported-ds' — agent identity
(ui agents init) derives from this name. Reseal with an explicit --name: …
```

Art II closing on itself: a prose standard drifted for exactly as long as nobody shipped its check.

## Notes

- `project-scan.ts` is now 278 lines and **was already over Art IX's ~200 before this task** (233). Not refactored — that is scope creep in a narrow fix commit and risky against the Art I byte-identity walk. Flagged for a follow-up split.
- The implementer's numbers differed from mine in two places (traicaybentre visited 2971 not 3054) and it **reported them as-is rather than tuning to match**. Correct.

Four gates green, 2064 tests, `ui knowledge check` clean.