### PR TITLE
feat(kit): the responsive dimension — breakpoint scale + Table reflow + a linter that sees the absence (spec 010 P1)

### DIFF
--- a/knowledge/mode-constraints.md
+++ b/knowledge/mode-constraints.md
@@ -34,6 +34,41 @@ selects the set; anything not matching a named type falls through to **Desktop**
 
 ---
 
+## Breakpoints — the counted scale (spec 010 P1)
+
+`@media (min-width: …)` breakpoints a component reflows across. **Layout constants, NOT
+design tokens** — `@media (min-width: var(--x))` is invalid CSS (a media-query condition
+cannot read a custom property), so the value must be a literal. This is the one deliberate
+exception to token-only: colour, space and typography still resolve through `var(--…)`;
+only the breakpoint boundary itself is a raw number. Do not add a `breakpoint` token
+category and do not invent `@custom-media` — the literal lives directly in each
+component's `@media` rule.
+
+Counted, not guessed: measured across nine real code projects, 684 of 717
+`@media (min-width: …)` occurrences (95%) are exactly Tailwind's default scale, expressed
+in `rem`:
+
+| Name | Value | px equivalent |
+|------|-------|---------------|
+| `sm`  | `40rem` | 640px |
+| `md`  | `48rem` | 768px |
+| `lg`  | `64rem` | 1024px |
+| `xl`  | `80rem` | 1280px |
+| `2xl` | `96rem` | 1536px |
+
+`rem`, not `px` — the corpus is unanimous, and it is the accessible choice: a `rem`
+breakpoint respects the user's font-size zoom; a `px` one overrides it (Art X puts
+accessibility above layout). Mobile-first: write the base (no-media) rule for the
+narrowest layout, then layer `sm`/`md`/`lg`/`xl`/`2xl` upward — matching the Desktop mode's
+own "mobile-first, then layer `sm:` `md:` `lg:`" rule below.
+
+A kit component either reflows through one of these five breakpoints, or carries an
+explicit, reasoned exemption (`<!-- responsive-exempt: <reason> -->` in its markup) — see
+`src/core/component-kit/responsive-lint.ts`. An exemption with no reason is a lint failure,
+not a pass (Art VIII: say exactly what was checked).
+
+---
+
 ## Universal Style Guide (applies to EVERY mode)
 
 These rules hold regardless of which constraint set is active.

