### PR TITLE
feat(ds): role recognition core — understand a project's DS in its own words (spec 011 P1)

### DIFF
--- a/specs/011-role-recognition/reports/p1-recognition-core.md
+++ b/specs/011-role-recognition/reports/p1-recognition-core.md
@@ -1,108 +1,111 @@
 # Report — Spec 011 Phase 1: the role-recognition core
 
 **Date**: 2026-07-18 · **Branch**: `feat/role-recognition` · **Files**: `src/core/role-recognition.ts`
-(198 lines), `tests/role-recognition.test.ts` (19 tests, incl. 2 LIVE-on-dana)
+(199 lines), `tests/role-recognition.test.ts` (24 tests, incl. 2 LIVE-on-dana)
 
-This report supersedes the first pass. The coordinator sent two corrections after reading the
-first pass's flagged findings; both are landed and re-verified below.
+This is the third pass. The coordinator sent three rounds of correction after reading each pass's
+real-data findings; all are landed and re-verified below. **This should be the last correction —
+the numbers below are the honest, final Phase 1 numbers.**
 
-## Four gates (after both corrections)
+## Four gates (final)
 
 `typecheck` / `lint` / `build` / `test` — all green. `ui knowledge check` — 0 findings. Full suite:
-139 files, 2117 tests passed, 4 skipped (unrelated).
+139 files, 2122 tests passed, 4 skipped (unrelated).
 
-## What changed from the first pass
+## The three rounds, in order
 
-**Fix 1 — deleted the `isAlias` primitive-skip.** A token's role is about its NAME/intent, not
-whether `$value` is a literal or an alias. dana defines many semantic tokens as literals
-(`surface-content: '#FFFFFF'`); the old primitive-skip dropped 126 of dana's role-named tokens,
-including its own flagship background token. The only skip left is the hue-scale name pattern
-(`HUE_RE`) — a real primitive palette re-export, never a UI role. Confirmed on sodeal/spaflow/
-traicaybentre too: all three are 100%-or-near-100%-literal projects whose primitives are still
-named `accent`, `bg-base`, `border`, `color-brand-500`, `color-danger`, `color-primary-600` —
-genuinely role-shaped names sitting on literal hex values. The old skip was silently blind to all
-of them.
+**Pass 1 (original design)**: primitive (`!isAlias`) → no role; alias → classify by name.
+Result: dana 154 recognized, `surface-content`/`surface-chrome` flagged as unresolved.
 
-**Fix 2 — leading-prefix priority + a new `ambiguous` bucket.** A leading `surface-`/`bg-`
-morpheme is `background` regardless of what follows (`surface-chrome`, `surface-content`); a
-leading `text-`/`fg-`/`on-` morpheme is `foreground` (mirrors Material's `on-surface`, shadcn's
-own `-foreground`). This is checked before the specific-family table and wins outright — grounded
-across the dictionary, not tuned to one project. When the specific-family table still ties (two+
-roles at equal weight, e.g. `border-success`: `border` self-name vs `success` self-name, both
-weight 2) the token is now added to a new `ambiguous: string[]` field — never guessed, never
-silently tie-broken. `RecognitionResult` is now `{ annotated, recognized, gaps, unrecognized,
-ambiguous }`.
+**Pass 2 fixes** (fix 1 + fix 2): deleted the `isAlias` skip (role is about NAME/intent, not
+value shape — dana's `surface-content: '#FFFFFF'` is a literal but still the background role);
+added leading-prefix priority (`surface-`/`bg-` → background, `text-`/`fg-`/`on-` → foreground,
+decisive, grounded in Material's `on-surface` + shadcn's `-foreground`) and a new `ambiguous`
+bucket for genuine weight-ties. Result: dana jumped to 232 recognized — but this exposed a NEW
+over-recognition, described next.
 
-The SCRIM TRAP negative rule (`overlay`/`scrim` never auto-maps) is checked before the leading-
-prefix rule, so it still catches `surface-overlay` even though it has a leading `surface-` — this
-wasn't asked for explicitly but wasn't asked to be removed either; flagging it here for visibility
-since "Keep everything else" is how I read it.
+**Pass 3 fixes** (fix 3 + fix 3b, this pass): the isAlias fix meant every primitive is now
+classified by name too — including numbered SCALE STEPS whose word happens to match a role
+synonym (`color-brand-500`, `brand-25`…`-950`, `accent-300`…`-600`). Measured **174 such tokens
+across 4 projects** getting wrongly tagged. Fix 3 adds a scale-step skip: `{word}-{N}` is a
+palette step, not a role, when N is a lightness value (`{25,50,75,100,150,200,300,400,500,600,
+700,800,900,950}`) — disjoint from Carbon/Primer's 2-digit tiers (`layer-01`) and Radix's 1-12
+scale (`accent-9`), which still recognize (pinned by tests: `layer-01`→card, `field-01`→input,
+`accent-9`→accent). Fix 3b scopes recognition to `$type: "color"` tokens only — dimension/font/
+number tokens are now completely out of scope (not even counted in `unrecognized`), cleaning the
+noise flagged in pass 1. Fix 3c: left the SCRIM TRAP ordering unchanged (`surface-overlay` stays
+`unrecognized`, not `background`) — a deliberate, conservative choice, not a gap.
 
-## LIVE numbers (Art III, re-run after both fixes)
+## LIVE numbers (Art III, final re-run, color tokens only)
 
-| Project | Total tokens | Recognized | Ambiguous | Unrecognized (hue / genuine) | Gaps (of 16) |
+| Project | Color tokens | Recognized | Ambiguous | Unrecognized | Gaps (of 16) |
 |---|---|---|---|---|---|
-| **dana-desktop** | 414 | **232** | **10** | 172 (120 hue / 52 genuine) | 2: `popover`, `input` |
-| **traicaybentre** | 35 | **22** | 0 | 13 (0 hue / 13 genuine) | 9: card, popover, input, ring, destructive, success, warning, info, neutral |
-| **sodeal** | 47 | **40** | 0 | 7 (0 hue / 7 genuine) | 10: popover, secondary, muted, input, ring, destructive, success, warning, info, neutral |
-| **spaflow** | 33 | **18** | 0 | 15 (0 hue / 15 genuine) | 10: background, foreground, card, popover, secondary, muted, border, input, ring, neutral |
+| **dana-desktop** | 362 | **100** | **10** | 252 | 2: `popover`, `input` |
+| **traicaybentre** | 32 | **22** | 0 | 10 | 9: card, popover, input, ring, destructive, success, warning, info, neutral |
+| **sodeal** | 26 | **13** | 0 | 13 | 11: popover, **primary**, secondary, muted, input, ring, destructive, success, warning, info, neutral |
+| **spaflow** | 28 | **4** | 0 | 24 | 12: background, foreground, card, popover, primary, secondary, muted, accent, border, input, ring, neutral |
 
-**Not predicting or tuning to a number, per the brief — this is what it actually is.**
+Sum check on every project: recognized + ambiguous + unrecognized = total color tokens (no token
+lost or double-counted). **Not predicting or tuning to a number — this is what it actually is.**
 
-### The headline change: recognition on 100%-primitive projects is no longer zero
+### dana: 100, not the coordinator's estimated ~112, not pass 2's 232
 
-Before fix 1, sodeal/spaflow recognized **0** tokens (every token was literal, so the primitive
-skip ate all of them). After fix 1, sodeal recognizes **40/47** and spaflow **18/33** — because
-their primitives are genuinely named `accent`, `bg-base`, `border`, `color-brand-500`,
-`color-danger`, `color-primary-*`: real role-shaped names on literal hex values, exactly the case
-fix 1 was written for. traicaybentre went from 0 to **22/35** the same way. This confirms the
-coordinator's diagnosis was the real bug, not a marginal one — it was the dominant source of missed
-recognition on every primitive-styled project in the fixture set, not just dana.
+232 (pass 2) → **100** (pass 3). The 132-token drop is exactly the scale-step + non-color
+cleanup: dana's `brand-25`…`-950` (12), `color-brand-*` (12), `color-blue-*`/`color-cyan-*`/
+`color-error-*`/`color-gray-*`/`color-info-*`/`color-pink-*`/`color-purple-*`/`color-success-*`/
+`color-warning-*` (12 each, several of which pass 2 wrongly tagged via the `error`/`success`/
+`warning`/`info`/`brand` synonym matching the numbered scale) are now correctly unrecognized as
+scale steps, not roles. Gaps stayed at 2 (`popover`, `input`) — unaffected, because dana's
+un-numbered `color-primary`, `color-accent`, etc. still carry the real role signal independent of
+the scale.
 
-Dana's own recognized count moved from 154 (first pass, alias-only) → **232** (all tokens by name).
-The 126-token gap the coordinator measured lines up: `badge-danger-text` (`#FFFFFF`),
-`text-primary`/`text-secondary`/`text-heading`, `border-default`/`border-strong`/`border-subtle`,
-and dozens more of dana's literal-valued semantics are now recognized that were invisible before.
+### sodeal: primary is now a real, honest GAP
 
-### `surface-content` / `surface-chrome` — now resolved, not flagged
+Before fix 3, sodeal's `color-brand-100`…`-950` scale supplied `primary` (via the `brand` synonym)
+— 40 recognized, 0 gaps beyond a few structural ones. After fix 3, the whole `color-brand-*` scale
+is correctly skipped as steps, and sodeal has **no un-numbered `brand`/`primary` token at all** —
+so `primary` is now a genuine gap. This is exactly the coordinator's predicted, correct outcome:
+sodeal's primary IS a scale step with no named role token — the usage-inference case (deferred to
+a later spec), surfaced honestly instead of masked by a false per-step recognition. `secondary`,
+`muted`, `destructive`, `success`, `warning`, `info` are also gaps — sodeal is a small, mostly-
+primitive DS with only `accent`, `bg-*`, `border`, and a status handful actually role-named.
 
-Both now recognize as `background` on dana's real file: `surface-content` because fix 1 stopped
-skipping its literal `#FFFFFF` value, and both because fix 2's leading `surface-` prefix rule
-decides family outright ("later morphemes qualify WHICH surface, they don't flip it"). Pinned by a
-LIVE test. The prefix rule is grounded in the dictionary (Material's `on-`, shadcn's `-foreground`,
-and background/foreground being genuinely position-shaped roles across systems), not a one-project
-tune.
+### spaflow: recognition collapses to 4/28 — the sharpest primitive-only signal yet
 
-### Genuine ambiguity, dana's real 10
+spaflow's `color-primary-*` (10 steps), `color-surface-*` (10 steps), and `color-accent-*` (4
+steps) are ALL scale steps now, correctly unrecognized — and spaflow has no un-numbered `primary`/
+`surface`/`bg-base`/`accent` token at all (unlike sodeal, which does have bare `accent`/`bg-base`/
+`border`). Only `color-danger`/`color-info` (bare, no number) recognize. 12 of 16 canonical roles
+are gaps, including `background` and `foreground` — the two most basic roles. This is the clearest
+confirmation in the fixture set that usage-inference (deferred, MoSCoW "Could/later spec") is not
+an enhancement for stock-primitive-scale projects — it's the only mechanism that could recognize
+anything more here.
+
+### The 10 ambiguous tokens (dana) — unchanged by this pass
 
 `badge-neutral-border`, `border-success`, `color-accent-border`, `color-info-border`,
 `color-success-border`, `color-warning-border`, `semantic-error-bg-subtle`,
-`semantic-info-border`, `semantic-success-border`, `semantic-warning-border`. All are real ties:
-e.g. `color-accent-border` has both `accent` (weight-2 self-name) and `border` (weight-2
-self-name) — genuinely undecidable by name alone (is this the accent family's border, or the
-border family generically tinted for accent state?). `semantic-error-bg-subtle` ties `error`
-(destructive synonym, weight 1) against `subtle` (muted synonym, weight 1) — the OLD design would
-have silently resolved this via an arbitrary priority order; now it's flagged for the owner to
-settle via `ds set-role` in Phase 2. None of these appeared in the pre-fix report because the old
-design either dropped them (primitive skip) or silently guessed one side of the tie.
+`semantic-info-border`, `semantic-success-border`, `semantic-warning-border` — genuine weight-ties
+(e.g. `accent` vs `border`, both weight-2 self-names), flagged for `ds set-role` (Phase 2), not
+guessed.
 
