### PR TITLE
fix(a11y): recognize -text/-bg pairing synonyms — dana's 1011 false positives → 1 real bug

### DIFF
--- a/specs/009-code-road/reports/a11y-pairing-fix.md
+++ b/specs/009-code-road/reports/a11y-pairing-fix.md
@@ -1,0 +1,100 @@
+# F11 fix — `ds a11y` foreground-role synonyms (dana over-pairing)
+
+**Branch**: `fix/a11y-pairing-synonyms` (off `main` @ `29bb90f`)
+**Files changed**: `src/core/token-pairs.ts` (65 lines), `tests/token-pairs.test.ts` (+8 tests)
+**`ds-a11y.ts` untouched** — mode selection already branches purely on
+`inferForegroundPairs(...).length > 0`, so extending the inference function alone flips the mode;
+no change needed there.
+
+## Root cause (confirmed against dana's real tokens)
+
+dana declares 0 tokens named `-foreground`, so `inferForegroundPairs` found nothing and
+`ds-a11y` fell back to the `inferred` cartesian mode (every color-typed "text-ish" token ×
+every "surface-ish" token). But dana DOES declare the same paired-contrast intent under a
+different suffix word: `badge-danger-text` + `badge-danger-bg`, `semantic-error-text` +
+`semantic-error-bg`, `interactive-primary-text` + `interactive-primary`, etc. — 13 such pairs,
+confirmed by reading `design/design.tokens.json` directly.
+
+## The fix
+
+`FOREGROUND_RE` in `src/core/token-pairs.ts` extended from matching only the literal
+`-foreground` suffix to matching the counted synonym set from
+`specs/009-code-road/reports/role-synonym-dictionary.md`'s foreground row: `foreground | text |
+fg | content | ink`.
+
+```
+const FOREGROUND_RE = /^(.+?)[.\-/](?:foreground|text|fg|content|ink)$/i;
+```
+
+No other logic changed. The existing base-stripping + same-group-sibling lookup (unchanged)
+already enforces the safety constraint by construction: for a match like `badge-danger-text`,
+the base extracted is `badge-danger`, and the function only looks for `badge-danger-background /
+-bg / -surface / -base` — never any other role's surface. A role with a foreground-shaped token
+but no matching surface (`badge-light-text`, which only has `badge-light-border`) falls through
+to no pair, per spec.
+
+## Tests added (`tests/token-pairs.test.ts`)
+
+8 new cases under `inferForegroundPairs — foreground synonyms`:
+1. Real dana pair resolves: `badge-danger-text` ↔ `badge-danger-bg`.
+2. **Safety test (explicit)**: `badge-danger-text` + `badge-neutral-bg` present together →
+   asserts the pair list contains ONLY same-role pairs and explicitly
+   `.not.toContainEqual(["badge-danger-text", "badge-neutral-bg"])`.
+3. `badge-light-text` (no matching `-bg`, only `-border`) → no pair (real dana shape).
+4. `-fg` synonym pairs correctly (`alert-fg` ↔ `alert-bg`).
+5. `-ink` synonym pairs correctly (`panel-ink` ↔ `panel-bg`).
+6. `-content` synonym: proves the real dana token `color.surface-content` (itself a surface,
+   coincidentally ending in the synonym word) does NOT misfire into a stray pair when no
+   `surface-content-bg` sibling exists, while a genuine `callout-content`/`callout-bg` pair still
+   resolves — guards the specific false-positive risk this suffix introduces.
+7. **Regression guard**: a DS mixing shadcn's real `{role}-foreground` convention (`color.primary`
+   / `color.primary-foreground`) alongside a dana-style `-text`/`-bg` pair resolves both
+   correctly in one call — proves the synonym extension didn't break shadcn-convention DSs.
+8. Bare-token shape: `interactive-primary` + `interactive-primary-text` (base token itself is the
+   surface, real dana shape) resolves via the existing branch-1 lookup.
+
+All 8 new + all 14 pre-existing `token-pairs.test.ts` cases pass. Full suite: 136 files / 2080
+tests pass (4 skipped, pre-existing).
+
+## Live dana-desktop result (measured, not simulated)
+
+```
+node dist/cli.js ds a11y --dir <dana-desktop> --json
+```
+
+| | Before | After |
+|---|---|---|
+| mode | `inferred` (cartesian fallback) | `paired` |
+| checked pairs | 1540 | 13 |
+| checked state-pairs | 0 | 4 |
+| "below AA" failures | 1011 | **1** |
+
+The 13 declared pairs cover all of dana's real `{role}-text`/`{role}-bg` and
+`{role}`/`{role}-text` roles: badge-danger/default/info/neutral/purple/success/warning (7),
+semantic-error/info/success/warning (4), interactive-primary/secondary (2). `badge-light-text`
+(no matching `-bg`) correctly emits nothing, matching the "fall through, don't cartesian-fill"
+rule.
+
+### True positive remaining — NOT suppressed, reported
+
+```
+color.badge-info-text on color.badge-info-bg — 4.1:1 (AA-large); fails normal-text AA
+```
+
+`badge-info-bg`/`badge-info-text` is a real declared pair that fails AA-normal (4.5:1 required,
+measures 4.1:1 — passes only the AA-large 3:1 threshold). This is a genuine contrast bug in
+dana's design system, not a false positive — it should be reported to dana's owner, not fixed or
+hidden here.
+
+## Gates (all green)
+
+- `npm run typecheck` — clean
+- `npm run lint` — clean (`eslint src tests`)
+- `npm run build` — clean, `dist/cli.js` 820.09 KB
+- `npm test` — 136 test files, 2080 tests passed, 4 skipped (pre-existing)
+- `node dist/cli.js knowledge check` — `0 findings`
+
+## Unresolved questions
+
+None — root cause confirmed against real dana tokens, fix scoped to `token-pairs.ts` only, live
+before/after measured on the exact fixture path given.

--- a/src/core/token-pairs.ts
+++ b/src/core/token-pairs.ts
@@ -10,20 +10,31 @@
  * Pure, name-based, separator-agnostic (`.`, `-`, `/`). No IO.
  */
 
-/** Trailing `foreground` segment, e.g. "color.primary-foreground" or "color.foreground". */
-const FOREGROUND_RE = /^(.+?)[.\-/]foreground$/i;
+/**
+ * Trailing foreground-role segment: the literal `foreground`, plus the counted synonyms
+ * `text` / `fg` / `content` / `ink` (role-synonym-dictionary.md, foreground row — synonyms
+ * observed across Carbon/Ant/Base Web/Primer/Polaris/SLDS/USWDS/M3/Fluent/Spectrum). A DS that
+ * declares `{role}-text` + `{role}-bg` (dana's convention) is the SAME declared-pair shape as
+ * shadcn's `{role}` + `{role}-foreground` — just a different suffix word — so it must resolve
+ * through the same base-stripping + same-role-sibling lookup below, never the text×surface
+ * cartesian fallback.
+ */
+const FOREGROUND_RE = /^(.+?)[.\-/](?:foreground|text|fg|content|ink)$/i;
 /** A background/surface sibling under a group, tried in priority order. */
 const SURFACE_SUFFIXES = ["background", "bg", "surface", "base"] as const;
 
 /**
  * Infer `[foregroundPath, surfacePath]` pairs from token paths following the
- * `{role}` / `{role}-foreground` convention.
+ * `{role}` / `{role}-foreground` convention — or any of its counted synonyms
+ * (`{role}-text`, `{role}-fg`, `{role}-content`, `{role}-ink`).
  *
  * - `X-foreground` → its base `X` when that token exists (e.g. primary-foreground → primary).
  * - a bare `…/foreground` whose base is a category (no sibling token) → the app-default pair:
- *   the `background`/`bg`/`surface` token in the same group (e.g. color.foreground → color.background).
+ *   the `background`/`bg`/`surface` token in the SAME group (e.g. color.foreground → color.background,
+ *   badge-danger-text → badge-danger-bg). Same-role only — never a different role's surface.
  *
- * Only emits a pair when BOTH tokens are present in `paths`.
+ * Only emits a pair when BOTH tokens are present in `paths`; a foreground-shaped token with no
+ * matching surface sibling (e.g. `badge-light-text` with no `badge-light-bg`) emits nothing.
  */
 export function inferForegroundPairs(paths: readonly string[]): [string, string][] {
   const set = new Set(paths);
@@ -48,7 +59,7 @@ export function inferForegroundPairs(paths: readonly string[]): [string, string]
   return out;
 }
 
-/** True when any token follows the `-foreground` / `…foreground` convention. */
+/** True when any token follows the `-foreground` convention or a counted synonym (`-text`/`-fg`/`-content`/`-ink`). */
 export function hasForegroundTokens(paths: readonly string[]): boolean {
   return paths.some((p) => FOREGROUND_RE.test(p));
 }

--- a/tests/token-pairs.test.ts
+++ b/tests/token-pairs.test.ts
@@ -75,6 +75,77 @@ describe("inferForegroundPairs", () => {
   });
 });
 
+// ─── foreground synonyms (F11 fix — role-synonym-dictionary.md) ────────────────
+
+describe("inferForegroundPairs — foreground synonyms (-text/-fg/-content/-ink)", () => {
+  it("pairs dana's real {role}-text with {role}-bg (badge-danger-text on badge-danger-bg)", () => {
+    expect(inferForegroundPairs(["color.badge-danger-bg", "color.badge-danger-text"])).toEqual([
+      ["color.badge-danger-text", "color.badge-danger-bg"],
+    ]);
+  });
+
+  it("SAFETY: badge-danger-text pairs ONLY with badge-danger-bg — never badge-neutral-bg (no cross-role over-pairing)", () => {
+    const paths = [
+      "color.badge-danger-text",
+      "color.badge-danger-bg",
+      "color.badge-neutral-text",
+      "color.badge-neutral-bg",
+    ];
+    const result = inferForegroundPairs(paths);
+    expect(result).toEqual([
+      ["color.badge-danger-text", "color.badge-danger-bg"],
+      ["color.badge-neutral-text", "color.badge-neutral-bg"],
+    ]);
+    expect(result).not.toContainEqual(["color.badge-danger-text", "color.badge-neutral-bg"]);
+    expect(result).not.toContainEqual(["color.badge-neutral-text", "color.badge-danger-bg"]);
+  });
+
+  it("emits no pair when a role has -text but no matching -bg (real dana shape: badge-light-text + badge-light-border only)", () => {
+    expect(inferForegroundPairs(["color.badge-light-text", "color.badge-light-border"])).toEqual([]);
+  });
+
+  it("pairs the -fg synonym with its role's -bg", () => {
+    expect(inferForegroundPairs(["color.alert-fg", "color.alert-bg"])).toEqual([
+      ["color.alert-fg", "color.alert-bg"],
+    ]);
+  });
+
+  it("pairs the -ink synonym with its role's -bg", () => {
+    expect(inferForegroundPairs(["color.panel-ink", "color.panel-bg"])).toEqual([
+      ["color.panel-ink", "color.panel-bg"],
+    ]);
+  });
+
+  it("pairs the -content synonym with its role's -bg, but does NOT misfire on a bare surface token ending in 'content' (color.surface-content, real dana shape)", () => {
+    // "surface-content" itself ends in the "content" synonym, but has no "surface-content-bg"
+    // sibling — must fall through to no pair, not be treated as a stray foreground.
+    expect(inferForegroundPairs(["color.surface-content", "color.surface-chrome"])).toEqual([]);
+    // A real role-content/-bg pair still resolves.
+    expect(inferForegroundPairs(["color.callout-content", "color.callout-bg"])).toEqual([
+      ["color.callout-content", "color.callout-bg"],
+    ]);
+  });
+
+  it("still pairs shadcn's {role}-foreground convention correctly alongside a dana-style {role}-text/-bg pair (no regression from the synonym extension)", () => {
+    const paths = [
+      "color.primary",
+      "color.primary-foreground",
+      "color.badge-danger-text",
+      "color.badge-danger-bg",
+    ];
+    expect(inferForegroundPairs(paths)).toEqual([
+      ["color.badge-danger-text", "color.badge-danger-bg"],
+      ["color.primary-foreground", "color.primary"],
+    ]);
+  });
+
+  it("pairs a bare {role}-text with the bare {role} token when it exists (interactive-primary-text → interactive-primary, real dana shape)", () => {
+    expect(inferForegroundPairs(["color.interactive-primary", "color.interactive-primary-text"])).toEqual([
+      ["color.interactive-primary-text", "color.interactive-primary"],
+    ]);
+  });
+});
+
 // ─── hasForegroundTokens ────────────────────────────────────────────────────────
 
 describe("hasForegroundTokens", () => {


### PR DESCRIPTION
Fixes F11, the dogfood's noisiest finding: `ds a11y` reported **1011 false-positive contrast failures** on dana's imported design system.

## Root cause (measured, not guessed)

`ds a11y` runs `paired` mode (checks only declared `{role}`/`{role}-foreground` pairs) when the DS carries `-foreground` tokens, else falls to `inferred` cartesian mode (every text×surface combination — over-pairs).

dana has **0 tokens named `-foreground`** — but it declares `badge-danger-text`+`badge-danger-bg`, `badge-info-text`+`badge-info-bg`, etc. **The foreground/background pairs exist — dana just names them `-text`/`-bg`, not shadcn's `-foreground`.** The pairing inference only matched the literal `-foreground` suffix, so it missed dana's convention and fell to cartesian, checking 1540 combinations that mostly never render.

## The fix

One regex, grounded in the role-synonym dictionary committed today (`role-synonym-dictionary.md`, foreground row — `text`/`fg`/`content`/`ink` are the counted synonyms across Carbon/Material/Primer/…):

```
- FOREGROUND_RE = /^(.+?)[.\-/]foreground$/i
+ FOREGROUND_RE = /^(.+?)[.\-/](?:foreground|text|fg|content|ink)$/i
```

No other logic touched. The existing base-stripping + same-group-sibling lookup already enforces same-role-only pairing by construction, so `badge-danger-text` pairs with `badge-danger-bg` and nothing else. `ds-a11y.ts` untouched (mode selection already branches on `inferForegroundPairs(...).length`).

## Live result — dana-desktop

| | before | after |
|---|---|---|
| mode | `inferred` (cartesian) | `paired` |
| pairs checked | 1540 | 13 (+4 state) |
| failures | **1011** | **1** |

The 1 remaining is a **true positive, not suppressed**: `color.badge-info-text` on `color.badge-info-bg` — 4.1:1, fails normal-text AA (needs 4.5:1). A real DS bug the cartesian noise was burying.

## Safety — the over-pairing bug is not reintroduced

The comment names a prior bug (VSF "L3": cartesian mis-paired light text against dark panels). The fix is strictly `{sameRole}-text` on `{sameRole}-bg`. Explicit test: `badge-danger-text` pairs ONLY with `badge-danger-bg`, **never** `badge-neutral-bg`. Plus a fall-through test (`badge-light-text` with no matching `-bg` → no pair) and a regression test (a real `-foreground` DS still resolves). Caught a subtle risk in passing: dana's `surface-content` ends in the `-content` synonym but has no `-bg` sibling — verified it correctly falls through.

Four gates green, `ui knowledge check` clean, 2080 tests.

Report: `specs/009-code-road/reports/a11y-pairing-fix.md`