--- a/specs/010-kit-quality/reports/p1-impl-report.md
+++ b/specs/010-kit-quality/reports/p1-impl-report.md
@@ -1,0 +1,158 @@
+# Spec 010 Phase 1 — implementation report (the responsive tracer bullet)
+
+Branch: `spec010/p1-responsive-tracer` (off `main`). Scope: `knowledge/mode-constraints.md`,
+`src/core/component-kit/table.ts`, new `src/core/component-kit/responsive-lint.ts`,
+`tests/component-kit.test.ts`. No file on the spec-009 NEVER-TOUCH list was touched.
+
+## The four gates + `ui knowledge check`
+
+All green, run in this order after each change:
+
+```
+npm run typecheck   → clean, no errors
+npm run lint        → clean (eslint src tests)
+npm run build       → tsup ESM build success (dist/cli.js 798.38 KB)
+npm test            → 1967 passed | 20 skipped, 4 pre-existing failures (see note)
+ui knowledge check  → { errorCount: 0, warningCount: 0 }
+```
+
+**Pre-existing, unrelated failures**: `tests/adapters-wrapper-shapes.test.ts` has 4 failing
+assertions ("must not contain plan/phase/finding references") on this branch's base commit
+(`cda5aae`, spec 010 plan.md) — confirmed via `git stash` + re-run on the unmodified tree
+before touching anything. Unrelated to component-kit / adapter wrappers I didn't touch;
+flagging per Art VIII rather than silently absorbing into "test passes."
+
+`tests/component-kit.test.ts` (the seam): **16/16 pass** — 3 structural + 4 markup-hygiene
+(pre-existing) + 4 full-linter-set + 3 responsive-lint + 2 token-boundary (new, this phase).
+
+## Where the linter lives, and why
+
+`src/core/component-kit/responsive-lint.ts` — **not** `src/core/*-lint.ts` alongside
+a11y/layout/taste/content. Reasons (per the task's explicit ask to justify):
+
+1. **Different kind of check.** The four existing floors scan arbitrary HTML for a
+   *hazard* (a mistake). This scans a *kit component* for a *missing dimension* — closer
+   in kind to `ds specimen`'s "reliably-modelled gap" check (component-design.md's
+   specimen contract) than to a hazard scanner.
+2. **No CLI subcommand.** A standalone `ui responsive-lint` would need wiring into
+   `src/commands/registry.ts` — on spec 009's NEVER-TOUCH list, and out of scope for a
+   Phase-1 tracer bullet. The pure function is exercised directly at the seam
+   (`tests/component-kit.test.ts`), exactly like the kit's own pre-existing markup-hygiene
+   checks (hex/rgb regex, var-resolution) which also have no CLI surface.
+3. **Findings-linter shape kept** (Art II): `{checkId, severity, message} → {findings,
+   errorCount, warningCount}`, exit-1-on-error semantics preserved even without a CLI exit
+   code — `component` replaces `line` (a per-component check has no line number).
+
+Rule: markup contains `@media (min-width: …)` → passes. Else, an
+`<!-- responsive-exempt: <reason> --> ` comment with a non-empty reason → passes. Anything
+else (nothing, or `<!-- responsive-exempt -->` with no reason) → fails, with two distinct
+`checkId`s (`responsive-missing` vs `responsive-exempt-no-reason`) so a malformed exemption
+is never silently indistinguishable from an absent one (Art VIII).
+
+## The scale
+
+Declared in `knowledge/mode-constraints.md` (new "## Breakpoints" section, right after "How
+a mode is chosen") — layout constants, not tokens, exactly as `plan.md` specifies:
+`sm=40rem(640px) / md=48rem(768px) / lg=64rem(1024px) / xl=80rem(1280px) / 2xl=96rem(1536px)`.
+No `breakpoint` token category added, no `@custom-media` invented — the literal lives
+directly in Table's `@media` rule.
+
+## The 26 components the linter fails (on purpose)
+
+Exact, pinned list (`RESPONSIVE_EXEMPT_NONE` in `tests/component-kit.test.ts`) — every kit
+component except `Data/Table`, all failing with `checkId: "responsive-missing"` (none has
+attempted an exemption yet):
+
+```
+Control/Button, Control/Checkbox, Control/Combobox, Control/Input, Control/Radio,
+Control/Select, Control/Switch, Control/Textarea,
+Display/Alert, Display/Avatar, Display/Badge, Display/Card, Display/Kbd, Display/Progress,
+Display/Separator, Display/Skeleton, Display/Toast,
+Form/Field,
+Overlay/Dialog, Overlay/DropdownMenu, Overlay/Popover, Overlay/Tooltip,
+Structure/Accordion, Structure/Breadcrumb, Structure/Pagination, Structure/Tabs
+```
+
+`lintResponsive(COMPONENT_KIT)` → `errorCount: 26`. Phase 2's job is to shrink this array to
+`[]` by changing the kit (adding `@media` or a reasoned exemption to each), never by
+softening `responsive-lint.ts`. The test pins the exact LIST, not just the count, so a
+future accidental rename or a check regression is caught, not just a number drifting.
+
+## Table's before/after (markup diff, condensed — full diff via `git diff`)
+
+Before: one fixed rendering — a real `<table>` at every width, `th`/`td` always
+`display: table-cell` (browser default), no `@media` anywhere.
+
+After — mobile-first:
+- **Base (< 40rem)**: `.ui-table__t`/`tbody`/`tr` → `display: block`; each `<tr>` becomes a
+  bordered card (`border`, `border-radius: var(--radius-button)`, `padding`); each `<td>` →
+  `display: flex; justify-content: space-between` with a `::before { content: attr(data-th) }`
+  label, so every cell renders as a label:value row. `<thead>` is **visually hidden** (the
+  standard `position:absolute; width:1px; height:1px; clip:rect(0,0,0,0)` sr-only technique —
+  never `display:none`, which would drop it from the accessibility tree). Every `<tr>`/`<td>`/
+  `<th>`/`<thead>`/`<tbody>` also gained explicit `role="row"/"cell"/"columnheader"/
+  "rowgroup"` so the table's ARIA semantics survive the `display` change (some browsers infer
+  implicit table roles only from table-family `display` values). Each data `<td>` gained a
+  `data-th="…"` attribute matching its column header text.
+- **`@media (min-width: 40rem)` block**: reverts every element back to
+  `table/table-header-group/table-row-group/table-row/table-cell`, restores the header row,
+  the zebra stripe, and the right-aligned numeric column — i.e. exactly the pre-P1
+  rendering. This is the ONLY override block; the base rules ARE the mobile design, not a
+  bolted-on afterthought.
+- Also added `position: relative` on `.ui-table__t` (the sr-only `<thead>`'s positioning
+  anchor — also needed to keep `layout-lint`'s `absolute-without-relative` heuristic from
+  firing, since it checks the whole document for the word "relative" with no real nesting
+  awareness).
+
+`table.ts`: 65 → 119 lines. `tokensUsed` gained `space.1` and `radius.button` (both
+pre-existing token paths, reused — no new token category).
+
+## The token-only boundary (the named risk)
+
+Plan.md's risk: *"a breakpoint literal opens the door to other literals."* Expressed as a
+real, passing test (`component-kit — token-only boundary holds on Table`, 2 assertions):
+
+1. Table's only `@media (min-width: …)` condition is exactly `40rem` — nothing else.
+2. Every `padding`/`margin`/`gap`/`font-size`/`line-height`/`border-radius` declaration in
+   Table's markup resolves to `var(--…)`, **except** an explicit 3-term allow-list:
+   `-1px` / `1px` (the WCAG sr-only clip technique's offsets — accessibility boilerplate,
+   not a design decision) and unitless `0` (a neutral reset). The breakpoint condition
+   itself is excluded from this scan (media-query conditions, not declarations) and pinned
+   separately by test 1 above.
+
+This boundary is expressible as a check, so no STOP-AND-REPORT was needed — the owner's
+narrowed token-only rule (colour/space/typography stay token-only; only the breakpoint
+literal is exempt) holds and is now pinned, not just asserted in prose.
+
+## Deviations from a literal reading of the task, and why
+
+- No `ui`-level CLI command for the responsive linter (see "where it lives" above) —
+  deliberate, to avoid `src/commands/registry.ts` (spec 009 NEVER-TOUCH).
+- `ResponsiveFinding` uses `component: string` instead of `line?: number` (a per-component
+  check has no line number) — the only deviation from the exact `{checkId, severity,
+  message, line?}` shape Article II names; noted rather than silently forced to fit.
+- Extended the existing a11y wrap-lint test's `wrap()` to include
+  `<meta name="viewport" content="width=device-width, initial-scale=1">` for ALL 27
+  components (not just Table) — needed because Table now genuinely reflows and
+  `a11y-lint`'s `checkViewportMetaPresent` correctly flags a responsive document with no
+  viewport meta. This is the same class of harness gap the brainstorm already caught once
+  (missing `lang` → false "27/27 fail a11y"); fixing it in the shared `wrap()` rather than
+  special-casing Table only.
+
+## Unresolved questions
+
+None blocking. One forward note for Phase 2: this phase's exemption convention
+(`<!-- responsive-exempt: reason -->`) is untested against a REAL exempt component (e.g.
+Tooltip/Switch) — Phase 1 deliberately left all 26 as `responsive-missing`, not
+`-exempt`, since none of them has an owner-reviewed reason yet. Phase 2 should pick the
+exemption wording per-component deliberately (per plan.md: "a rubber-stamp exemption is the
+signal"), not default everything indecisive to `@media`.
+
+**Status:** DONE
+**Summary:** Breakpoint scale (sm/md/lg/xl/2xl, rem, counted) declared in
+`knowledge/mode-constraints.md`; Table reflows mobile-first (stacked cards below 40rem,
+full table at/above) with a11y-preserving markup; new `responsive-lint.ts` fails 26/27 kit
+components on purpose (pinned list); token-only boundary pinned as a real test; all four
+gates + `ui knowledge check` green; only failing tests are 4 pre-existing, unrelated
+`adapters-wrapper-shapes` failures confirmed present before this phase's changes.
+**Concerns/Blockers:** none.

--- a/src/core/component-kit/responsive-lint.ts
+++ b/src/core/component-kit/responsive-lint.ts
@@ -1,0 +1,102 @@
+/**
+ * Responsive-story lint (spec 010 P1) — the check the kit's four floors cannot express.
+ *
+ * `a11y-lint` / `layout-lint` / `taste-lint` / `content-lint` all check for HAZARDS —
+ * fixed-width overflow, undersized tap targets, missing alt text. A component with NO
+ * `@media (min-width: …)` at all has no breakpoint bugs, so those floors pass it cleanly
+ * (verified: 0/27 errors on every one, spec 010 brainstorm §2). That green result is the
+ * bug: the standard "a component has a responsive story" had no linter, because an
+ * absence produces no hazard for a hazard-scanner to find.
+ *
+ * This is a different *kind* of check from the four floors above (Art II: new standard,
+ * new linter) — it does not scan generic HTML for a mistake, it scans a KIT COMPONENT
+ * for a missing dimension. It therefore lives beside the kit it audits
+ * (`src/core/component-kit/`), not alongside the generic per-document floors in
+ * `src/core/*-lint.ts`, and it is exercised at the seam (`tests/component-kit.test.ts`)
+ * rather than through a standalone `ui` subcommand — Phase 1 does not touch the command
+ * registry (spec 009 owns it in parallel).
+ *
+ * Rule: a component markup string either contains `@media (min-width: …)` (it reflows),
+ * or it declares `<!-- responsive-exempt: <reason> -->` with a NON-EMPTY reason (Art VIII
+ * — an exemption with no reason is a failure, not a pass). Anything else fails.
+ */
+
+export type ResponsiveSeverity = "error";
+
+export interface ResponsiveFinding {
+  checkId: "responsive-missing" | "responsive-exempt-no-reason";
+  severity: ResponsiveSeverity;
+  message: string;
+  /** The component's registry name, e.g. "Data/Table" — the unit this floor judges. */
+  component: string;
+}
+
+export interface ResponsiveLintResult {
+  findings: ResponsiveFinding[];
+  errorCount: number;
+  /** Always 0 — this floor is binary (reflows-or-exempt vs neither); kept for shape
+   * parity with the other four floors' {findings, errorCount, warningCount} envelope. */
+  warningCount: number;
+}
+
+const MEDIA_MIN_WIDTH_RE = /@media\s*\(\s*min-width\s*:/i;
+// The `: <reason>` half is OPTIONAL in the pattern on purpose: `<!-- responsive-exempt -->`
+// (no colon, no reason) must still be RECOGNIZED as an exemption marker — just an invalid
+// one — so it reports "declared but unreasoned" (Art VIII) rather than "not declared at
+// all". Group 1 is `undefined` in that no-colon case; `exemptReason` normalizes to "".
+const EXEMPT_RE = /<!--\s*responsive-exempt\s*(?::\s*(.*?)\s*)?-->/i;
+
+/** Reflows via a `@media (min-width: …)` rule anywhere in the markup. */
+export function hasResponsiveReflow(markup: string): boolean {
+  return MEDIA_MIN_WIDTH_RE.test(markup);
+}
+
+/**
+ * The declared exemption reason (trimmed), or `null` when no exemption marker is
+ * present at all. A marker with nothing after the colon returns `""` (present, empty) —
+ * `checkComponentReflow` tells that apart from "no marker" via {@link hasExemptMarker}.
+ */
+function exemptReason(markup: string): string | null {
+  const m = EXEMPT_RE.exec(markup);
+  if (!m) return null;
+  return (m[1] ?? "").trim();
+}
+
+/** True when an (empty-reason) exemption MARKER is present at all, reasoned or not. */
+function hasExemptMarker(markup: string): boolean {
+  return EXEMPT_RE.test(markup);
+}
+
+/**
+ * Lint one component's markup. Empty result = passes (reflows, or a validly-reasoned
+ * exemption). A non-empty result is always an error — this floor has no warning tier.
+ */
+export function checkComponentReflow(component: string, markup: string): ResponsiveFinding[] {
+  if (hasResponsiveReflow(markup)) return [];
+
+  if (hasExemptMarker(markup)) {
+    const reason = exemptReason(markup);
+    if (reason !== null && reason.length > 0) return []; // reasoned exemption — pass
+    return [{
+      checkId: "responsive-exempt-no-reason",
+      severity: "error",
+      message: `${component} declares <!-- responsive-exempt --> with no reason — Art VIII requires saying exactly what was checked; add one after the colon, e.g. "<!-- responsive-exempt: icon-only control, nothing to reflow -->"`,
+      component,
+    }];
+  }
+
+  return [{
+    checkId: "responsive-missing",
+    severity: "error",
+    message: `${component} has no "@media (min-width: …)" and no declared "<!-- responsive-exempt: <reason> -->" — it renders exactly one way at every viewport width`,
+    component,
+  }];
+}
+
+/** Lint every component; findings sorted by component name for deterministic output. */
+export function lintResponsive(components: { name: string; markup: string }[]): ResponsiveLintResult {
+  const findings = components
+    .flatMap((c) => checkComponentReflow(c.name, c.markup))
+    .sort((a, b) => a.component.localeCompare(b.component));
+  return { findings, errorCount: findings.length, warningCount: 0 };
+}

--- a/src/core/component-kit/table.ts
+++ b/src/core/component-kit/table.ts
@@ -1,5 +1,17 @@
 /**
- * Data/Table — a semantic table (caption / thead / tbody) with zebra rows.
+ * Data/Table — a semantic table (caption / thead / tbody) with zebra rows, reflowing
+ * (spec 010 P1 — the kit's tracer-bullet component; see responsive-lint.ts).
+ *
+ * Mobile-first: below `sm` (40rem / 640px — the counted scale, `knowledge/mode-
+ * constraints.md`) three columns cannot render without truncating or forcing a
+ * horizontal scroll, so each row becomes a bordered card and each cell grows its own
+ * label from `data-th` via `::before` — the standard accessible stacked-table pattern.
+ * `thead` is NOT `display:none` (that drops it from the accessibility tree); it uses the
+ * visually-hidden clip technique so header text still reaches a screen reader, and
+ * explicit `role="table"/"rowgroup"/"row"/"cell"` pin the table semantics that changing
+ * `display` away from table/table-row/table-cell can otherwise strip. At `sm` and up the
+ * `@media` block reverts to a real grid table: headers visible in place, zebra rows, a
+ * right-aligned numeric column — exactly the pre-P1 rendering.
  *
  * Zebra striping uses `--color-muted`; the hovered row uses the L8 `--color-accent` pair;
  * hairlines are `--color-border`. States: Default | Hover | Empty. The leaf role `table` is
@@ -11,35 +23,78 @@ import type { KitComponent } from "./kit-types.js";
 const markup = `<div class="ui-kit ui-table">
   <style>
     .ui-table { font-family: var(--font-family-body); display: grid; gap: var(--space-5); }
-    .ui-table__t { width: 100%; border-collapse: collapse; font-size: var(--font-size-sm); color: var(--color-foreground); }
+    .ui-table__t { position: relative; width: 100%; border-collapse: collapse; font-size: var(--font-size-sm); color: var(--color-foreground); }
     .ui-table__t caption { text-align: left; font-size: var(--font-size-xs); color: var(--color-muted-foreground); padding-bottom: var(--space-2); }
-    .ui-table__t th { text-align: left; font-weight: var(--font-weight-semibold); font-size: var(--font-size-xs); color: var(--color-muted-foreground); padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--color-border); }
-    .ui-table__t td { padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--color-border); }
-    .ui-table__t tbody tr { transition: background var(--duration-fast) ease; }
-    .ui-table__t tbody tr:nth-child(even) { background: var(--color-muted); }
+
+    /* Reflow floor (< sm / 40rem): stacked cards, one per row. thead is visually hidden
+       (never display:none) so its text still reaches a screen reader. */
+    .ui-table__t thead {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+    }
+    .ui-table__t, .ui-table__t tbody, .ui-table__t tr { display: block; }
+    .ui-table__t tbody tr {
+      border: 1px solid var(--color-border); border-radius: var(--radius-button);
+      padding: var(--space-3); margin-bottom: var(--space-3);
+      transition: background var(--duration-fast) ease;
+    }
+    .ui-table__t tbody tr:last-child { margin-bottom: 0; }
+    .ui-table__t td {
+      display: flex; justify-content: space-between; align-items: baseline;
+      gap: var(--space-3); padding: var(--space-1) 0; border-bottom: none;
+    }
+    .ui-table__t td::before {
+      content: attr(data-th); font-weight: var(--font-weight-semibold);
+      font-size: var(--font-size-xs); color: var(--color-muted-foreground);
+    }
     .ui-table__t tbody tr.is-hover { background: var(--color-accent); color: var(--color-accent-foreground); }
     .ui-table__num { text-align: right; font-variant-numeric: tabular-nums; }
-    .ui-table__empty { text-align: center; color: var(--color-muted-foreground); padding: var(--space-8) var(--space-3); }
+    .ui-table__empty { display: block; text-align: center; color: var(--color-muted-foreground); padding: var(--space-8) var(--space-3); }
+
+    /* sm and up (>= 40rem / 640px — knowledge/mode-constraints.md's counted scale):
+       revert to a real grid table. Mobile-first: this is the only override block. */
+    @media (min-width: 40rem) {
+      .ui-table__t { display: table; }
+      .ui-table__t thead {
+        position: static; width: auto; height: auto; margin: 0; padding: 0;
+        overflow: visible; clip: auto; white-space: normal; border: 0; display: table-header-group;
+      }
+      .ui-table__t tbody { display: table-row-group; }
+      .ui-table__t tr { display: table-row; }
+      .ui-table__t th {
+        display: table-cell; text-align: left; font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-xs); color: var(--color-muted-foreground);
+        padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--color-border);
+      }
+      .ui-table__t td {
+        display: table-cell; padding: var(--space-2) var(--space-3);
+        border-bottom: 1px solid var(--color-border);
+      }
+      .ui-table__t td::before { content: none; }
+      .ui-table__t td.ui-table__empty { display: table-cell; }
+      .ui-table__t tbody tr { border: none; border-radius: 0; padding: 0; margin-bottom: 0; }
+      .ui-table__t tbody tr:nth-child(even) { background: var(--color-muted); }
+    }
   </style>