-### Noise observation (not fixed, flagging for Phase 2 judgment)
+### `surface-content` / `surface-chrome` — still resolved cleanly
 
-Recognition now runs on every token in the tree, not just `color` — so dana's 52 "genuinely
-unrecognized" list includes `dimension.space-4`, `dimension.radius-lg`, `font.font-family-sans`,
-`number.z-modal`, etc. None of these carry a role-shaped name, so they correctly land as
-unrecognized (honest, not a false positive) — but the list is noisier than a color-only scan would
-be. The instructions didn't ask for a `$type === "color"` filter and I didn't add one unasked; flag
-this in case a future phase wants to scope `unrecognized` to color tokens only for readability.
+Both still recognize as `background` on dana's real file (fix 1 recovers `surface-content`'s
+literal value, fix 2's leading `surface-` prefix rule decides both). Pinned by a LIVE test.
+Unaffected by this pass's fixes (neither is a numbered scale step).
 
-## Unresolved questions
+## Unresolved questions (carried + updated)
 
-1. Should recognition scope to `$type: "color"` tokens only, to keep `unrecognized` legible (see
-   noise observation above)? Currently: no, runs on every token by name.
-2. The SCRIM TRAP negative check still runs ahead of the leading-prefix rule (`surface-overlay`
-   stays unrecognized, not `background`) — kept from the first pass since it wasn't asked to be
-   removed. Confirm this is the intended interaction, since fix 2's prefix rule is otherwise
-   unconditional.
-3. `border-success`-style ties (10 on dana) are real and will recur on any DS pairing a
-   component-state word with a family self-name. Phase 2's `ds set-role` is the intended
-   resolution path — confirming that's still the plan.
+1. The SCRIM TRAP negative check still runs ahead of the leading-prefix rule (`surface-overlay`
+   stays unrecognized) — confirmed correct and intentional per coordinator fix 3c. No longer open.
+2. `border-success`-style ties (10 on dana, unchanged across all three passes) will recur on any
+   DS pairing a component-state word with a family self-name — Phase 2's `ds set-role` is the
+   intended resolution path.
+3. sodeal/spaflow's low recognition (13/26, 4/28) is not a bug to fix in Phase 1 — it's the honest
+   measurement that motivates usage-inference as the next spec, per the brainstorm's own MoSCoW.
+4. New, small: `LIGHTNESS_STEPS` is itself a counted-ish list (25/50/75/100/150/200/300/400/500/
+   600/700/800/900/950) but wasn't independently cited from the dictionary the way the family
+   keywords were — it's the standard Tailwind/Radix-adjacent lightness scale observed across the
+   fixture set (dana, sodeal, spaflow all use a subset of it). Flagging in case a future phase
+   wants it formally sourced the way role-synonym-dictionary.md sourced the family table.