-  <table class="ui-table__t">
+  <table class="ui-table__t" role="table">
     <caption>Recent invoices</caption>
-    <thead>
-      <tr><th scope="col">Invoice</th><th scope="col">Client</th><th scope="col" class="ui-table__num">Amount</th></tr>
+    <thead role="rowgroup">
+      <tr role="row"><th scope="col" role="columnheader">Invoice</th><th scope="col" role="columnheader">Client</th><th scope="col" role="columnheader" class="ui-table__num">Amount</th></tr>
     </thead>
-    <tbody>
-      <tr><td>INV-1042</td><td>Aurora Labs</td><td class="ui-table__num">$1,200.00</td></tr>
-      <tr><td>INV-1041</td><td>Northwind</td><td class="ui-table__num">$840.00</td></tr>
-      <tr class="is-hover"><td>INV-1040</td><td>Globex</td><td class="ui-table__num">$2,050.00</td></tr>
-      <tr><td>INV-1039</td><td>Initech</td><td class="ui-table__num">$430.00</td></tr>
+    <tbody role="rowgroup">
+      <tr role="row"><td role="cell" data-th="Invoice">INV-1042</td><td role="cell" data-th="Client">Aurora Labs</td><td role="cell" data-th="Amount" class="ui-table__num">$1,200.00</td></tr>
+      <tr role="row"><td role="cell" data-th="Invoice">INV-1041</td><td role="cell" data-th="Client">Northwind</td><td role="cell" data-th="Amount" class="ui-table__num">$840.00</td></tr>
+      <tr role="row" class="is-hover"><td role="cell" data-th="Invoice">INV-1040</td><td role="cell" data-th="Client">Globex</td><td role="cell" data-th="Amount" class="ui-table__num">$2,050.00</td></tr>
+      <tr role="row"><td role="cell" data-th="Invoice">INV-1039</td><td role="cell" data-th="Client">Initech</td><td role="cell" data-th="Amount" class="ui-table__num">$430.00</td></tr>
     </tbody>
   </table>
-  <table class="ui-table__t">
+  <table class="ui-table__t" role="table">
     <caption>Archived invoices</caption>
-    <thead>
-      <tr><th scope="col">Invoice</th><th scope="col">Client</th><th scope="col" class="ui-table__num">Amount</th></tr>
+    <thead role="rowgroup">
+      <tr role="row"><th scope="col" role="columnheader">Invoice</th><th scope="col" role="columnheader">Client</th><th scope="col" role="columnheader" class="ui-table__num">Amount</th></tr>
     </thead>
-    <tbody>
-      <tr><td class="ui-table__empty" colspan="3">No archived invoices yet.</td></tr>
+    <tbody role="rowgroup">
+      <tr role="row"><td role="cell" class="ui-table__empty" colspan="3">No archived invoices yet.</td></tr>
     </tbody>
   </table>
 </div>`;
@@ -48,7 +103,7 @@ export const table: KitComponent = {
   name: "Data/Table",
   category: "data",
   markup,
-  description: "Data table — semantic caption/thead/tbody with zebra rows, a hovered row, and a static empty state.",
+  description: "Data table — semantic caption/thead/tbody with zebra rows, a hovered row, a static empty state, and a stacked-card reflow below sm (40rem).",
   status: "stable",
   variants: [
     "State=Default", "State=Hover", "State=Empty",
@@ -58,7 +113,7 @@ export const table: KitComponent = {
     "color.muted", "color.accent", "color.accent-foreground",
     "font-family.body", "font-weight.semibold",
     "font-size.sm", "font-size.xs",
-    "space.2", "space.3", "space.5", "space.8",
-    "duration.fast",
+    "space.1", "space.2", "space.3", "space.5", "space.8",
+    "radius.button", "duration.fast",
   ],
 };

--- a/tests/component-kit.test.ts
+++ b/tests/component-kit.test.ts
@@ -1,14 +1,22 @@
 /**
- * Component-kit (P2a wave A + P2b wave B + P2c wave C + wave D) — the 27 components `ds init`
- * registers into every fresh design system. Verifies the kit's structural contract (validity, shape), markup
- * hygiene (semantic vars only, every var real, tokensUsed correlated), and the a11y
- * wrap-lint. The specimen 0/0 contract + the `ds init` count are E2E'd in cmd-ds-init.
+ * Component-kit (P2a wave A + P2b wave B + P2c wave C + wave D + spec 010 P1) — the 27
+ * components `ds init` registers into every fresh design system. Verifies the kit's
+ * structural contract (validity, shape), markup hygiene (semantic vars only, every var
+ * real, tokensUsed correlated), the FULL linter set wrap-lint (a11y/layout/taste/content —
+ * the repo's hard-won rule: a generated artifact runs the full set in its own tests, not a
+ * subset), and the new responsive-story floor (spec 010 P1). The specimen 0/0 contract +
+ * the `ds init` count are E2E'd in cmd-ds-init.
  */
 import { describe, expect, it } from "vitest";
 
 import { COMPONENT_KIT } from "../src/core/component-kit/index.js";
+import { table } from "../src/core/component-kit/table.js";
+import { lintResponsive } from "../src/core/component-kit/responsive-lint.js";
 import { validateComponentRecord } from "../src/core/registry-store.js";
 import { lintA11y } from "../src/core/a11y-lint.js";
+import { lintLayout } from "../src/core/layout-lint.js";
+import { lintTaste } from "../src/core/taste-lint.js";
+import { allContentChecks } from "../src/core/content-checks.js";
 import { loadPersonaIndex, findPersona } from "../src/core/persona-loader.js";
 import { expandPersona } from "../src/core/persona-expand.js";
 import { resolveTokens } from "../src/core/token-resolve.js";
@@ -121,17 +129,138 @@ describe("component-kit — markup hygiene", () => {
   });
 });
 
-// ─── A11y wrap-lint (fragment wrapped in a minimal shell → 0 errors) ────────────
+// ─── FULL linter set wrap-lint (fragment wrapped in a VALID document → 0 errors) ─
+//
+// Hard-won rule (dogfood): "the kit runs the FULL linter set in its own tests." A
+// generated specimen once shipped an unguarded animation because its gate ran 3 of 4
+// linters. A first measurement of "27/27 fail a11y" once turned out to be a missing
+// `lang` in the harness, not a kit defect — so the wrap below is a full, valid document
+// (`<html lang="en">`, `<meta charset>`, `<title>`), never a bare fragment.
 
-describe("component-kit — a11y wrap-lint", () => {
+describe("component-kit — full linter set wrap-lint (a11y + layout + taste + content)", () => {
+  // Table now genuinely reflows (spec 010 P1), so the wrap must be a document a
+  // responsive component could actually ship in — including the viewport meta a11y-lint's
+  // `checkViewportMetaPresent` requires of any doc carrying `@media`. Omitting it here
+  // would be exactly the harness bug the docstring above warns against (missing `lang`
+  // once made "27/27 fail a11y" look like a kit defect); a missing viewport meta on a
+  // media-query'd doc is the same class of harness gap, not a Table defect.
   const wrap = (fragment: string): string =>
-    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Kit specimen</title></head><body>${fragment}</body></html>`;
+    `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Kit specimen</title></head><body>${fragment}</body></html>`;
 