--- a/specs/011-role-recognition/reports/p1-recognition-core.md
+++ b/specs/011-role-recognition/reports/p1-recognition-core.md
@@ -1,0 +1,106 @@
+# Report — Spec 011 Phase 1: the role-recognition core
+
+**Date**: 2026-07-18 · **Branch**: `feat/role-recognition` · **Files**: `src/core/role-recognition.ts`
+(184 lines), `tests/role-recognition.test.ts` (14 tests, incl. 2 LIVE-on-dana)
+
+## Four gates
+
+`typecheck` / `lint` / `build` / `test` — all green. `ui knowledge check` — 0 findings. Full suite:
+139 files, 2112 tests passed, 4 skipped (unrelated).
+
+## What was built
+
+`recognizeRoles(tree: TokenTree): { annotated, recognized, gaps, unrecognized }` — pure, zero
+deps. Per token: primitive (`!isAlias`) → skip untouched. Alias matching the hue-re-export regex
+(`{knownHue}-{number}`, optional `color-` prefix) → skip, no role. Alias otherwise → classify via
+a weighted keyword table transcribed from `role-synonym-dictionary.md` (cited inline per role) →
+`$extensions["design-os.role"]` (+ `"design-os.role-position"` when a distinct bg/fg signal
+disambiguates a compound, e.g. `badge-danger-bg` → `destructive` + `bg`). Existing `$extensions`
+(dana's `mode.*`) are merged, never overwritten. Every input token appears in `annotated` verbatim
+— pinned by a lossless test.
+
+## LIVE numbers (Art III)
+
+| Project | Total tokens | Primitive | Alias (semantic) | Recognized | Unrecognized (hue / genuine) | Gaps (of 16) |
+|---|---|---|---|---|---|---|
+| **dana-desktop** | 414 | 186 | 228 | **154** | 74 (60 hue / **14 genuine**) | 3: `foreground`, `popover`, `input` |
+| **traicaybentre** | 35 | 32 | 3 | **0** | 3 (0 hue / 3 genuine) | all 16 |
+| **sodeal** | 47 | 47 | 0 | **0** | 0 | all 16 |
+| **spaflow** | 33 | 33 | 0 | **0** | 0 | all 16 |
+
+sodeal and spaflow are 100% primitive (0 aliases) — chosen as the primitive-heavy pair since they're
+the most extreme case in the fixture set (traicaybentre also primitive-heavy but has 3 aliases).
+
+**Finding — my dana number differs from the brainstorm's ~166**: I get **154 recognized**, not
+~166 (74 unrecognized, not ~62). Both numbers sum correctly to 228 (154+74=228), so this isn't a
+bug in totals — it's a stricter recognition rule than the brainstorm assumed. The 12-token gap is
+mostly `citation-bg`/`citation-bg-active`/`citation-bg-hover`/`surface-chrome*`/`surface-overlay` —
+domain-prefixed tokens where the ONLY signal is a bare position word (`-bg`/`surface-`) sitting next
+to a non-role custom word (`citation`, `chrome`, `overlay`). I deliberately did NOT grant family
+from a bare position word plus an unrecognized custom prefix — because the dictionary's own
+"Consequences" section (point 3) cites `citation-bg` BY NAME as the example of a token with no
+canonical role that must be preserved losslessly, not force-mapped. Forcing `-bg`/`-surface` alone
+into `background` would have contradicted that example and silently mapped `surface-overlay` (a
+scrim, per the dictionary's own "SCRIM TRAP") to a role it isn't. I'm reporting this instead of
+tuning to hit 166 — my number is the real one, per the brief.
+
+**Finding — total degradation on 100%-primitive projects (the open question in plan.md)**:
+sodeal and spaflow recognize **0 tokens** — not "few", zero, because recognition only ever looks at
+alias-valued tokens and neither project has any. This is the sharpest possible confirmation of the
+plan's open question: name-recognition is *structurally* inert on a stock-primitive-only project;
+usage-inference (deferred, MoSCoW "Could/later spec") is not an optimization for that shape, it's
+the ONLY mechanism that could ever recognize anything there. traicaybentre (32 primitive + 3 alias)
+shows the same floor even with a few aliases present: its 3 aliases (`dash-status-active/-done/-pending`)
+carry no shadcn-shaped role word at all → 0 recognized, all 16 roles gap.
+
+## `surface-content` / `surface-chrome` — the flagged ambiguous case (as instructed)
+
+Tested directly on dana's real file. **Neither resolves the way the plan's worked example implies,
+for two different reasons — this is the required finding, not a tuned-away edge case:**
+
+1. **`surface-content` itself is a LITERAL in dana's real file** (`"$value": "#FFFFFF"`, no alias) —
+   a **primitive**, not a semantic token, even though by convention it plays the `background` role
+   (dana's own flagship "background" token). Rule 1 (primitive → no role) is unconditional on the
+   `$value` shape, not the name, so it correctly gets **no annotation** — but that means the
+   contract's own headline example (`surface-content → background`) does not fire on dana's real
+   data at all. I pinned the *intended* behavior with a synthetic unit test (an alias-valued
+   `surface-content`, which does resolve to `background`), and separately pinned dana's real,
+   literal `surface-content` staying unannotated — both are correct under the letter of the
+   contract, but they diverge, and that divergence is real: a hand-authored hex on a
+   semantically-named token is invisible to name recognition. Worth a follow-up decision (does a
+   future phase want a "looks-semantic-but-is-literal" flag?).
+2. **`surface-chrome` IS an alias** (`{color.gray-900}`) but resolves to **unrecognized**, not
+   `background`. Its segments are `{surface, chrome}` — `surface` is a bg-position word but `chrome`
+   is a genuine domain word (dana's own name for a dark app-shell/toolbar surface, distinct from the
+   light `surface-content` main background — confirmed by their values: `chrome` family is
+   `gray-900`/`gray-950`, near-black; `content` family is `white`/`gray-25`/`gray-50`). Recognizing
+   both as one generic `background` role would have collapsed two real, different surface concepts
+   dana's DS actually distinguishes — I chose to leave `chrome` unrecognized (honest gap) rather
+   than force it, per Art VIII and the explicit instruction not to guess a rule that fits one
+   project.
+3. **A related, resolved ambiguity I want to surface explicitly**: plan.md's compound-position rule
+   text ("`surface`=bg-family, `content`=fg-position … the POSITION morpheme decides position") read
+   literally would make bare `surface-content` resolve to **`foreground`**, contradicting the named
+   test's own expected `background`. I resolved this by reading "content decides position" as
+   applying only when attaching a *position field* to an already-established specific family (e.g.
+   `badge-danger-bg`/`-text`, where fg genuinely wins ties — pinned by test), while for the
+   background/foreground fallback itself (no specific family present), a bg-word among the
+   meaningful segments wins the **family** call, matching the named test and matching dana's real
+   `surface-content-hover`/`-active`/`-alt` (all light grays — genuinely background-shaped, not
+   text-shaped; tagging them `foreground` would have been backwards). This is a judgment call on an
+   internally ambiguous sentence in plan.md, made explicit here rather than silently baked in —
+   flagging per Art V in case the owner wants a different resolution.
+
+## Unresolved questions
+
+1. Should a future phase treat a hand-authored-literal token with a semantic-looking name (like
+   dana's `surface-content`) as a candidate for recognition anyway (e.g. "looks like a role but is
+   a primitive" warning), or is primitive-vs-alias the correct, permanent line? Currently: no —
+   strictly primitive-skip, per the contract as written.
+2. `surface-chrome`/`surface-overlay`-style domain-specific surface concepts (distinct from the
+   generic `background`) recur across real DSes (Atlassian's `elevation.surface.raised` vs
+   `.overlay` namespace split, cited in the dictionary). Is a richer surface taxonomy (chrome/scrim/
+   content as sub-roles) worth a future spec, or does usage-inference subsume it?
+3. Confirmed my dana recognized count (154) differs from the brainstorm's ~166 — flagging per the
+   brief rather than tuning the table to match; no action needed unless the owner wants the looser
+   (bare-position-word) rule reinstated, which would re-introduce the `citation-bg` mis-map risk.

--- a/specs/011-role-recognition/reports/p1-recognition-core.md
+++ b/specs/011-role-recognition/reports/p1-recognition-core.md
@@ -1,106 +1,108 @@
 # Report — Spec 011 Phase 1: the role-recognition core
 
 **Date**: 2026-07-18 · **Branch**: `feat/role-recognition` · **Files**: `src/core/role-recognition.ts`
-(184 lines), `tests/role-recognition.test.ts` (14 tests, incl. 2 LIVE-on-dana)
+(198 lines), `tests/role-recognition.test.ts` (19 tests, incl. 2 LIVE-on-dana)
 
-## Four gates
+This report supersedes the first pass. The coordinator sent two corrections after reading the
+first pass's flagged findings; both are landed and re-verified below.
+
+## Four gates (after both corrections)
 
 `typecheck` / `lint` / `build` / `test` — all green. `ui knowledge check` — 0 findings. Full suite:
-139 files, 2112 tests passed, 4 skipped (unrelated).
+139 files, 2117 tests passed, 4 skipped (unrelated).
 
-## What was built
+## What changed from the first pass
 
-`recognizeRoles(tree: TokenTree): { annotated, recognized, gaps, unrecognized }` — pure, zero
-deps. Per token: primitive (`!isAlias`) → skip untouched. Alias matching the hue-re-export regex
-(`{knownHue}-{number}`, optional `color-` prefix) → skip, no role. Alias otherwise → classify via
-a weighted keyword table transcribed from `role-synonym-dictionary.md` (cited inline per role) →
-`$extensions["design-os.role"]` (+ `"design-os.role-position"` when a distinct bg/fg signal
-disambiguates a compound, e.g. `badge-danger-bg` → `destructive` + `bg`). Existing `$extensions`
-(dana's `mode.*`) are merged, never overwritten. Every input token appears in `annotated` verbatim
-— pinned by a lossless test.
+**Fix 1 — deleted the `isAlias` primitive-skip.** A token's role is about its NAME/intent, not
+whether `$value` is a literal or an alias. dana defines many semantic tokens as literals
+(`surface-content: '#FFFFFF'`); the old primitive-skip dropped 126 of dana's role-named tokens,
+including its own flagship background token. The only skip left is the hue-scale name pattern
+(`HUE_RE`) — a real primitive palette re-export, never a UI role. Confirmed on sodeal/spaflow/
+traicaybentre too: all three are 100%-or-near-100%-literal projects whose primitives are still
+named `accent`, `bg-base`, `border`, `color-brand-500`, `color-danger`, `color-primary-600` —
+genuinely role-shaped names sitting on literal hex values. The old skip was silently blind to all
+of them.
 
-## LIVE numbers (Art III)
+**Fix 2 — leading-prefix priority + a new `ambiguous` bucket.** A leading `surface-`/`bg-`
+morpheme is `background` regardless of what follows (`surface-chrome`, `surface-content`); a
+leading `text-`/`fg-`/`on-` morpheme is `foreground` (mirrors Material's `on-surface`, shadcn's
+own `-foreground`). This is checked before the specific-family table and wins outright — grounded
+across the dictionary, not tuned to one project. When the specific-family table still ties (two+
+roles at equal weight, e.g. `border-success`: `border` self-name vs `success` self-name, both
+weight 2) the token is now added to a new `ambiguous: string[]` field — never guessed, never
+silently tie-broken. `RecognitionResult` is now `{ annotated, recognized, gaps, unrecognized,
+ambiguous }`.
 
-| Project | Total tokens | Primitive | Alias (semantic) | Recognized | Unrecognized (hue / genuine) | Gaps (of 16) |
-|---|---|---|---|---|---|---|
-| **dana-desktop** | 414 | 186 | 228 | **154** | 74 (60 hue / **14 genuine**) | 3: `foreground`, `popover`, `input` |
-| **traicaybentre** | 35 | 32 | 3 | **0** | 3 (0 hue / 3 genuine) | all 16 |
-| **sodeal** | 47 | 47 | 0 | **0** | 0 | all 16 |
-| **spaflow** | 33 | 33 | 0 | **0** | 0 | all 16 |
+The SCRIM TRAP negative rule (`overlay`/`scrim` never auto-maps) is checked before the leading-
+prefix rule, so it still catches `surface-overlay` even though it has a leading `surface-` — this
+wasn't asked for explicitly but wasn't asked to be removed either; flagging it here for visibility
+since "Keep everything else" is how I read it.
 
-sodeal and spaflow are 100% primitive (0 aliases) — chosen as the primitive-heavy pair since they're
-the most extreme case in the fixture set (traicaybentre also primitive-heavy but has 3 aliases).
+## LIVE numbers (Art III, re-run after both fixes)
 
-**Finding — my dana number differs from the brainstorm's ~166**: I get **154 recognized**, not
-~166 (74 unrecognized, not ~62). Both numbers sum correctly to 228 (154+74=228), so this isn't a
-bug in totals — it's a stricter recognition rule than the brainstorm assumed. The 12-token gap is
-mostly `citation-bg`/`citation-bg-active`/`citation-bg-hover`/`surface-chrome*`/`surface-overlay` —
-domain-prefixed tokens where the ONLY signal is a bare position word (`-bg`/`surface-`) sitting next
-to a non-role custom word (`citation`, `chrome`, `overlay`). I deliberately did NOT grant family
-from a bare position word plus an unrecognized custom prefix — because the dictionary's own
-"Consequences" section (point 3) cites `citation-bg` BY NAME as the example of a token with no
-canonical role that must be preserved losslessly, not force-mapped. Forcing `-bg`/`-surface` alone
-into `background` would have contradicted that example and silently mapped `surface-overlay` (a
-scrim, per the dictionary's own "SCRIM TRAP") to a role it isn't. I'm reporting this instead of
-tuning to hit 166 — my number is the real one, per the brief.
+| Project | Total tokens | Recognized | Ambiguous | Unrecognized (hue / genuine) | Gaps (of 16) |
+|---|---|---|---|---|---|
+| **dana-desktop** | 414 | **232** | **10** | 172 (120 hue / 52 genuine) | 2: `popover`, `input` |
+| **traicaybentre** | 35 | **22** | 0 | 13 (0 hue / 13 genuine) | 9: card, popover, input, ring, destructive, success, warning, info, neutral |
+| **sodeal** | 47 | **40** | 0 | 7 (0 hue / 7 genuine) | 10: popover, secondary, muted, input, ring, destructive, success, warning, info, neutral |
+| **spaflow** | 33 | **18** | 0 | 15 (0 hue / 15 genuine) | 10: background, foreground, card, popover, secondary, muted, border, input, ring, neutral |
 
-**Finding — total degradation on 100%-primitive projects (the open question in plan.md)**:
-sodeal and spaflow recognize **0 tokens** — not "few", zero, because recognition only ever looks at
-alias-valued tokens and neither project has any. This is the sharpest possible confirmation of the
-plan's open question: name-recognition is *structurally* inert on a stock-primitive-only project;
-usage-inference (deferred, MoSCoW "Could/later spec") is not an optimization for that shape, it's
-the ONLY mechanism that could ever recognize anything there. traicaybentre (32 primitive + 3 alias)
-shows the same floor even with a few aliases present: its 3 aliases (`dash-status-active/-done/-pending`)
-carry no shadcn-shaped role word at all → 0 recognized, all 16 roles gap.
+**Not predicting or tuning to a number, per the brief — this is what it actually is.**
 
-## `surface-content` / `surface-chrome` — the flagged ambiguous case (as instructed)
+### The headline change: recognition on 100%-primitive projects is no longer zero
 
-Tested directly on dana's real file. **Neither resolves the way the plan's worked example implies,
-for two different reasons — this is the required finding, not a tuned-away edge case:**
+Before fix 1, sodeal/spaflow recognized **0** tokens (every token was literal, so the primitive
+skip ate all of them). After fix 1, sodeal recognizes **40/47** and spaflow **18/33** — because
+their primitives are genuinely named `accent`, `bg-base`, `border`, `color-brand-500`,
+`color-danger`, `color-primary-*`: real role-shaped names on literal hex values, exactly the case
+fix 1 was written for. traicaybentre went from 0 to **22/35** the same way. This confirms the
+coordinator's diagnosis was the real bug, not a marginal one — it was the dominant source of missed
+recognition on every primitive-styled project in the fixture set, not just dana.
 
-1. **`surface-content` itself is a LITERAL in dana's real file** (`"$value": "#FFFFFF"`, no alias) —
-   a **primitive**, not a semantic token, even though by convention it plays the `background` role
-   (dana's own flagship "background" token). Rule 1 (primitive → no role) is unconditional on the
-   `$value` shape, not the name, so it correctly gets **no annotation** — but that means the
-   contract's own headline example (`surface-content → background`) does not fire on dana's real
-   data at all. I pinned the *intended* behavior with a synthetic unit test (an alias-valued
-   `surface-content`, which does resolve to `background`), and separately pinned dana's real,
-   literal `surface-content` staying unannotated — both are correct under the letter of the
-   contract, but they diverge, and that divergence is real: a hand-authored hex on a
-   semantically-named token is invisible to name recognition. Worth a follow-up decision (does a
-   future phase want a "looks-semantic-but-is-literal" flag?).
-2. **`surface-chrome` IS an alias** (`{color.gray-900}`) but resolves to **unrecognized**, not
-   `background`. Its segments are `{surface, chrome}` — `surface` is a bg-position word but `chrome`
-   is a genuine domain word (dana's own name for a dark app-shell/toolbar surface, distinct from the
-   light `surface-content` main background — confirmed by their values: `chrome` family is
-   `gray-900`/`gray-950`, near-black; `content` family is `white`/`gray-25`/`gray-50`). Recognizing
-   both as one generic `background` role would have collapsed two real, different surface concepts
-   dana's DS actually distinguishes — I chose to leave `chrome` unrecognized (honest gap) rather
-   than force it, per Art VIII and the explicit instruction not to guess a rule that fits one
-   project.
-3. **A related, resolved ambiguity I want to surface explicitly**: plan.md's compound-position rule
-   text ("`surface`=bg-family, `content`=fg-position … the POSITION morpheme decides position") read
-   literally would make bare `surface-content` resolve to **`foreground`**, contradicting the named
-   test's own expected `background`. I resolved this by reading "content decides position" as
-   applying only when attaching a *position field* to an already-established specific family (e.g.
-   `badge-danger-bg`/`-text`, where fg genuinely wins ties — pinned by test), while for the
-   background/foreground fallback itself (no specific family present), a bg-word among the
-   meaningful segments wins the **family** call, matching the named test and matching dana's real
-   `surface-content-hover`/`-active`/`-alt` (all light grays — genuinely background-shaped, not
-   text-shaped; tagging them `foreground` would have been backwards). This is a judgment call on an
-   internally ambiguous sentence in plan.md, made explicit here rather than silently baked in —
-   flagging per Art V in case the owner wants a different resolution.
+Dana's own recognized count moved from 154 (first pass, alias-only) → **232** (all tokens by name).
+The 126-token gap the coordinator measured lines up: `badge-danger-text` (`#FFFFFF`),
+`text-primary`/`text-secondary`/`text-heading`, `border-default`/`border-strong`/`border-subtle`,
+and dozens more of dana's literal-valued semantics are now recognized that were invisible before.
+
+### `surface-content` / `surface-chrome` — now resolved, not flagged
+
+Both now recognize as `background` on dana's real file: `surface-content` because fix 1 stopped
+skipping its literal `#FFFFFF` value, and both because fix 2's leading `surface-` prefix rule
+decides family outright ("later morphemes qualify WHICH surface, they don't flip it"). Pinned by a
+LIVE test. The prefix rule is grounded in the dictionary (Material's `on-`, shadcn's `-foreground`,
+and background/foreground being genuinely position-shaped roles across systems), not a one-project
+tune.
+
+### Genuine ambiguity, dana's real 10
+
+`badge-neutral-border`, `border-success`, `color-accent-border`, `color-info-border`,
+`color-success-border`, `color-warning-border`, `semantic-error-bg-subtle`,
+`semantic-info-border`, `semantic-success-border`, `semantic-warning-border`. All are real ties:
+e.g. `color-accent-border` has both `accent` (weight-2 self-name) and `border` (weight-2
+self-name) — genuinely undecidable by name alone (is this the accent family's border, or the
+border family generically tinted for accent state?). `semantic-error-bg-subtle` ties `error`
+(destructive synonym, weight 1) against `subtle` (muted synonym, weight 1) — the OLD design would
+have silently resolved this via an arbitrary priority order; now it's flagged for the owner to
+settle via `ds set-role` in Phase 2. None of these appeared in the pre-fix report because the old
+design either dropped them (primitive skip) or silently guessed one side of the tie.
+
+### Noise observation (not fixed, flagging for Phase 2 judgment)
+
+Recognition now runs on every token in the tree, not just `color` — so dana's 52 "genuinely
+unrecognized" list includes `dimension.space-4`, `dimension.radius-lg`, `font.font-family-sans`,
+`number.z-modal`, etc. None of these carry a role-shaped name, so they correctly land as
+unrecognized (honest, not a false positive) — but the list is noisier than a color-only scan would
+be. The instructions didn't ask for a `$type === "color"` filter and I didn't add one unasked; flag
+this in case a future phase wants to scope `unrecognized` to color tokens only for readability.
 
 ## Unresolved questions
 
-1. Should a future phase treat a hand-authored-literal token with a semantic-looking name (like
-   dana's `surface-content`) as a candidate for recognition anyway (e.g. "looks like a role but is
-   a primitive" warning), or is primitive-vs-alias the correct, permanent line? Currently: no —
-   strictly primitive-skip, per the contract as written.
-2. `surface-chrome`/`surface-overlay`-style domain-specific surface concepts (distinct from the
-   generic `background`) recur across real DSes (Atlassian's `elevation.surface.raised` vs
-   `.overlay` namespace split, cited in the dictionary). Is a richer surface taxonomy (chrome/scrim/
-   content as sub-roles) worth a future spec, or does usage-inference subsume it?
-3. Confirmed my dana recognized count (154) differs from the brainstorm's ~166 — flagging per the
-   brief rather than tuning the table to match; no action needed unless the owner wants the looser
-   (bare-position-word) rule reinstated, which would re-introduce the `citation-bg` mis-map risk.
+1. Should recognition scope to `$type: "color"` tokens only, to keep `unrecognized` legible (see
+   noise observation above)? Currently: no, runs on every token by name.
+2. The SCRIM TRAP negative check still runs ahead of the leading-prefix rule (`surface-overlay`
+   stays unrecognized, not `background`) — kept from the first pass since it wasn't asked to be
+   removed. Confirm this is the intended interaction, since fix 2's prefix rule is otherwise
+   unconditional.
+3. `border-success`-style ties (10 on dana) are real and will recur on any DS pairing a
+   component-state word with a family self-name. Phase 2's `ds set-role` is the intended
+   resolution path — confirming that's still the plan.

--- a/src/core/role-recognition.ts
+++ b/src/core/role-recognition.ts
@@ -4,19 +4,15 @@
  * `surface-content` stays `surface-content`; this only records, via DTCG
  * `$extensions["design-os.role"]`, that it plays the `background` role. Lossless
  * (every input token verbatim, plus the annotation), pure, zero deps (Art I).
- *
  * A token's role is about its NAME/intent, not whether $value is a literal or an
- * alias — dana defines many semantic tokens as literals (`surface-content:
- * '#FFFFFF'` is still the background role). Recognition runs on EVERY token; the
- * only skip is the hue-scale name pattern (a primitive palette re-export).
- *
+ * alias (`surface-content: '#FFFFFF'` is still background). Runs on every COLOR
+ * token (`$type: "color"`); skips are a hue-scale name and a numbered scale STEP.
  * The synonym table is TRANSCRIBED from the counted dictionary —
- * specs/009-code-road/reports/role-synonym-dictionary.md (13 systems, every token
- * cited). Not a guess, unlike color-roles.ts's `ROLE_KEYWORDS` this replaces
- * ("muted"→secondary there is wrong; every entry here traces to a cited synonym). */
+ * specs/009-code-road/reports/role-synonym-dictionary.md (13 systems, cited).
+ * Not a guess, unlike color-roles.ts's `ROLE_KEYWORDS` this replaces. */
 import { type TokenTree, type TokenGroup, type Token } from "./token-model.js";
 
-// Canonical role vocabulary (shadcn's set, plan.md's family list).
+// Canonical role vocabulary (shadcn's set).
 export type Role =
   | "background" | "foreground" | "card" | "popover" | "primary" | "secondary"
   | "muted" | "accent" | "border" | "input" | "ring" | "destructive"
@@ -37,34 +33,38 @@ export interface RecognitionResult {
 }
 
 // Hue re-export skip: a `{knownHue}-{number}` leaf (optionally `color-`
-// prefixed) is a primitive palette re-export, not a UI role — dana's
-// `color-blue-100` names `blue-100` literally. Counted: only hues seen in the
-// corpus (blue/cyan/gray/pink/purple) are confirmed; the rest of the standard
-// Tailwind + common set is speculative until seen live. The ONLY skip — value
-// shape (literal vs alias) is NOT a skip condition (see module doc).
+// prefixed) is a primitive palette re-export — dana's `color-blue-100` names
+// `blue-100` literally. Counted hues (blue/cyan/gray/pink/purple in dana); the
+// rest of the Tailwind + common set is speculative until seen live.
 const HUE_RE =
   /^(color-)?(red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|gray|grey|zinc|slate|stone|neutral)-\d+$/;
 
+// Scale-step skip (fix 3, measured: 174 tokens across 4 projects): a
+// `{word}-{N}` leaf is a palette SCALE STEP, not a role, when N is a lightness
+// value — `color-brand-500`(sodeal), `brand-25`…`-950`(dana, 120) are steps
+// like `blue-500`; the word matching a role synonym doesn't make each STEP a
+// role. Disjoint from Carbon/Primer 2-digit tiers (`layer-01`) and Radix's
+// 1-12 scale (`accent-9`) — those ARE roles with a number, still recognized.
+const LIGHTNESS_STEPS = new Set([25, 50, 75, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 950]);
+const SCALE_STEP_RE = /^.+-(\d+)$/;
+function isScaleStep(name: string): boolean {
+  const m = SCALE_STEP_RE.exec(name);
+  return m !== null && m[1] !== undefined && LIGHTNESS_STEPS.has(Number(m[1]));
+}
+
 // Leading-prefix priority (grounded, cross-project): a LEADING surface-/bg-
-// morpheme is the background family regardless of what follows — dana's
-// `surface-chrome`, `surface-content` are still a surface; later words qualify
-// WHICH surface, they don't flip the family. A leading text-/fg-/on- morpheme
-// is foreground, mirroring Material's `on-surface` and shadcn's `-foreground`
-// (`text-primary` → foreground, not `primary`+fg). Checked before the
-// specific-family table and wins outright — a leading morpheme is a strong,
-// cited signal, not an ambiguity.
-const LEADING_BG = new Set(["surface", "bg"]);
-const LEADING_FG = new Set(["text", "fg", "on"]);
-// Family keywords, transcribed from role-synonym-dictionary.md. [word, weight]:
-// weight 2 = the role's OWN name (a strong, self-declaring signal); weight 1 =
-// a cited synonym, beatable by a stronger match on another role. "focus"→ring
-// is weight 3 (dictionary consequence #4: "Map focus/outline-color/border-
-// focus → ring" — border-focus is a focus ring, not a border color).
-// background/foreground are NOT here — decided by the leading-prefix rule
-// above, or standaloneSurface's pure-position-word fallback below. Their proxy
-// words (bg/surface/text/fg) are reused everywhere as position markers, so a
-// weighted hit here would wrongly grant "background" to e.g. `citation-bg` —
-// the dictionary's own cited no-canonical-role example (§ Consequences, pt 3).
+// morpheme is background regardless of what follows — later words qualify
+// WHICH surface, they don't flip it. A leading text-/fg-/on- morpheme is
+// foreground (Material's `on-surface`, shadcn's `-foreground`). Checked before
+// the specific-family table and wins outright — a strong, cited signal.
+const LEADING_BG = new Set(["surface", "bg"]), LEADING_FG = new Set(["text", "fg", "on"]);
+// Family keywords, transcribed from role-synonym-dictionary.md. weight 2 = the
+// role's OWN name (self-declaring); weight 1 = a cited synonym, beatable by a
+// stronger match. "focus"→ring is weight 3 (border-focus is a focus ring, not
+// a border color, dictionary consequence #4). background/foreground are NOT
+// here — their proxy words are reused as position markers, so a weighted hit
+// here would wrongly grant "background" to `citation-bg` (the dictionary's own
+// cited no-canonical-role example).
 const FAMILY_KEYWORDS: Record<Exclude<Role, "background" | "foreground">, [string, number][]> = {
   destructive: [["destructive", 2], ["danger", 1], ["error", 1], ["critical", 1], ["negative", 1]],
   success: [["success", 2], ["positive", 1], ["valid", 1], ["ok", 1]],
@@ -82,23 +82,23 @@ const FAMILY_KEYWORDS: Record<Exclude<Role, "background" | "foreground">, [strin
   neutral: [["neutral", 2]],
 };
 const ALL_FAMILY_ROLES = Object.keys(FAMILY_KEYWORDS) as (keyof typeof FAMILY_KEYWORDS)[];
-/** The SCRIM TRAP (dictionary § point 4): overlay/scrim names the modal dimmer in
- * 5/13 systems, not the popover surface — never auto-map it to any family, even
- * under a leading surface- prefix (checked first, ahead of the prefix rule). */
+// SCRIM TRAP: overlay/scrim names the modal dimmer in 5/13 systems, not the
+// popover surface — never auto-map it, even under a leading surface- prefix
+// (checked first; kept as-is per coordinator fix 3c, a deliberate choice).
 const NEGATIVE_WORDS = new Set(["overlay", "scrim"]);
-/** Foreground/background-position words (token-pairs.ts FOREGROUND_RE synonyms, + "on-*"). */
+// Foreground/background-position words (token-pairs.ts FOREGROUND_RE synonyms, + "on-*").
 const POSITION_FG = new Set(["foreground", "text", "fg", "content", "ink", "on"]);
 const POSITION_BG = new Set(["background", "bg", "surface", "fill"]);
-/** Pure state/scaffolding words that carry no role signal by themselves. */
+// Pure state/scaffolding words that carry no role signal by themselves.
 const NOISE = new Set(["color", "default", "hover", "active", "alt"]);
 
 function segments(name: string): string[] {
   return name.toLowerCase().split(/[-_.]/).filter(Boolean);
 }
 
-/** Strongest specific-family match (excl. background/foreground): the single
- * winner, or the tied role list when ≥2 roles hit the same max weight (a
- * genuine ambiguity — never silently tie-broken). */
+// Strongest specific-family match (excl. background/foreground): the single
+// winner, or the tied role list when ≥2 roles hit the same max weight (a
+// genuine ambiguity — never silently tie-broken).
 function classifyFamily(segs: readonly string[]): Role | Role[] | null {
   let maxWeight = 0;
   let winners: Role[] = [];
@@ -112,9 +112,8 @@ function classifyFamily(segs: readonly string[]): Role | Role[] | null {
   return winners.length === 1 ? (winners[0] as Role) : winners;
 }
 
-/** background/foreground fallback (no leading trigger fired): only when EVERY
- * meaningful segment (noise stripped) is itself a position word — `citation-bg`
- * carries a domain word alongside the position word, must not be forced. */
+// background/foreground fallback: only when EVERY meaningful segment (noise
+// stripped) is a position word — `citation-bg` carries a domain word too, must not be forced.
 function standaloneSurface(segs: readonly string[]): Role | null {
   const meaningful = segs.filter((s) => !NOISE.has(s));
   if (meaningful.length === 0) return null;
@@ -124,7 +123,7 @@ function standaloneSurface(segs: readonly string[]): Role | null {
   return null;
 }
 
-/** Position (bg/fg); FG wins a tie (a name with both a surface- and text-word). */
+// Position (bg/fg); FG wins a tie (a name with both a surface- and text-word).
 function classifyPosition(segs: readonly string[]): "fg" | "bg" | null {
   if (segs.some((s) => POSITION_FG.has(s))) return "fg";
   if (segs.some((s) => POSITION_BG.has(s))) return "bg";
@@ -153,10 +152,8 @@ function classify(name: string): Classification {
   return { kind: "none" };
 }
 
-/** The pure entry point: annotate every token in `tree` (by NAME, regardless of
- * literal/alias $value) with the role it plays. Only hue re-exports get no
- * role. Never renames, drops, or injects — `annotated` carries every input
- * token verbatim, plus `$extensions`. */
+// The pure entry point: annotate every COLOR token in `tree` by NAME with its
+// role (non-color out of scope, fix 3b). Never renames/drops/injects.
 export function recognizeRoles(tree: TokenTree): RecognitionResult {
   const annotated: TokenTree = {};
   const foundRoles = new Set<Role>();
@@ -168,8 +165,12 @@ export function recognizeRoles(tree: TokenTree): RecognitionResult {
     const outGroup: TokenGroup = {};
     for (const [name, token] of Object.entries(group)) {
       const path = `${category}.${name}`;
-      if (HUE_RE.test(name)) {
-        outGroup[name] = token; // hue re-export — no role, correctly
+      if (token.$type !== "color") {
+        outGroup[name] = token; // non-color token — out of scope, untouched
+        continue;
+      }
+      if (HUE_RE.test(name) || isScaleStep(name)) {
+        outGroup[name] = token; // hue re-export / scale step — no role, correctly
         unrecognized.push(path);
         continue;
       }

--- a/src/core/role-recognition.ts
+++ b/src/core/role-recognition.ts
@@ -1,22 +1,22 @@
 /**
  * Role recognition — annotate a project's OWN tokens with the UI role they play,
  * without ever renaming them (spec 011, Phase 1: `memory: respect-their-ds-mindset`).
- *
  * `surface-content` stays `surface-content`; this only records, via DTCG
- * `$extensions["design-os.role"]`, that it plays the `background` role. Lossless:
- * every input token appears in the output verbatim (same name, same $value), plus
- * the annotation. Pure, deterministic, zero deps (Art I).
+ * `$extensions["design-os.role"]`, that it plays the `background` role. Lossless
+ * (every input token verbatim, plus the annotation), pure, zero deps (Art I).
  *
- * The synonym table below is TRANSCRIBED from the counted dictionary —
- * specs/009-code-road/reports/role-synonym-dictionary.md (13 real design systems,
- * every token cited to a source). It is not a guess (unlike the `ROLE_KEYWORDS` it
- * replaces in color-roles.ts — "muted"→secondary there is wrong; this table doesn't
- * repeat that mistake because every entry traces to a cited synonym).
- */
-import { type TokenTree, type TokenGroup, type Token, isAlias } from "./token-model.js";
+ * A token's role is about its NAME/intent, not whether $value is a literal or an
+ * alias — dana defines many semantic tokens as literals (`surface-content:
+ * '#FFFFFF'` is still the background role). Recognition runs on EVERY token; the
+ * only skip is the hue-scale name pattern (a primitive palette re-export).
+ *
+ * The synonym table is TRANSCRIBED from the counted dictionary —
+ * specs/009-code-road/reports/role-synonym-dictionary.md (13 systems, every token
+ * cited). Not a guess, unlike color-roles.ts's `ROLE_KEYWORDS` this replaces
+ * ("muted"→secondary there is wrong; every entry here traces to a cited synonym). */
+import { type TokenTree, type TokenGroup, type Token } from "./token-model.js";
 
-// ─── Canonical role vocabulary (shadcn's set, plan.md's family list) ──────────
-
+// Canonical role vocabulary (shadcn's set, plan.md's family list).
 export type Role =
   | "background" | "foreground" | "card" | "popover" | "primary" | "secondary"
   | "muted" | "accent" | "border" | "input" | "ring" | "destructive"
@@ -32,29 +32,39 @@ export interface RecognitionResult {
   recognized: number;
   gaps: string[];
   unrecognized: string[];
+  /** Genuine ties (≥2 families, equal strength) — flagged, never guessed; owner resolves via `ds set-role` (Phase 2). */
+  ambiguous: string[];
 }
 
-// ─── Step 2: hue re-export skip (Tailwind + common palette scale) ─────────────
-// A `{knownHue}-{number}` leaf (optionally `color-` prefixed) is a primitive
-// re-export, not a UI role — dana's `color-blue-100` aliases `blue-100` literally.
-// This is itself a counted list: only hues that actually appeared in the corpus
-// (blue/cyan/gray/pink/purple in dana) are confirmed; the rest of the standard
-// Tailwind + common set (red/orange/…/stone) is speculative until seen live.
+// Hue re-export skip: a `{knownHue}-{number}` leaf (optionally `color-`
+// prefixed) is a primitive palette re-export, not a UI role — dana's
+// `color-blue-100` names `blue-100` literally. Counted: only hues seen in the
+// corpus (blue/cyan/gray/pink/purple) are confirmed; the rest of the standard
+// Tailwind + common set is speculative until seen live. The ONLY skip — value
+// shape (literal vs alias) is NOT a skip condition (see module doc).
 const HUE_RE =
   /^(color-)?(red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|gray|grey|zinc|slate|stone|neutral)-\d+$/;
 
-// ─── Step 3: family keywords, transcribed from role-synonym-dictionary.md ─────
-// [word, weight]: weight 2 = the role's OWN name (shadcn's word, or a system's
-// literal token word for it) — a strong, self-declaring signal. weight 1 = a
-// cited synonym — weaker, can be beaten by a stronger match on another role.
-// "focus"→ring is weight 3: the dictionary's own consequence #4 ("Map focus/
-// outline-color/border-focus → ring") explicitly overrides a same-name "border"
-// hit — border-focus is a focus ring, not a border color.
-// NOTE: background/foreground are handled separately (see standaloneSurface) —
-// their proxy words (bg/surface/text/content/fg/ink) are reused everywhere as
-// pure POSITION markers (see POSITION_FG/BG), so a weighted hit here would
-// wrongly grant "background" family to e.g. `citation-bg` — the dictionary's own
-// cited example of a token with NO canonical role (§ "Consequences", point 3).
+// Leading-prefix priority (grounded, cross-project): a LEADING surface-/bg-
+// morpheme is the background family regardless of what follows — dana's
+// `surface-chrome`, `surface-content` are still a surface; later words qualify
+// WHICH surface, they don't flip the family. A leading text-/fg-/on- morpheme
+// is foreground, mirroring Material's `on-surface` and shadcn's `-foreground`
+// (`text-primary` → foreground, not `primary`+fg). Checked before the
+// specific-family table and wins outright — a leading morpheme is a strong,
+// cited signal, not an ambiguity.
+const LEADING_BG = new Set(["surface", "bg"]);
+const LEADING_FG = new Set(["text", "fg", "on"]);
+// Family keywords, transcribed from role-synonym-dictionary.md. [word, weight]:
+// weight 2 = the role's OWN name (a strong, self-declaring signal); weight 1 =
+// a cited synonym, beatable by a stronger match on another role. "focus"→ring
+// is weight 3 (dictionary consequence #4: "Map focus/outline-color/border-
+// focus → ring" — border-focus is a focus ring, not a border color).
+// background/foreground are NOT here — decided by the leading-prefix rule
+// above, or standaloneSurface's pure-position-word fallback below. Their proxy
+// words (bg/surface/text/fg) are reused everywhere as position markers, so a
+// weighted hit here would wrongly grant "background" to e.g. `citation-bg` —
+// the dictionary's own cited no-canonical-role example (§ Consequences, pt 3).
 const FAMILY_KEYWORDS: Record<Exclude<Role, "background" | "foreground">, [string, number][]> = {
   destructive: [["destructive", 2], ["danger", 1], ["error", 1], ["critical", 1], ["negative", 1]],
   success: [["success", 2], ["positive", 1], ["valid", 1], ["ok", 1]],
@@ -71,17 +81,13 @@ const FAMILY_KEYWORDS: Record<Exclude<Role, "background" | "foreground">, [strin
   border: [["border", 2], ["outline", 1], ["divider", 1], ["stroke", 1], ["split", 1], ["rule", 1], ["separator", 1]],
   neutral: [["neutral", 2]],
 };
-/** Tie-break order when two roles hit the same weight (state role beats generic border). */
-const PRIORITY: readonly (keyof typeof FAMILY_KEYWORDS)[] = [
-  "ring", "destructive", "success", "warning", "info", "primary", "secondary",
-  "accent", "muted", "card", "popover", "input", "border", "neutral",
-];
+const ALL_FAMILY_ROLES = Object.keys(FAMILY_KEYWORDS) as (keyof typeof FAMILY_KEYWORDS)[];
 /** The SCRIM TRAP (dictionary § point 4): overlay/scrim names the modal dimmer in
- * 5/13 systems, not the popover surface — never auto-map it to any family. */
+ * 5/13 systems, not the popover surface — never auto-map it to any family, even
+ * under a leading surface- prefix (checked first, ahead of the prefix rule). */
 const NEGATIVE_WORDS = new Set(["overlay", "scrim"]);
-/** Foreground-position words (token-pairs.ts FOREGROUND_RE synonyms, + "on-*"). */
+/** Foreground/background-position words (token-pairs.ts FOREGROUND_RE synonyms, + "on-*"). */
 const POSITION_FG = new Set(["foreground", "text", "fg", "content", "ink", "on"]);
-/** Background-position words. */
 const POSITION_BG = new Set(["background", "bg", "surface", "fill"]);
 /** Pure state/scaffolding words that carry no role signal by themselves. */
 const NOISE = new Set(["color", "default", "hover", "active", "alt"]);
@@ -90,87 +96,90 @@ function segments(name: string): string[] {
   return name.toLowerCase().split(/[-_.]/).filter(Boolean);
 }
 
-/** Steps 3a: the strongest specific-family match (excludes background/foreground). */
-function classifyFamily(segs: readonly string[]): Role | null {
-  if (segs.some((s) => NEGATIVE_WORDS.has(s))) return null;
-  let best: { role: Role; weight: number } | null = null;
-  for (const role of PRIORITY) {
-    const words = FAMILY_KEYWORDS[role];
-    const weight = Math.max(0, ...words.filter(([w]) => segs.includes(w)).map(([, wt]) => wt));
-    if (weight > 0 && (best === null || weight > best.weight)) best = { role, weight };
+/** Strongest specific-family match (excl. background/foreground): the single
+ * winner, or the tied role list when ≥2 roles hit the same max weight (a
+ * genuine ambiguity — never silently tie-broken). */
+function classifyFamily(segs: readonly string[]): Role | Role[] | null {
+  let maxWeight = 0;
+  let winners: Role[] = [];
+  for (const role of ALL_FAMILY_ROLES) {
+    const weight = Math.max(0, ...FAMILY_KEYWORDS[role].filter(([w]) => segs.includes(w)).map(([, wt]) => wt));
+    if (weight === 0) continue;
+    if (weight > maxWeight) { maxWeight = weight; winners = [role]; }
+    else if (weight === maxWeight) { winners.push(role); }
   }
-  return best?.role ?? null;
+  if (winners.length === 0) return null;
+  return winners.length === 1 ? (winners[0] as Role) : winners;
 }
 
-/** Step 3b: background/foreground only when EVERY meaningful segment (after
- * stripping noise) is itself a position word — a compound like `surface-chrome`
- * or `citation-bg` carries a domain word alongside the position word and must
- * NOT be forced into background/foreground (see the module doc + Phase 1
- * report). `surface-content` (both a bg-word and an fg-word, no domain word)
- * is the plan's own worked example: "surface" is the bg-FAMILY morpheme, so
- * background wins here — the fg-word ("content") only decides POSITION when a
- * position is being attached to an already-established specific family (see
- * classifyPosition below); it does not flip background↔foreground on its own. */
+/** background/foreground fallback (no leading trigger fired): only when EVERY
+ * meaningful segment (noise stripped) is itself a position word — `citation-bg`
+ * carries a domain word alongside the position word, must not be forced. */
 function standaloneSurface(segs: readonly string[]): Role | null {
   const meaningful = segs.filter((s) => !NOISE.has(s));
   if (meaningful.length === 0) return null;
-  const allPositional = meaningful.every((s) => POSITION_BG.has(s) || POSITION_FG.has(s));
-  if (!allPositional) return null;
+  if (!meaningful.every((s) => POSITION_BG.has(s) || POSITION_FG.has(s))) return null;
   if (meaningful.some((s) => POSITION_BG.has(s))) return "background";
   if (meaningful.some((s) => POSITION_FG.has(s))) return "foreground";
   return null;
 }
 
-/** Position (bg/fg), independent of which segment decided the family. FG wins a
- * tie (plan.md: "surface-content" — content, the position morpheme, decides). */
+/** Position (bg/fg); FG wins a tie (a name with both a surface- and text-word). */
 function classifyPosition(segs: readonly string[]): "fg" | "bg" | null {
   if (segs.some((s) => POSITION_FG.has(s))) return "fg";
   if (segs.some((s) => POSITION_BG.has(s))) return "bg";
   return null;
 }
 
-/** Classify one leaf name → { family, position } or null (unrecognized). */
-function classify(name: string): { family: Role; position: "fg" | "bg" | null } | null {
+type Classification =
+  | { kind: "role"; family: Role; position: "fg" | "bg" | null }
+  | { kind: "ambiguous"; families: Role[] }
+  | { kind: "none" };
+
+// Classify one leaf name. Order: negative trap → leading prefix (decisive) →
+// specific-family table (single winner, or a flagged tie) → standalone
+// background/foreground fallback → unrecognized.
+function classify(name: string): Classification {
   const segs = segments(name);
+  if (segs.some((s) => NEGATIVE_WORDS.has(s))) return { kind: "none" };
+  const leading = segs[0];
+  if (leading !== undefined && LEADING_BG.has(leading)) return { kind: "role", family: "background", position: null };
+  if (leading !== undefined && LEADING_FG.has(leading)) return { kind: "role", family: "foreground", position: null };
   const specific = classifyFamily(segs);
-  if (specific !== null) {
-    const pos = specific === "background" || specific === "foreground" ? null : classifyPosition(segs);
-    return { family: specific, position: pos };
-  }
+  if (Array.isArray(specific)) return { kind: "ambiguous", families: specific };
+  if (specific !== null) return { kind: "role", family: specific, position: classifyPosition(segs) };
   const surface = standaloneSurface(segs);
-  if (surface !== null) return { family: surface, position: null };
-  return null;
+  if (surface !== null) return { kind: "role", family: surface, position: null };
+  return { kind: "none" };
 }
 
-// ─── The pure entry point ──────────────────────────────────────────────────────
-
-/**
- * Annotate every semantic (alias-valued) token in `tree` with the role it plays,
- * from the counted synonym dictionary. Primitives and hue re-exports get no
- * role. Never renames, drops, or injects a token — `annotated` carries every
- * input token verbatim, plus `$extensions`.
- */
+/** The pure entry point: annotate every token in `tree` (by NAME, regardless of
+ * literal/alias $value) with the role it plays. Only hue re-exports get no
+ * role. Never renames, drops, or injects — `annotated` carries every input
+ * token verbatim, plus `$extensions`. */
 export function recognizeRoles(tree: TokenTree): RecognitionResult {
   const annotated: TokenTree = {};
   const foundRoles = new Set<Role>();
   const unrecognized: string[] = [];
+  const ambiguous: string[] = [];
   let recognized = 0;
 
   for (const [category, group] of Object.entries(tree)) {
     const outGroup: TokenGroup = {};
     for (const [name, token] of Object.entries(group)) {
       const path = `${category}.${name}`;
-      if (!isAlias(token.$value)) {
-        outGroup[name] = token; // primitive — untouched
-        continue;
-      }
       if (HUE_RE.test(name)) {
         outGroup[name] = token; // hue re-export — no role, correctly
         unrecognized.push(path);
         continue;
       }
       const hit = classify(name);
-      if (hit === null) {
+      if (hit.kind === "ambiguous") {
+        outGroup[name] = token;
+        ambiguous.push(path);
+        continue;
+      }
+      if (hit.kind === "none") {
         outGroup[name] = token;
         unrecognized.push(path);
         continue;
@@ -185,5 +194,5 @@ export function recognizeRoles(tree: TokenTree): RecognitionResult {
   }
 
   const gaps = CANONICAL_ROLES.filter((r) => !foundRoles.has(r));
-  return { annotated, recognized, gaps, unrecognized };
+  return { annotated, recognized, gaps, unrecognized, ambiguous };
 }

--- a/src/core/role-recognition.ts
+++ b/src/core/role-recognition.ts
@@ -1,0 +1,189 @@
+/**
+ * Role recognition — annotate a project's OWN tokens with the UI role they play,
+ * without ever renaming them (spec 011, Phase 1: `memory: respect-their-ds-mindset`).
+ *
+ * `surface-content` stays `surface-content`; this only records, via DTCG
+ * `$extensions["design-os.role"]`, that it plays the `background` role. Lossless:
+ * every input token appears in the output verbatim (same name, same $value), plus
+ * the annotation. Pure, deterministic, zero deps (Art I).
+ *
+ * The synonym table below is TRANSCRIBED from the counted dictionary —
+ * specs/009-code-road/reports/role-synonym-dictionary.md (13 real design systems,
+ * every token cited to a source). It is not a guess (unlike the `ROLE_KEYWORDS` it
+ * replaces in color-roles.ts — "muted"→secondary there is wrong; this table doesn't
+ * repeat that mistake because every entry traces to a cited synonym).
+ */
+import { type TokenTree, type TokenGroup, type Token, isAlias } from "./token-model.js";
+
+// ─── Canonical role vocabulary (shadcn's set, plan.md's family list) ──────────
+
+export type Role =
+  | "background" | "foreground" | "card" | "popover" | "primary" | "secondary"
+  | "muted" | "accent" | "border" | "input" | "ring" | "destructive"
+  | "success" | "warning" | "info" | "neutral";
+
+const CANONICAL_ROLES: readonly Role[] = [
+  "background", "foreground", "card", "popover", "primary", "secondary", "muted",
+  "accent", "border", "input", "ring", "destructive", "success", "warning", "info", "neutral",
+];
+
+export interface RecognitionResult {
+  annotated: TokenTree;
+  recognized: number;
+  gaps: string[];
+  unrecognized: string[];
+}
+
+// ─── Step 2: hue re-export skip (Tailwind + common palette scale) ─────────────
+// A `{knownHue}-{number}` leaf (optionally `color-` prefixed) is a primitive
+// re-export, not a UI role — dana's `color-blue-100` aliases `blue-100` literally.
+// This is itself a counted list: only hues that actually appeared in the corpus
+// (blue/cyan/gray/pink/purple in dana) are confirmed; the rest of the standard
+// Tailwind + common set (red/orange/…/stone) is speculative until seen live.
+const HUE_RE =
+  /^(color-)?(red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|gray|grey|zinc|slate|stone|neutral)-\d+$/;
+
+// ─── Step 3: family keywords, transcribed from role-synonym-dictionary.md ─────
+// [word, weight]: weight 2 = the role's OWN name (shadcn's word, or a system's
+// literal token word for it) — a strong, self-declaring signal. weight 1 = a
+// cited synonym — weaker, can be beaten by a stronger match on another role.
+// "focus"→ring is weight 3: the dictionary's own consequence #4 ("Map focus/
+// outline-color/border-focus → ring") explicitly overrides a same-name "border"
+// hit — border-focus is a focus ring, not a border color.
+// NOTE: background/foreground are handled separately (see standaloneSurface) —
+// their proxy words (bg/surface/text/content/fg/ink) are reused everywhere as
+// pure POSITION markers (see POSITION_FG/BG), so a weighted hit here would
+// wrongly grant "background" family to e.g. `citation-bg` — the dictionary's own
+// cited example of a token with NO canonical role (§ "Consequences", point 3).
+const FAMILY_KEYWORDS: Record<Exclude<Role, "background" | "foreground">, [string, number][]> = {
+  destructive: [["destructive", 2], ["danger", 1], ["error", 1], ["critical", 1], ["negative", 1]],
+  success: [["success", 2], ["positive", 1], ["valid", 1], ["ok", 1]],
+  warning: [["warning", 2], ["caution", 1], ["attention", 1], ["alert", 1]],
+  info: [["info", 2], ["information", 1], ["note", 1]],
+  primary: [["primary", 2], ["brand", 1], ["cta", 1], ["action", 1], ["interactive", 1]],
+  secondary: [["secondary", 2]],
+  accent: [["accent", 2]],
+  muted: [["muted", 2], ["subtle", 1], ["tertiary", 1], ["quaternary", 1], ["helper", 1], ["placeholder", 1], ["faint", 1], ["disabled", 1]],
+  card: [["card", 2], ["layer", 1], ["container", 1], ["elevated", 1], ["panel", 1], ["raised", 1]],
+  popover: [["popover", 2]],
+  input: [["input", 2], ["field", 1], ["control", 1]],
+  ring: [["ring", 2], ["focus", 3]],
+  border: [["border", 2], ["outline", 1], ["divider", 1], ["stroke", 1], ["split", 1], ["rule", 1], ["separator", 1]],
+  neutral: [["neutral", 2]],
+};
+/** Tie-break order when two roles hit the same weight (state role beats generic border). */
+const PRIORITY: readonly (keyof typeof FAMILY_KEYWORDS)[] = [
+  "ring", "destructive", "success", "warning", "info", "primary", "secondary",
+  "accent", "muted", "card", "popover", "input", "border", "neutral",
+];
+/** The SCRIM TRAP (dictionary § point 4): overlay/scrim names the modal dimmer in
+ * 5/13 systems, not the popover surface — never auto-map it to any family. */
+const NEGATIVE_WORDS = new Set(["overlay", "scrim"]);
+/** Foreground-position words (token-pairs.ts FOREGROUND_RE synonyms, + "on-*"). */
+const POSITION_FG = new Set(["foreground", "text", "fg", "content", "ink", "on"]);
+/** Background-position words. */
+const POSITION_BG = new Set(["background", "bg", "surface", "fill"]);
+/** Pure state/scaffolding words that carry no role signal by themselves. */
+const NOISE = new Set(["color", "default", "hover", "active", "alt"]);
+
+function segments(name: string): string[] {
+  return name.toLowerCase().split(/[-_.]/).filter(Boolean);
+}
+
+/** Steps 3a: the strongest specific-family match (excludes background/foreground). */
+function classifyFamily(segs: readonly string[]): Role | null {
+  if (segs.some((s) => NEGATIVE_WORDS.has(s))) return null;
+  let best: { role: Role; weight: number } | null = null;
+  for (const role of PRIORITY) {
+    const words = FAMILY_KEYWORDS[role];
+    const weight = Math.max(0, ...words.filter(([w]) => segs.includes(w)).map(([, wt]) => wt));
+    if (weight > 0 && (best === null || weight > best.weight)) best = { role, weight };
+  }
+  return best?.role ?? null;
+}
+
+/** Step 3b: background/foreground only when EVERY meaningful segment (after
+ * stripping noise) is itself a position word — a compound like `surface-chrome`
+ * or `citation-bg` carries a domain word alongside the position word and must
+ * NOT be forced into background/foreground (see the module doc + Phase 1
+ * report). `surface-content` (both a bg-word and an fg-word, no domain word)
+ * is the plan's own worked example: "surface" is the bg-FAMILY morpheme, so
+ * background wins here — the fg-word ("content") only decides POSITION when a
+ * position is being attached to an already-established specific family (see
+ * classifyPosition below); it does not flip background↔foreground on its own. */
+function standaloneSurface(segs: readonly string[]): Role | null {
+  const meaningful = segs.filter((s) => !NOISE.has(s));
+  if (meaningful.length === 0) return null;
+  const allPositional = meaningful.every((s) => POSITION_BG.has(s) || POSITION_FG.has(s));
+  if (!allPositional) return null;
+  if (meaningful.some((s) => POSITION_BG.has(s))) return "background";
+  if (meaningful.some((s) => POSITION_FG.has(s))) return "foreground";
+  return null;
+}
+
+/** Position (bg/fg), independent of which segment decided the family. FG wins a
+ * tie (plan.md: "surface-content" — content, the position morpheme, decides). */
+function classifyPosition(segs: readonly string[]): "fg" | "bg" | null {
+  if (segs.some((s) => POSITION_FG.has(s))) return "fg";
+  if (segs.some((s) => POSITION_BG.has(s))) return "bg";
+  return null;
+}
+
+/** Classify one leaf name → { family, position } or null (unrecognized). */
+function classify(name: string): { family: Role; position: "fg" | "bg" | null } | null {
+  const segs = segments(name);
+  const specific = classifyFamily(segs);
+  if (specific !== null) {
+    const pos = specific === "background" || specific === "foreground" ? null : classifyPosition(segs);
+    return { family: specific, position: pos };
+  }
+  const surface = standaloneSurface(segs);
+  if (surface !== null) return { family: surface, position: null };
+  return null;
+}
+
+// ─── The pure entry point ──────────────────────────────────────────────────────
+
+/**
+ * Annotate every semantic (alias-valued) token in `tree` with the role it plays,
+ * from the counted synonym dictionary. Primitives and hue re-exports get no
+ * role. Never renames, drops, or injects a token — `annotated` carries every
+ * input token verbatim, plus `$extensions`.
+ */
+export function recognizeRoles(tree: TokenTree): RecognitionResult {
+  const annotated: TokenTree = {};
+  const foundRoles = new Set<Role>();
+  const unrecognized: string[] = [];
+  let recognized = 0;
+
+  for (const [category, group] of Object.entries(tree)) {
+    const outGroup: TokenGroup = {};
+    for (const [name, token] of Object.entries(group)) {
+      const path = `${category}.${name}`;
+      if (!isAlias(token.$value)) {
+        outGroup[name] = token; // primitive — untouched
+        continue;
+      }
+      if (HUE_RE.test(name)) {
+        outGroup[name] = token; // hue re-export — no role, correctly
+        unrecognized.push(path);
+        continue;
+      }
+      const hit = classify(name);
+      if (hit === null) {
+        outGroup[name] = token;
+        unrecognized.push(path);
+        continue;
+      }
+      foundRoles.add(hit.family);
+      recognized += 1;
+      const ext: Record<string, unknown> = { ...token.$extensions, "design-os.role": hit.family };
+      if (hit.position !== null) ext["design-os.role-position"] = hit.position;
+      outGroup[name] = { ...token, $extensions: ext } satisfies Token;
+    }
+    annotated[category] = outGroup;
+  }
+
+  const gaps = CANONICAL_ROLES.filter((r) => !foundRoles.has(r));
+  return { annotated, recognized, gaps, unrecognized };
+}

--- a/tests/role-recognition.test.ts
+++ b/tests/role-recognition.test.ts
@@ -10,6 +10,14 @@ function tree(color: Record<string, { $value: string; $extensions?: Record<strin
   return { color: group };
 }
 
+/** Like `tree`, but each leaf carries an explicit `$type` — for fix 3b (color-type scoping). */
+function treeTyped(
+  category: string,
+  leaves: Record<string, { $value: string; $type: "color" | "dimension" | "fontFamily" | "fontWeight" | "number" }>,
+): TokenTree {
+  return { [category]: leaves };
+}
+
 describe("recognizeRoles — Phase 1 contract", () => {
   it("a hue-scale name gets no role, literal or alias (blue-100, color-blue-100)", () => {
     const result = recognizeRoles(
@@ -162,6 +170,63 @@ describe("recognizeRoles — Phase 1 contract", () => {
     const result = recognizeRoles(tree({ "border-error": { $value: "{color.error-500}" } }));
     expect(result.annotated.color?.["border-error"]?.$extensions).toEqual({ "design-os.role": "border" });
     expect(result.ambiguous).toEqual([]);
+  });
+
+  // ─── FIX 3: a numbered SCALE STEP is not a role, even when the word matches one ──
+
+  it("a {word}-{lightness} leaf is a scale step, not a role, even when the word is a role synonym (color-brand-500, brand-25, accent-600)", () => {
+    const result = recognizeRoles(
+      tree({
+        "color-brand-500": { $value: "#14b8a6" },
+        "brand-25": { $value: "{color.teal-25}" },
+        "accent-600": { $value: "#b8923f" },
+      }),
+    );
+    expect(result.annotated.color?.["color-brand-500"]?.$extensions).toBeUndefined();
+    expect(result.annotated.color?.["brand-25"]?.$extensions).toBeUndefined();
+    expect(result.annotated.color?.["accent-600"]?.$extensions).toBeUndefined();
+    expect(result.recognized).toBe(0);
+    expect(result.unrecognized).toEqual(["color.color-brand-500", "color.brand-25", "color.accent-600"]);
+  });
+
+  it("Carbon/Primer 2-digit tiers still recognize — layer-01, field-01 are ROLES with a number, not scale steps", () => {
+    const result = recognizeRoles(
+      tree({ "layer-01": { $value: "{color.gray-50}" }, "field-01": { $value: "{color.gray-100}" } }),
+    );
+    expect(result.annotated.color?.["layer-01"]?.$extensions).toEqual({ "design-os.role": "card" });
+    expect(result.annotated.color?.["field-01"]?.$extensions).toEqual({ "design-os.role": "input" });
+  });
+
+  it("Radix's 1-12 step scale still recognizes — accent-9 is a ROLE with a number, not a scale step", () => {
+    const result = recognizeRoles(tree({ "accent-9": { $value: "#14b8a6" } }));
+    expect(result.annotated.color?.["accent-9"]?.$extensions).toEqual({ "design-os.role": "accent" });
+  });
+
+  // ─── FIX 3b: color roles only — non-color tokens are out of scope ────────────
+
+  it("non-color tokens are left untouched and out of scope — radius.button and font-size.md never enter recognition", () => {
+    const result = recognizeRoles(
+      treeTyped("dimension", {
+        "radius-button": { $value: "4px", $type: "dimension" },
+        "space-4": { $value: "16px", $type: "dimension" },
+      }),
+    );
+    expect(result.annotated.dimension?.["radius-button"]?.$extensions).toBeUndefined();
+    expect(result.annotated.dimension?.["space-4"]?.$extensions).toBeUndefined();
+    expect(result.recognized).toBe(0);
+    expect(result.unrecognized).toEqual([]); // out of scope, not "unrecognized"
+    expect(result.ambiguous).toEqual([]);
+  });
+
+  it("a mixed tree recognizes color tokens and leaves non-color tokens alone, both verbatim (lossless across types)", () => {
+    const mixed: TokenTree = {
+      color: { primary: { $value: "{color.brand-600}", $type: "color" } },
+      dimension: { "radius-lg": { $value: "8px", $type: "dimension" } },
+    };
+    const result = recognizeRoles(mixed);
+    expect(result.annotated.color?.["primary"]?.$extensions).toEqual({ "design-os.role": "primary" });
+    expect(result.annotated.dimension?.["radius-lg"]).toEqual(mixed.dimension?.["radius-lg"]);
+    expect(result.recognized).toBe(1);
   });
 });
 

--- a/tests/role-recognition.test.ts
+++ b/tests/role-recognition.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { recognizeRoles } from "../src/core/role-recognition.js";
+import type { TokenTree } from "../src/core/token-model.js";
+
+function tree(color: Record<string, { $value: string; $extensions?: Record<string, unknown> }>): TokenTree {
+  const group: Record<string, { $value: string; $type: "color"; $extensions?: Record<string, unknown> }> = {};
+  for (const [name, t] of Object.entries(color)) {
+    group[name] = { $value: t.$value, $type: "color", ...(t.$extensions ? { $extensions: t.$extensions } : {}) };
+  }
+  return { color: group };
+}
+
+describe("recognizeRoles — Phase 1 contract", () => {
+  it("a primitive gets no role (blue-100 literal)", () => {
+    const result = recognizeRoles(tree({ "blue-100": { $value: "#DBEAFE" } }));
+    expect(result.annotated.color?.["blue-100"]?.$extensions).toBeUndefined();
+    expect(result.recognized).toBe(0);
+    expect(result.unrecognized).toEqual([]);
+  });
+
+  it("a hue re-export gets no role (color-blue-100 alias)", () => {
+    const result = recognizeRoles(
+      tree({ "blue-100": { $value: "#DBEAFE" }, "color-blue-100": { $value: "{color.blue-100}" } }),
+    );
+    expect(result.annotated.color?.["color-blue-100"]?.$extensions).toBeUndefined();
+    expect(result.recognized).toBe(0);
+    expect(result.unrecognized).toEqual(["color.color-blue-100"]);
+  });
+
+  it("a semantic token is annotated with its family role (surface-content → background)", () => {
+    const result = recognizeRoles(tree({ "surface-content": { $value: "{color.gray-25}" } }));
+    expect(result.annotated.color?.["surface-content"]?.$extensions).toEqual({
+      "design-os.role": "background",
+    });
+    expect(result.recognized).toBe(1);
+  });
+
+  it("a compound token carries family and position (badge-danger-bg → destructive+bg)", () => {
+    const result = recognizeRoles(tree({ "badge-danger-bg": { $value: "{color.error-700}" } }));
+    expect(result.annotated.color?.["badge-danger-bg"]?.$extensions).toEqual({
+      "design-os.role": "destructive",
+      "design-os.role-position": "bg",
+    });
+  });
+
+  it("an unrecognized semantic is listed, not forced (made-up zorp-glimble alias)", () => {
+    const result = recognizeRoles(tree({ "zorp-glimble": { $value: "{color.gray-500}" } }));
+    expect(result.annotated.color?.["zorp-glimble"]?.$extensions).toBeUndefined();
+    expect(result.unrecognized).toEqual(["color.zorp-glimble"]);
+    expect(result.recognized).toBe(0);
+  });
+
+  it("names and values are byte-identical after recognition (lossless)", () => {
+    const input = tree({
+      "blue-100": { $value: "#DBEAFE" },
+      "badge-danger-bg": { $value: "{color.error-700}" },
+      "zorp-glimble": { $value: "{color.gray-500}" },
+    });
+    const result = recognizeRoles(input);
+    const inNames = Object.keys(input.color ?? {}).sort();
+    const outNames = Object.keys(result.annotated.color ?? {}).sort();
+    expect(outNames).toEqual(inNames);
+    for (const name of inNames) {
+      expect(result.annotated.color?.[name]?.$value).toBe(input.color?.[name]?.$value);
+    }
+  });
+
+  it("is idempotent on a shadcn-native name (background → background)", () => {
+    const result = recognizeRoles(tree({ background: { $value: "{color.white}" } }));
+    expect(result.annotated.color?.["background"]?.$extensions).toEqual({ "design-os.role": "background" });
+  });
+
+  it("preserves existing $extensions (mode.*) — merges, never overwrites", () => {
+    const result = recognizeRoles(
+      tree({
+        "badge-light-border": {
+          $value: "{color.gray-300}",
+          $extensions: { "mode.dark": { $value: "{color.gray-600}" } },
+        },
+      }),
+    );
+    expect(result.annotated.color?.["badge-light-border"]?.$extensions).toEqual({
+      "mode.dark": { $value: "{color.gray-600}" },
+      "design-os.role": "border",
+    });
+  });
+
+  it("the SCRIM TRAP: overlay/scrim never auto-maps to popover or any family", () => {
+    const result = recognizeRoles(tree({ "surface-overlay": { $value: "{color.gray-950}" } }));
+    expect(result.annotated.color?.["surface-overlay"]?.$extensions).toBeUndefined();
+    expect(result.unrecognized).toEqual(["color.surface-overlay"]);
+  });
+
+  it("focus overrides border → ring (dictionary consequence #4: border-focus is a focus ring)", () => {
+    const result = recognizeRoles(tree({ "border-focus": { $value: "{color.blue-500}" } }));
+    expect(result.annotated.color?.["border-focus"]?.$extensions).toEqual({ "design-os.role": "ring" });
+  });
+
+  it("a domain-prefixed bare -bg/-border with no family keyword stays unrecognized (citation-bg, the dictionary's own cited example)", () => {
+    const result = recognizeRoles(tree({ "citation-bg": { $value: "{color.surface-content-hover}" } }));
+    expect(result.annotated.color?.["citation-bg"]?.$extensions).toBeUndefined();
+    expect(result.unrecognized).toEqual(["color.citation-bg"]);
+  });
+
+  it("gaps = canonical roles with zero recognized tokens", () => {
+    const result = recognizeRoles(tree({ "badge-danger-bg": { $value: "{color.error-700}" } }));
+    expect(result.gaps).toContain("card");
+    expect(result.gaps).toContain("popover");
+    expect(result.gaps).not.toContain("destructive");
+  });
+});
+
+// ─── LIVE (Art III) — dana's real design.tokens.json ───────────────────────────
+// Path is the onboard-all scratchpad fixture used across spec 011's research.
+// Kept as a conditional describe so the suite stays green on machines without
+// the scratchpad fixture (Art III: real data before "done", not a hard fixture
+// dependency baked into CI).
+
+import { readFileSync, existsSync } from "node:fs";
+import { parseTokenFile } from "../src/core/token-model.js";
+
+const DANA_PATH =
+  "/private/tmp/claude-501/-Users-jang-Products-ease-design/7771253a-22c4-494f-bfbc-7432719ee8c1/scratchpad/onboard-all/dana-desktop/design/design.tokens.json";
+
+describe.skipIf(!existsSync(DANA_PATH))("recognizeRoles — LIVE on dana's real tokens", () => {
+  it("recognizes dana's real semantic tokens without renaming or dropping any", () => {
+    const raw = JSON.parse(readFileSync(DANA_PATH, "utf-8"));
+    const parsedTree = parseTokenFile(raw);
+    const result = recognizeRoles(parsedTree);
+
+    // Lossless: every input token present in the output, byte-identical $value.
+    for (const [cat, group] of Object.entries(parsedTree)) {
+      for (const [name, token] of Object.entries(group)) {
+        expect(result.annotated[cat]?.[name]?.$value).toBe(token.$value);
+      }
+    }
+    // Real, non-trivial recognition happened.
+    expect(result.recognized).toBeGreaterThan(50);
+    expect(result.unrecognized.length).toBeGreaterThan(0);
+  });
+
+  it("surface-content and surface-chrome — the flagged ambiguous case (report only, no strict assertion)", () => {
+    const raw = JSON.parse(readFileSync(DANA_PATH, "utf-8"));
+    const result = recognizeRoles(parseTokenFile(raw));
+    // surface-content is a LITERAL in dana's real file (#FFFFFF) — a primitive,
+    // so it correctly gets no role under the primitive/alias split, even though
+    // it plays the background role by convention. See p1-recognition-core.md.
+    // (Its real $extensions already carries dana's own mode.classic/mode.dark —
+    // must stay untouched, no "design-os.role" key added.)
+    expect(result.annotated.color?.["surface-content"]?.$extensions).not.toHaveProperty("design-os.role");
+    // surface-chrome IS an alias ({color.gray-900}) but has no single-word
+    // reduction (surface + chrome) — correctly falls to unrecognized rather
+    // than a forced guess. See p1-recognition-core.md. (Its real $extensions
+    // already carries dana's own mode.classic/mode.dark — must stay untouched,
+    // no "design-os.role" key added.)
+    expect(result.annotated.color?.["surface-chrome"]?.$extensions).not.toHaveProperty("design-os.role");
+  });
+});

--- a/tests/role-recognition.test.ts
+++ b/tests/role-recognition.test.ts
@@ -11,20 +11,23 @@ function tree(color: Record<string, { $value: string; $extensions?: Record<strin
 }
 
 describe("recognizeRoles — Phase 1 contract", () => {
-  it("a primitive gets no role (blue-100 literal)", () => {
-    const result = recognizeRoles(tree({ "blue-100": { $value: "#DBEAFE" } }));
-    expect(result.annotated.color?.["blue-100"]?.$extensions).toBeUndefined();
-    expect(result.recognized).toBe(0);
-    expect(result.unrecognized).toEqual([]);
-  });
-
-  it("a hue re-export gets no role (color-blue-100 alias)", () => {
+  it("a hue-scale name gets no role, literal or alias (blue-100, color-blue-100)", () => {
     const result = recognizeRoles(
       tree({ "blue-100": { $value: "#DBEAFE" }, "color-blue-100": { $value: "{color.blue-100}" } }),
     );
+    expect(result.annotated.color?.["blue-100"]?.$extensions).toBeUndefined();
     expect(result.annotated.color?.["color-blue-100"]?.$extensions).toBeUndefined();
     expect(result.recognized).toBe(0);
-    expect(result.unrecognized).toEqual(["color.color-blue-100"]);
+    expect(result.unrecognized).toEqual(["color.blue-100", "color.color-blue-100"]);
+  });
+
+  it("recognizes by NAME regardless of $value shape — a literal-valued semantic token still gets its role (coordinator fix 1)", () => {
+    const result = recognizeRoles(tree({ "badge-danger-text": { $value: "#FFFFFF" } }));
+    expect(result.annotated.color?.["badge-danger-text"]?.$extensions).toEqual({
+      "design-os.role": "destructive",
+      "design-os.role-position": "fg",
+    });
+    expect(result.recognized).toBe(1);
   });
 
   it("a semantic token is annotated with its family role (surface-content → background)", () => {
@@ -108,6 +111,58 @@ describe("recognizeRoles — Phase 1 contract", () => {
     expect(result.gaps).toContain("popover");
     expect(result.gaps).not.toContain("destructive");
   });
+
+  // ─── FIX 2: leading-prefix priority (coordinator correction) ─────────────────
+
+  it("a leading surface-/bg- prefix wins background regardless of what follows (surface-content, surface-chrome)", () => {
+    const result = recognizeRoles(
+      tree({
+        "surface-content": { $value: "{color.gray-25}" },
+        "surface-chrome": { $value: "{color.gray-900}" },
+        "bg-danger": { $value: "{color.error-700}" },
+      }),
+    );
+    expect(result.annotated.color?.["surface-content"]?.$extensions).toEqual({ "design-os.role": "background" });
+    expect(result.annotated.color?.["surface-chrome"]?.$extensions).toEqual({ "design-os.role": "background" });
+    expect(result.annotated.color?.["bg-danger"]?.$extensions).toEqual({ "design-os.role": "background" });
+  });
+
+  it("a leading text-/fg-/on- prefix wins foreground regardless of what follows (text-primary, Material's on-surface)", () => {
+    const result = recognizeRoles(
+      tree({
+        "text-primary": { $value: "{color.brand-600}" },
+        "on-surface": { $value: "{color.gray-950}" },
+        "fg-danger": { $value: "{color.error-700}" },
+      }),
+    );
+    expect(result.annotated.color?.["text-primary"]?.$extensions).toEqual({ "design-os.role": "foreground" });
+    expect(result.annotated.color?.["on-surface"]?.$extensions).toEqual({ "design-os.role": "foreground" });
+    expect(result.annotated.color?.["fg-danger"]?.$extensions).toEqual({ "design-os.role": "foreground" });
+  });
+
+  it("the leading-prefix rule does not fire mid-name — badge-danger-bg still gets destructive+bg, not background", () => {
+    const result = recognizeRoles(tree({ "badge-danger-bg": { $value: "{color.error-700}" } }));
+    expect(result.annotated.color?.["badge-danger-bg"]?.$extensions).toEqual({
+      "design-os.role": "destructive",
+      "design-os.role-position": "bg",
+    });
+  });
+
+  // ─── FIX 2: genuine ties are flagged ambiguous, never guessed ────────────────
+
+  it("a genuine tie between two self-named families lands in `ambiguous`, not a guessed role (border-success)", () => {
+    const result = recognizeRoles(tree({ "border-success": { $value: "{color.success-500}" } }));
+    expect(result.annotated.color?.["border-success"]?.$extensions).toBeUndefined();
+    expect(result.ambiguous).toEqual(["color.border-success"]);
+    expect(result.unrecognized).toEqual([]);
+    expect(result.recognized).toBe(0);
+  });
+
+  it("an unambiguous weight difference still resolves cleanly, not ambiguous (border-error: border self-name beats error synonym)", () => {
+    const result = recognizeRoles(tree({ "border-error": { $value: "{color.error-500}" } }));
+    expect(result.annotated.color?.["border-error"]?.$extensions).toEqual({ "design-os.role": "border" });
+    expect(result.ambiguous).toEqual([]);
+  });
 });
 
 // ─── LIVE (Art III) — dana's real design.tokens.json ───────────────────────────
@@ -139,20 +194,20 @@ describe.skipIf(!existsSync(DANA_PATH))("recognizeRoles — LIVE on dana's real 
     expect(result.unrecognized.length).toBeGreaterThan(0);
   });
 
-  it("surface-content and surface-chrome — the flagged ambiguous case (report only, no strict assertion)", () => {
+  it("surface-content (a real dana LITERAL) now recognizes as background — coordinator fix 1 recovers the flagship token", () => {
     const raw = JSON.parse(readFileSync(DANA_PATH, "utf-8"));
     const result = recognizeRoles(parseTokenFile(raw));
-    // surface-content is a LITERAL in dana's real file (#FFFFFF) — a primitive,
-    // so it correctly gets no role under the primitive/alias split, even though
-    // it plays the background role by convention. See p1-recognition-core.md.
-    // (Its real $extensions already carries dana's own mode.classic/mode.dark —
-    // must stay untouched, no "design-os.role" key added.)
-    expect(result.annotated.color?.["surface-content"]?.$extensions).not.toHaveProperty("design-os.role");
-    // surface-chrome IS an alias ({color.gray-900}) but has no single-word
-    // reduction (surface + chrome) — correctly falls to unrecognized rather
-    // than a forced guess. See p1-recognition-core.md. (Its real $extensions
-    // already carries dana's own mode.classic/mode.dark — must stay untouched,
-    // no "design-os.role" key added.)
-    expect(result.annotated.color?.["surface-chrome"]?.$extensions).not.toHaveProperty("design-os.role");
+    // dana's real surface-content is $value: "#FFFFFF" (a literal, not an alias)
+    // — Phase 1's original isAlias skip dropped it; fix 1 removes that skip, so
+    // it's recognized by NAME like any other token. See p1-recognition-core.md.
+    expect(result.annotated.color?.["surface-content"]?.$extensions).toMatchObject({
+      "design-os.role": "background",
+    });
+    // surface-chrome — a real dana alias — also resolves via the leading
+    // surface- prefix rule (fix 2), even though "chrome" itself is not a
+    // recognized word.
+    expect(result.annotated.color?.["surface-chrome"]?.$extensions).toMatchObject({
+      "design-os.role": "background",
+    });
   });
 });


### PR DESCRIPTION
The recognition engine: given a project's own tokens, work out which token plays which canonical role — **without renaming any of them.** `surface-content` stays `surface-content`; the tool records that it plays `background`.

## The mindset (owner, 2026-07-17)

> *Respect whatever DS the user uses. Help them develop THEIR DS, don't impose ours.*

So this is recognition, never conversion. `recognizeRoles(tree)` annotates each token's role in DTCG `$extensions["design-os.role"]`, lossless — every name and value byte-identical, plus a note. It reasons in shadcn's role vocabulary (the interlingua) but never writes those names back.

## What it does

Pure `recognizeRoles(tree) → { annotated, recognized, gaps, unrecognized, ambiguous }`, using the **counted 13-system synonym dictionary** (`role-synonym-dictionary.md`), not a guessed list. Colour tokens only. Recognizes by NAME (a role token may be literal-valued — dana's flagship `surface-content` is `#FFFFFF`). Skips lightness-scale steps (`brand-500` is a palette step, not a role). Prefix-priority for compounds (`surface-content` → background). Genuinely-ambiguous tokens go to an `ambiguous` list for the owner, never a guess. **Gaps** = canonical roles with no token = the help-grow list.

## Three grounding rounds — each caught a real error in MY plan

This is the measure-and-correct loop, and it mattered:

1. **My plan's `isAlias` skip was wrong.** Measured: 126 of dana's role-named tokens are literal-valued (incl. `surface-content`, the flagship background). Skipping non-aliases dropped them. Fix: skip only the palette scale, recognize by name.
2. **Scale-number over-recognition.** Measured: 174 tokens across 4 projects are `{roleword}-{lightness}` (`brand-500`, `accent-300`, `ink-600`) — scale steps, not roles. dana alone had 120 `brand-N` steps wrongly tagged `primary`. Fix: skip the lightness-scale set; keep Carbon tiers (`layer-01`) and Radix steps (`accent-9`), which are disjoint.
3. Colour-type filter + scrim-trap ordering confirmed.

## Verified live on 4 real projects (honest numbers, not tuned)

| Project | Colour tokens | Recognized | Gaps |
|---|---|---|---|
| dana-desktop (real semantic tier) | 362 | 100 | 2 — `popover`, `input` → its DS is legible |
| traicaybentre | 32 | 22 | 9 |
| sodeal (primitive-heavy) | 26 | 13 | 11 — **`primary` is now a gap** |
| spaflow (100% primitive) | 28 | 4 | 12 — incl. `background`, `foreground` |

The honest story the numbers tell: **dana's real semantic DS is legible (only 2 gaps); sodeal/spaflow's primitive-only DSs surface `primary`/`background` as GAPS** — because their role IS a scale step with no named token, exactly the usage-inference case spec 011 deferred. Surfacing it as a gap is correct: it says "these projects need usage-inference," honestly, instead of over-recognizing.

Independently cross-checked: dana's 362 colour tokens confirmed; my rough synonym count (119) brackets the executor's careful 110 (100 + 10 ambiguous).

199 lines (Art IX). 24 tests incl. lossless, the regression tests (`layer-01`/`accent-9` still recognize), and 2 LIVE on dana. Four gates green, `ui knowledge check` clean, 2122 tests.

**No wiring yet** — this is the reusable core. Phase 2 bakes it into `ds import`, emits roles + gaps in `ds context`, and adds `ds set-role` (the owner-edit path). Report: `specs/011-role-recognition/reports/p1-recognition-core.md`