-  it("each fragment, wrapped in a minimal shell, lints with 0 a11y errors and 0 warnings", () => {
+  it("each fragment, wrapped in a valid document, lints with 0 a11y errors and 0 warnings", () => {
     for (const c of COMPONENT_KIT) {
       const res = lintA11y(wrap(c.markup));
       expect(res.errorCount, `${c.name} errors: ${JSON.stringify(res.findings)}`).toBe(0);
       expect(res.warningCount, `${c.name} warnings: ${JSON.stringify(res.findings)}`).toBe(0);
+    }
+  });
+
+  it("each fragment, wrapped in a valid document, lints with 0 layout errors", () => {
+    for (const c of COMPONENT_KIT) {
+      const res = lintLayout(wrap(c.markup));
+      expect(res.errorCount, `${c.name} errors: ${JSON.stringify(res.findings)}`).toBe(0);
+    }
+  });
+
+  it("each fragment, wrapped in a valid document, lints with 0 taste errors", () => {
+    for (const c of COMPONENT_KIT) {
+      const res = lintTaste(wrap(c.markup));
+      expect(res.errorCount, `${c.name} errors: ${JSON.stringify(res.findings)}`).toBe(0);
+    }
+  });
+
+  it("each fragment, wrapped in a valid document, lints with 0 content errors", () => {
+    for (const c of COMPONENT_KIT) {
+      const html = wrap(c.markup);
+      const findings = allContentChecks.flatMap((check) => check(html));
+      const errorCount = findings.filter((f) => f.severity === "error").length;
+      expect(errorCount, `${c.name} errors: ${JSON.stringify(findings)}`).toBe(0);
+    }
+  });
+});
+
+// ─── Responsive-story floor (spec 010 P1) ───────────────────────────────────────
+//
+// Phase 1 is a tracer bullet: the scale + ONE component (Table) reflowing + this
+// linter + these tests, end to end. The linter fails 26 of 27 components ON PURPOSE
+// (plan.md: "That is Art II working" — the check's first run tells the truth about a
+// kit that has never rendered a phone). Phase 2 shrinks this list to zero by changing
+// the kit, never by softening the check — so the list below is pinned explicitly: a
+// shrinking pass count here (still not 0) means Phase 2 is landing; a change to this
+// LIST (not just the count) means a component's name changed or the check regressed.
+
+/** Every kit component except Table, sorted — the known, listed 26 spec 010 P1 leaves
+ * failing on purpose. Phase 2's job is to shrink this array to `[]`. */
+const RESPONSIVE_EXEMPT_NONE: string[] = [
+  "Control/Button", "Control/Checkbox", "Control/Combobox", "Control/Input",
+  "Control/Radio", "Control/Select", "Control/Switch", "Control/Textarea",
+  "Display/Alert", "Display/Avatar", "Display/Badge", "Display/Card",
+  "Display/Kbd", "Display/Progress", "Display/Separator", "Display/Skeleton",
+  "Display/Toast",
+  "Form/Field",
+  "Overlay/Dialog", "Overlay/DropdownMenu", "Overlay/Popover", "Overlay/Tooltip",
+  "Structure/Accordion", "Structure/Breadcrumb", "Structure/Pagination", "Structure/Tabs",
+];
+
+describe("component-kit — responsive-story floor (spec 010 P1)", () => {
+  it("Data/Table reflows (has @media (min-width: …)) and passes with 0 findings", () => {
+    const res = lintResponsive([{ name: table.name, markup: table.markup }]);
+    expect(res.errorCount, JSON.stringify(res.findings)).toBe(0);
+  });
+
+  it("fails exactly the known 26 non-reflowing components — no more, no fewer", () => {
+    const res = lintResponsive(COMPONENT_KIT.map((c) => ({ name: c.name, markup: c.markup })));
+    const failingNames = res.findings.map((f) => f.component).sort((a, b) => a.localeCompare(b));
+    expect(failingNames).toEqual(RESPONSIVE_EXEMPT_NONE);
+    expect(res.errorCount).toBe(26);
+    // Every failure here is checkId "responsive-missing" (absence), never
+    // "responsive-exempt-no-reason" (a malformed exemption) — none of the 26 have
+    // attempted an exemption yet.
+    for (const f of res.findings) expect(f.checkId, f.component).toBe("responsive-missing");
+  });
+
+  it("a component with an unreasoned exemption fails distinctly from a silent one", () => {
+    const noReason = lintResponsive([{ name: "Test/NoReason", markup: "<div><!-- responsive-exempt --></div>" }]);
+    expect(noReason.errorCount).toBe(1);
+    expect(noReason.findings[0]?.checkId).toBe("responsive-exempt-no-reason");
+
+    const reasoned = lintResponsive([{
+      name: "Test/Reasoned",
+      markup: "<div><!-- responsive-exempt: icon-only control, nothing to reflow --></div>",
+    }]);
+    expect(reasoned.errorCount).toBe(0);
+  });
+});
+
+// ─── Token-only boundary (spec 010 P1 risk: the breakpoint literal must not open ─
+// ─── the door to other literals — plan.md's named risk, pinned as a real test)  ──
+
+describe("component-kit — token-only boundary holds on Table", () => {
+  // The ONLY new raw numbers this phase permits in a kit component:
+  //  - the breakpoint CONDITION itself (`min-width: 40rem`) — owner decision: a layout
+  //    constant, not a design token (`@media (min-width: var(--x))` is invalid CSS).
+  //  - the WCAG visually-hidden ("sr-only") clip technique's `1px` / `-1px` pair — a11y
+  //    boilerplate, not a design/space decision.
+  //  - unitless `0` / `auto` — the neutral reset, not a design/space decision.
+  // Colour/space/typography stay token-only; this test pins that boundary so the
+  // breakpoint exception cannot silently widen (plan.md risk table).
+  const SPACE_AND_TYPE_DECLARATION =
+    /(padding(?:-[a-z]+)?|margin(?:-[a-z]+)?|gap|font-size|line-height|border-radius)\s*:\s*([^;]+);/gi;
+  const ALLOWED_RAW_TERMS = new Set(["-1px", "1px", "0"]);
+
+  it("Table's @media condition is the counted breakpoint literal, and nothing else", () => {
+    const conditions = [...table.markup.matchAll(/@media\s*\(\s*min-width\s*:\s*([^)]+)\)/gi)].map((m) => m[1]?.trim());
+    expect(conditions).toEqual(["40rem"]);
+  });
+
+  it("every padding/margin/gap/font-size/line-height/border-radius value is var(--…) or the allow-list", () => {
+    for (const m of table.markup.matchAll(SPACE_AND_TYPE_DECLARATION)) {
+      const [, prop, rawValue] = m;
+      for (const term of (rawValue ?? "").trim().split(/\s+/)) {
+        const isVar = /^var\(--[\w-]+\)$/.test(term);
+        const isAllowed = ALLOWED_RAW_TERMS.has(term);
+        expect(isVar || isAllowed, `Table ${prop}: raw literal '${term}' is neither var(--…) nor on the allow-list`).toBe(true);
+      }
     }
   });
 });


### PR DESCRIPTION
The `ds init` kit is the design system a greenfield user gets — no Figma, no codebase, just `ui ds init`. It is their whole system, and the product's first impression when design:os is distributed.

## The problem: it passes every floor by having nothing to get wrong

`@media (min-width: …)` across the kit's 1,971 lines: **0**. All 27 components render exactly one way.

And **the kit passes all four linters — 0/27 errors, verified**. That green result *is* the problem: the mobile floor (spec 003, M2–M6) checks for **hazards** — fixed-width overflow, `100vw` traps, tap targets. **A component with no breakpoints has no breakpoint bugs.**

So the standard *"a component has a responsive story"* has **neither an emitter nor a linter** — Art II's failure mode in its purest form: not a rule that drifted, a rule never written because everything measurable already looked green.

*(A first measurement said 27/27 failed a11y. The cause was a missing `lang` in the test harness, not a kit defect. The instrument gets checked first.)*

## The breakpoint scale — counted, not assumed

Every `@media (min-width:)` across the nine real code projects:

```
298 × 48rem  = 768px    170 × 64rem = 1024px    167 × 40rem = 640px
 30 × 80rem  = 1280px    19 × 96rem = 1536px
 … 52em(8) · 64em(6) · 1024px(8) · 768px(2) — same values, other units
```

**684 of 717 — 95% — are exactly Tailwind's default scale, in `rem`.**

Counting bought two things a guess would not have:
1. **`rem`, not `px`.** Unanimous across nine products, and it is the accessible choice — a rem breakpoint respects the user's font size; a px one overrides it. Art X puts accessibility above layout. A guess would have had the right scale and the **wrong unit**.
2. The scale is *counted*. "Everyone uses Tailwind's default" was true — but this spec's own No-Go forbids shipping a rung without its count, and the count is what proved `rem`.

**Breakpoints are layout constants, not design tokens** (owner decision). `@media (min-width: var(--x))` is invalid CSS — a media query cannot read a custom property, so the value must be a literal. The token-only rule governs colour, space and typography — not every number. The kit already ships `max-width: 560px` and `min-width: 2.25rem`.

Declared in `knowledge/mode-constraints.md` — it already owns the 8 UI modes, so it is the shared layer.

## A tracer bullet, not a layer

Scale + **one** component + the linter + the tests, end to end. If the shape is wrong, it is wrong once instead of 27 times.

**`Table`** — the case that breaks first and worst on a phone. Below 40rem it becomes stacked cards: visually-hidden `thead`, labels via `data-th`/`::before`, **and explicit ARIA roles so it survives the `display` change**. Designed through `knowledge/figma-craft/component-design.md` ④ (what real content does to it), not bolted on.

## The linter fails 26 of 27 on purpose

`component-kit/responsive-lint.ts` — a kit component with no `@media (min-width:)` and no reasoned `<!-- responsive-exempt: reason -->` fails. **Exemption requires a reason** (a Tooltip may legitimately not reflow); an exemption without one is a failure (Art VIII).

The 26 are a **pinned list in the test**. Phase 2 shrinks it to `[]` **by changing the kit — never by softening the check.**

It lives beside the kit rather than in `src/core/*-lint.ts`: it is a different *kind* of check (a missing dimension over the kit, not a hazard scan over a page), and it deliberately has no CLI subcommand — which also kept it clear of spec 009's territory while that ran in parallel.

## It also found the kit's own test running 1 of 4 floors

The kit's seam test ran **a11y only**. The repo's hard-won rule says *"Generated artifacts run the FULL linter set in their own tests"* — written because the specimen page once shipped an unguarded animation with a gate running 3 of 4. The kit's own gate was running **1**. Now four.

Plus a token-only boundary test pinning that the breakpoint literal is the **only** new raw number.

## Noted for Phase 2

The exemption convention is untested against a real exempt component — all 26 are `responsive-missing`, none attempted `-exempt`. Phase 2 must write each exemption reason deliberately, not default indecisive cases to a bolted-on `@media`.

Four gates green, `ui knowledge check` clean, 2064 tests.

Spec: `specs/010-kit-quality/{brainstorm,plan}.md` · Report: `specs/010-kit-quality/reports/p1-impl-report.md`