### PR TITLE
feat(ds): wire role recognition — ds import bakes roles, ds context emits them, ds set-role edits (spec 011 P2)

### DIFF
--- a/specs/011-role-recognition/reports/p2-wiring.md
+++ b/specs/011-role-recognition/reports/p2-wiring.md
@@ -1,0 +1,121 @@
+# Report — Spec 011 Phase 2: wire role recognition into the DS commands
+
+**Date**: 2026-07-18 · **Branch**: `feat/role-recognition-wire` (off `main` @ `dfe92a7`, which
+has Phase 1's `role-recognition.ts` merged via #85)
+
+Makes the Phase 1 recognition core user-visible: `ds import` bakes the annotation, `ds context`
+surfaces it, `ds set-role` lets the owner correct it. Mindset held throughout: recognition
+annotates, never renames; a gap is a report, never an auto-add.
+
+## Files
+
+- `src/commands/ds-import-impl.ts` (134 lines, +12) — bakes `recognizeRoles` before sealing.
+- `src/commands/ds-set-role-impl.ts` (new, 137 lines) — the owner-edit path.
+- `src/core/ds-context-roles.ts` (new, 69 lines) — reads the BAKED annotation; pure, no recompute.
+- `src/core/ds-context.ts` (+36 lines, wiring only — the logic lives in the new helper above, per
+  the instruction not to grow this file's own logic; it was already over the 200-line guideline
+  before this phase, a pre-existing condition this phase did not create).
+- `src/core/role-recognition.ts` — exported `CANONICAL_ROLES` (was module-private) for reuse.
+- `src/core/ds-manifest.ts`, `src/core/changelog.ts` — new changelog `kind: "set-role"`.
+- `src/commands/ds.ts`, `src/core/command-signatures.ts` — dispatcher wiring, help text, schema.
+- Tests: `tests/cmd-ds-set-role.test.ts` (new, 9 tests), `tests/cmd-ds-context.test.ts` (+5 tests,
+  roles section), `tests/cmd-ds-import.test.ts` / `tests/cmd-ingest-css-ds.test.ts` (2 existing
+  assertions updated — baking is now unconditional, so tokens named `primary`/`bg`/`text-primary`
+  in those fixtures gain the annotation too).
+
+## Three wirings
+
+1. **`ds import`** — `recognizeRoles(dtcg)` runs before `paths.tokens` is written; the seal
+   (`compiledHash`) covers the annotated tree. Output gained one line:
+   `N roles recognized, M gaps: <role list>`.
+2. **`ds context`** — `## Roles` (role → the project's own token path(s), supports multiple
+   tokens per role) and `## Missing roles` (the gap list, in the mindset's exact words: `card,
+   popover (no token — add via 'ui ds change-token' in your own name)`). Reads `ds.tokens`'
+   baked `$extensions["design-os.role"]` directly — never calls `recognizeRoles` again, so a
+   `ds set-role` correction always wins. Omitted entirely (both sections) when no token in the
+   DS carries the annotation (pre-Phase-2 imports, hand-built DSes). Wired into both the markdown
+   and `--format json` (`roles`/`roleGaps` fields).
+3. **`ds set-role <token.path> <role>`** — loads the DS, validates the token exists (`BAD_TOKEN`,
+   reusing `registry-token-check.ts`'s existing `tokenExistsInTree`) and the role is canonical
+   (`BAD_ROLE`), then mutates ONLY that token's `$extensions["design-os.role"]` and reseals via
+   the shared `reseal()` ceremony (same load → mutate → reseal shape as `ds-change-token-impl.ts`).
+   New changelog kind `"set-role"` records `from`/`to`. No-op (same role) short-circuits before
+   reseal, matching `change-token`'s pattern.
+
+## A LIVE finding this phase caught (Art III)
+
+First LIVE run on dana's real 414-token DS (100 recognized) truncated the `## Missing roles` gap
+list clean out of the default `--max-bytes 4096` output — the Roles section was competing with
+the token table for the same byte budget and losing. Fixed by exempting Roles/Missing-roles from
+the budget entirely, the same way the soul chain already is (declared metadata, not variable
+data) — moved from the truncatable `build()` closure into the fixed prefix. The JSON formatter was
+already exempt by construction (`variableBytes()` never included the new fields). Re-verified: no
+truncation at the default budget on dana's real DS.
+
+## Four gates
+
+`typecheck` / `lint` / `build` / `test` (140 files, 2136 passed, 4 skipped — unrelated,
+scratchpad-fixture-conditional LIVE tests) all green. `ui knowledge check` — 0 findings.
+
+## LIVE verification (Art III) — the full loop, raw output
+
+Ran on a scratch copy of dana's real compiled tokens
+(`.../scratchpad/onboard-all/dana-desktop/design/design.tokens.json`), never written back to that
+directory:
+
+```
+$ ui ds import <dana-tokens> --dir <scratch> --name dana --force
+ds import: 414 token(s) [362 color, 39 dimension, 2 fontFamily, 11 number] across 4 categories → <scratch>/design
+  100 roles recognized, 2 gaps: popover, input
+  next: ui ds a11y --dir <scratch>  ·  ui ds status --dir <scratch>
+
+$ ui ds context --dir <scratch> --include tokens
+## Roles
+
+- accent → color.citation-accent, color.citation-accent-hover, color.color-accent, ...
+- background → color.surface-chrome, color.surface-chrome-active, color.surface-chrome-hover,
+  color.surface-content, color.surface-content-active, color.surface-content-alt,
+  color.surface-content-hover, color.surface-elevated, color.surface-elevated-hover
+- ... (14 families total, 100 tokens)
+
+## Missing roles
+
+popover, input (no token — add via 'ui ds change-token' in your own name)
+
+$ ui ds set-role color.surface-content foreground --dir <scratch>
+{ "ok": true, "command": "ds set-role",
+  "data": { "path": "color.surface-content", "role": "foreground", "changed": true,
+            "generation": 2, "compiledHash": "sha256-d0PC1T..." } }
+
+$ ui ds context --dir <scratch> --include tokens
+- background → color.surface-chrome, color.surface-chrome-active, color.surface-chrome-hover,
+  color.surface-content-active, color.surface-content-alt, color.surface-content-hover,
+  color.surface-elevated, color.surface-elevated-hover        # surface-content GONE
+- foreground → color.surface-content, color.text-disabled, ...  # surface-content HERE now
+
+$ ui ds set-role color.surface-content background --dir <scratch>   # fix it back
+{ "ok": true, ..., "generation": 3, ... }
+
+$ ui ds context --dir <scratch> --include tokens
+- background → ..., color.surface-content, ...    # back where it started
+- foreground → color.text-disabled, ...           # (surface-content correctly removed)
+```
+
+**Confirmed: the owner edit via `set-role` survives — `ds context` never recomputes, it reads
+exactly what `set-role` wrote.** Note dana's real `background` family has 9 tokens, not 1, so
+after the (deliberately wrong) correction `background` degrades to 8 tokens rather than
+disappearing into the gap list outright — the plan's illustrative single-token example doesn't
+hold on real multi-token data, but the mechanism (owner edit sticks, nothing recomputed) is
+exactly verified either way. Changelog confirmed both `set-role` entries recorded
+(`Role color.surface-content: background → foreground` / `... foreground → background`).
+
+## Explicitly out of scope
+
+`ds a11y` still uses its own F11 special-case pairing logic, unchanged — generalizing it to
+consume `recognizeRoles`/the baked annotation is a follow-up (per the task's DO NOT list), not
+done here.
+
+## Unresolved questions
+
+- None blocking. Open follow-up (not this phase): generalize `ds a11y`'s F11 pairing to read the
+  baked role annotation instead of its own regex.

--- a/src/commands/ds-import-impl.ts
+++ b/src/commands/ds-import-impl.ts
@@ -15,6 +15,7 @@ import { canonicalStringify, canonicalHash, newManifest } from "../core/ds-manif
 import { createEmptyRegistry } from "../core/registry-store.js";
 import { parseTokenFile } from "../core/token-model.js";
 import { importFlatTokens } from "../core/token-import.js";
+import { recognizeRoles } from "../core/role-recognition.js";
 import type { ParsedArgs } from "../core/cli-args.js";
 import type { CommandResult } from "../core/output.js";
 
@@ -91,30 +92,41 @@ export function runImport(parsed: ParsedArgs): CommandResult {
     return err("BAD_JSON", `internal: emitted DTCG did not validate: ${e instanceof Error ? e.message : String(e)}`);
   }
 
+  // Bake role recognition (spec 011 Phase 2) BEFORE sealing, so the seal covers
+  // the annotated tree — deterministic, so the hash is stable. Lossless: every
+  // name/value survives verbatim; only $extensions["design-os.role"] is added.
+  // Never renames, drops, or injects a token (see role-recognition.ts).
+  const recognition = recognizeRoles(dtcg);
+  const annotated = recognition.annotated;
+
   // Seal a minimal store: tokens + empty registry + manifest.
   const registry = createEmptyRegistry();
   const manifest = newManifest({
     name,
     persona: { slug: "imported", family: "imported" },
     intent: `imported from ${src}`,
-    compiledHash: canonicalHash(dtcg),
+    compiledHash: canonicalHash(annotated),
     registryHash: canonicalHash(registry),
   });
   try {
     mkdirSync(designDir, { recursive: true });
     // canonicalStringify already appends a trailing "\n" (ds-manifest.ts) — do not double it.
-    writeFileSync(paths.tokens, canonicalStringify(dtcg));
+    writeFileSync(paths.tokens, canonicalStringify(annotated));
     writeFileSync(paths.registry, canonicalStringify(registry));
     writeFileSync(paths.manifest, canonicalStringify(manifest));
   } catch (e) {
     return err("WRITE_ERROR", `could not write DS store: ${e instanceof Error ? e.message : String(e)}`);
   }
 
-  const summary = { name, dir: designDir, ...stats, categories: Object.keys(dtcg).length };
+  const summary = {
+    name, dir: designDir, ...stats, categories: Object.keys(annotated).length,
+    rolesRecognized: recognition.recognized, roleGaps: recognition.gaps,
+  };
   if (useJson) return okJsonWithExit(CMD, summary, 0);
   const typeLine = Object.entries(stats.byType).map(([t, n]) => `${n} ${t}`).join(", ");
   const lines = [
     `ds import: ${stats.imported} token(s) [${typeLine}] across ${summary.categories} categories → ${designDir}`,
+    `  ${recognition.recognized} roles recognized, ${recognition.gaps.length} gaps: ${recognition.gaps.join(", ")}`,
     ...(stats.skipped > 0 ? [`  skipped ${stats.skipped} un-typeable token(s): ${stats.skippedKeys.slice(0, 6).map((s) => s.key).join(", ")}${stats.skipped > 6 ? " …" : ""}`] : []),
     `  next: ui ds a11y --dir ${parsed.flags["dir"] ?? "."}  ·  ui ds status --dir ${parsed.flags["dir"] ?? "."}`,
   ];

--- a/src/commands/ds-set-role-impl.ts
+++ b/src/commands/ds-set-role-impl.ts
@@ -1,0 +1,137 @@
+/**
+ * runSetRole — implementation for `ui ds set-role <token.path> <role>`.
+ *
+ * The owner-edit path for role recognition (spec 011 Phase 2, decision 2: editable).
+ * Sets $extensions["design-os.role"] on ONE token and reseals — the same load →
+ * mutate → reseal ceremony as ds-change-token-impl.ts (the proven oracle for
+ * `reseal`). This is how an owner corrects a mis-recognition (`ds set-role
+ * color.surface-overlay popover`) as a first-class, changelogged mutation —
+ * never a silent hand-edit of design.tokens.json.
+ *
+ * `ds context` reads exactly what this writes and never recomputes recognition,
+ * so a correction here is permanent until the owner runs `set-role` again.
+ */
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+
+import { errJson, errText, okJson } from "../core/output.js";
+import { findUnknownFlag, unknownFlagMessage } from "../core/flag-guard.js";
+import { discoverDesignSystem, loadDesignSystem, pathsForDir, DSError } from "../core/design-system.js";
+import { DSManifestError } from "../core/ds-manifest.js";
+import { reseal } from "../core/ds-reseal.js";
+import { tokenExistsInTree } from "../core/registry-token-check.js";
+import { CANONICAL_ROLES } from "../core/role-recognition.js";
+import type { Role } from "../core/role-recognition.js";
+import type { ParsedArgs } from "../core/cli-args.js";
+import type { CommandResult } from "../core/output.js";
+
+const CMD = "ds set-role";
+
+/** Long flags `ui ds set-role` accepts (globals --help/--json handled separately). */
+const KNOWN_FLAGS = ["dir"] as const;
+
+function isRole(v: string): v is Role {
+  return (CANONICAL_ROLES as readonly string[]).includes(v);
+}
+
+export function runSetRole(parsed: ParsedArgs): CommandResult {
+  const useJson = parsed.json;
+  const err = (code: string, msg: string): CommandResult =>
+    useJson ? errJson(CMD, code, msg) : errText(`ui: ${msg}\n`);
+
+  // ── Reject unknown flags ────────────────────────────────────────────────────
+
+  const unknown = findUnknownFlag(parsed.flags, KNOWN_FLAGS);
+  if (unknown !== null) return err("UNKNOWN_FLAG", unknownFlagMessage(unknown));
+
+  // ── Validate positionals ────────────────────────────────────────────────────
+
+  const tokenPath = parsed.positionals[0];
+  const role = parsed.positionals[1];
+  if (typeof tokenPath !== "string" || tokenPath.length === 0 || typeof role !== "string" || role.length === 0) {
+    return err("BAD_ARG", "missing required arguments. Usage: ui ds set-role <token.path> <role> [--dir <project>]");
+  }
+
+  const parts = tokenPath.split(".");
+  if (parts.length !== 2) {
+    return err("BAD_ARG", `token path '${tokenPath}' must be two-level (e.g. color.primary)`);
+  }
+  const [category, tokenName] = parts as [string, string];
+
+  // ── Resolve DS paths ────────────────────────────────────────────────────────
+
+  const dirFlag = parsed.flags["dir"];
+  const baseDir = typeof dirFlag === "string" ? resolve(dirFlag) : cwd();
+
+  let paths;
+  try {
+    paths = typeof dirFlag === "string" ? pathsForDir(resolve(baseDir, "design")) : discoverDesignSystem(undefined);
+  } catch (e) {
+    const code = e instanceof DSError ? e.code : "DS_NOT_FOUND";
+    return err(code, e instanceof Error ? e.message : String(e));
+  }
+
+  // ── Load and verify current DS ──────────────────────────────────────────────
+
+  let ds;
+  try {
+    ds = loadDesignSystem(paths);
+  } catch (e) {
+    const code = e instanceof DSError ? e.code : e instanceof DSManifestError ? e.code : "BAD_DS";
+    return err(code, e instanceof Error ? e.message : String(e));
+  }
+
+  // ── Validate the token exists (BAD_TOKEN), then the role is canonical (BAD_ROLE) ──
+
+  if (!tokenExistsInTree(ds.tokens, tokenPath)) {
+    return err("BAD_TOKEN", `token '${tokenPath}' does not exist in the compiled design system`);
+  }
+  if (!isRole(role)) {
+    return err("BAD_ROLE", `'${role}' is not a known role — expected one of: ${CANONICAL_ROLES.join(", ")}`);
+  }
+
+  const categoryGroup = ds.tokens[category]!;
+  const existingToken = categoryGroup[tokenName]!;
+  const prevRole = (existingToken.$extensions as Record<string, unknown> | undefined)?.["design-os.role"];
+  const prevRoleStr = typeof prevRole === "string" ? prevRole : undefined;
+
+  // ── No-op check ─────────────────────────────────────────────────────────────
+
+  if (prevRoleStr === role) {
+    return okJson(CMD, {
+      path: tokenPath, role, changed: false,
+      generation: ds.manifest.generation, compiledHash: ds.manifest.compiledHash,
+    });
+  }
+
+  // ── Build new TokenTree (shallow clone, replace one leaf's $extensions) ─────
+
+  const newExtensions = { ...existingToken.$extensions, "design-os.role": role };
+  const newCategoryGroup = { ...categoryGroup, [tokenName]: { ...existingToken, $extensions: newExtensions } };
+  const newTokens = { ...ds.tokens, [category]: newCategoryGroup };
+
+  // ── Reseal (spec 009 P1: the shared Art IV ceremony) ────────────────────────
+
+  let resealResult;
+  try {
+    resealResult = reseal({
+      ds, paths, tokens: newTokens,
+      entry: {
+        kind: "set-role",
+        by: "ui ds set-role",
+        path: tokenPath,
+        ...(prevRoleStr !== undefined && { from: prevRoleStr }),
+        to: role,
+      },
+      nowIso: new Date().toISOString(),
+    });
+  } catch (e) {
+    const code = e instanceof DSManifestError ? e.code : "WRITE_ERROR";
+    return err(code, e instanceof Error ? e.message : String(e));
+  }
+
+  return okJson(CMD, {
+    path: tokenPath, role, changed: true,
+    generation: resealResult.generation, compiledHash: resealResult.compiledHash,
+  });
+}

--- a/src/commands/ds.ts
+++ b/src/commands/ds.ts
@@ -8,6 +8,7 @@ import { runDiff } from "./ds-diff-impl.js";
 import { runDocs } from "./ds-docs-impl.js";
 import { runA11y } from "./ds-a11y-impl.js";
 import { runChangeToken } from "./ds-change-token-impl.js";
+import { runSetRole } from "./ds-set-role-impl.js";
 import { runStatus } from "./ds-status-impl.js";
 import { runImport } from "./ds-import-impl.js";
 import { runSpecimen } from "./ds-specimen-impl.js";
@@ -24,6 +25,7 @@ Usage:
   ui ds init <name> --persona <slug> --intent "<text>" [options]
   ui ds context [--strict] [--with-theme] [--format markdown|json] [options]
   ui ds change-token <path> --value <v> [options]
+  ui ds set-role <token.path> <role> [--dir <project>] [--json]
   ui ds status   [--dir <project-dir>] [--json]
   ui ds diff <base-dir> <head-dir> [--format markdown|json|pr-comment] [--base-version <v>]
   ui ds docs [--dir <project>] [--out <file>] [--format markdown|json]
@@ -37,6 +39,8 @@ Subcommands:
   import         Onboard an EXISTING flat tokens.json → the DTCG store (so ds a11y/status/diff work)
   context        Emit the active design system as a context block for the host model
   change-token   Update one token's $value (only sanctioned mutation post-init)
+  set-role       Set/correct one token's recognized role — the owner-edit path for
+                 recognition (spec 011 P2); 'ds context' reads this, never recomputes it
   status         Show the manifest summary (generation, persona, hashes)
   diff           Compare two DS states (dirs with design.tokens.json) → semver + visual-breaking classification
   docs           Regenerate component reference docs from the registry (decay-proof)
@@ -80,6 +84,11 @@ Subcommands:
   $type per value (color/dimension/number/fontFamily/fontWeight/duration). Nested
   groups are hoisted to <cat>-<sub>. Un-typeable values (box-shadow strings,
   bezier easings) are SKIPPED and reported — never emitted with a bad type.
+  Also BAKES role recognition into every $type:color token before sealing
+  (spec 011 P2): each recognized token gets $extensions["design-os.role"],
+  lossless (never renames/drops/injects). Output reports "N roles recognized,
+  M gaps: <role list>" — the gaps are reported, never auto-injected. Correct a
+  mis-recognition afterwards with 'ui ds set-role'.
 
 'ds specimen' options:
   --dir <path>       Project directory holding design/ (default: cwd)
@@ -105,6 +114,17 @@ Subcommands:
   --reason "<text>"  Changelog note recorded with the mutation
   --dir <path>       Override the project directory
 
+'ds set-role' options:
+  <token.path>       Existing token path (e.g. color.surface-content) — BAD_TOKEN if unknown
+  <role>             One of the canonical roles (background, foreground, card, popover,
+                     primary, secondary, muted, accent, border, input, ring, destructive,
+                     success, warning, info, neutral) — BAD_ROLE if not
+  --dir <path>       Override the project directory
+  The owner-edit path for recognition (decision 2: editable). Sets
+  $extensions["design-os.role"] on the ONE named token and reseals (bumps
+  generation, appends a changelog entry) — never renames the token, never
+  touches any other token. 'ds context' reads exactly what this writes.
+
 'ds context' options:
   --strict       Prepend the registered-components-only enforcement preamble
   --with-theme   Also emit the compiled Tailwind v4 @theme block (full token map,
@@ -122,6 +142,12 @@ Subcommands:
   the project section since the project always wins on conflict. Either,
   both, or neither may exist; a missing file just omits its section, never
   an error.
+  The 'tokens' section also emits '## Roles' (role → your own token name,
+  e.g. background → color.surface-content) and '## Missing roles' (the gap
+  list, e.g. "card, popover (no token — add via 'ui ds change-token' in your
+  own name)") — read from the BAKED $extensions["design-os.role"] annotation
+  ('ds import' or 'ds set-role'), never recomputed, so a 'ds set-role'
+  correction always sticks. A DS with no baked roles omits both, never an error.
 
 'ds soul' options:
   init           Write the design/soul.md scaffold (status: draft)
@@ -177,6 +203,7 @@ Error codes:
   BAD_TOKEN          Compiled token set failed validation on 'ds init'
   PERSONA_NOT_FOUND  --persona slug not in personas.json
   TOKEN_NOT_FOUND    'change-token' on a non-existent path
+  BAD_ROLE           'set-role' <role> is not one of the canonical roles
   UNKNOWN_FLAG       Unrecognised --flag
   BAD_ARG            Missing <tokens.json> on 'ds import'
   FILE_NOT_FOUND     'ds import' source file does not exist
@@ -216,6 +243,7 @@ export const dsCommand = {
       case "import":       return runImport(parsed);
       case "context":      return runContext(parsed);
       case "change-token": return runChangeToken(parsed);
+      case "set-role":     return runSetRole(parsed);
       case "status":       return runStatus(parsed);
       case "diff":         return runDiff(parsed);
       case "docs":         return runDocs(parsed);

--- a/src/core/changelog.ts
+++ b/src/core/changelog.ts
@@ -51,6 +51,10 @@ export function buildChangelog(
       const move = c.from !== undefined && c.to !== undefined ? `: ${c.from} → ${c.to}` : "";
       const why = c.reason !== undefined ? ` — ${c.reason}` : "";
       entries.push({ date, type: "Changed", text: `Token ${path}${move}${why}`, provenance: by });
+    } else if (c.kind === "set-role") {
+      const path = c.path ?? "(token)";
+      const move = c.from !== undefined ? `${c.from} → ${c.to}` : `${c.to}`;
+      entries.push({ date, type: "Changed", text: `Role ${path}: ${move}`, provenance: by });
     }
   }
 

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -540,6 +540,15 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
         ],
         errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "DS_NOT_FOUND", "DS_TAMPERED", "BAD_MANIFEST", "TOKEN_NOT_FOUND", "BAD_VALUE", "ALIAS_CYCLE", "DANGLING_ALIAS", "TYPE_MISMATCH", "WRITE_ERROR"],
       },
+      "set-role": {
+        summary: "Set/correct one token's recognized role (owner-edit path, spec 011 P2)",
+        positionals: [
+          { name: "<token.path>", required: true, summary: "Existing token path (e.g. color.primary)" },
+          { name: "<role>", required: true, summary: "One of the canonical roles (background, foreground, card, popover, primary, secondary, muted, accent, border, input, ring, destructive, success, warning, info, neutral)" },
+        ],
+        flags: [{ name: "dir", type: "string", summary: "Override the project directory" }],
+        errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "DS_NOT_FOUND", "DS_TAMPERED", "BAD_MANIFEST", "BAD_TOKEN", "BAD_ROLE", "WRITE_ERROR"],
+      },
       status: {
         summary: "Show the manifest summary (generation, persona, hashes)",
         positionals: [],

--- a/src/core/ds-context-roles.ts
+++ b/src/core/ds-context-roles.ts
@@ -1,0 +1,69 @@
+/**
+ * Roles section for `ds context` (spec 011 Phase 2).
+ *
+ * Reads the BAKED `$extensions["design-os.role"]` annotation already written by
+ * `ds import` (role-recognition.ts) or corrected by `ds set-role` — NEVER
+ * recomputes recognition here. Re-running `recognizeRoles` in this module would
+ * silently discard an owner's manual `ds set-role` correction; reading the
+ * stored annotation is what makes that correction stick.
+ *
+ * Kept out of ds-context.ts (already near/at the 200-line guideline) as its own
+ * small, pure module — one responsibility, one file.
+ */
+import { CANONICAL_ROLES } from "./role-recognition.js";
+import type { Role } from "./role-recognition.js";
+import type { TokenTree } from "./token-model.js";
+
+export interface RolesSummary {
+  /** Every canonical role with ≥1 token carrying it, sorted by role name; each entry's paths sorted. */
+  roles: { role: Role; paths: string[] }[];
+  /** Canonical roles with zero tokens carrying them. */
+  gaps: Role[];
+}
+
+/**
+ * Scan every token's baked role annotation. Returns `null` when NO token in the
+ * tree carries one — a DS imported before this feature shipped, or hand-built
+ * with no bake step. Both context sections are then omitted entirely (never an
+ * error, never a guessed section for a DS that never opted in).
+ */
+export function summarizeRoles(tokens: TokenTree): RolesSummary | null {
+  const byRole = new Map<Role, string[]>();
+  for (const [category, group] of Object.entries(tokens)) {
+    for (const [name, token] of Object.entries(group)) {
+      const role = (token.$extensions as Record<string, unknown> | undefined)?.["design-os.role"];
+      if (typeof role !== "string" || !(CANONICAL_ROLES as readonly string[]).includes(role)) continue;
+      const paths = byRole.get(role as Role);
+      const path = `${category}.${name}`;
+      if (paths !== undefined) paths.push(path);
+      else byRole.set(role as Role, [path]);
+    }
+  }
+  if (byRole.size === 0) return null;
+
+  const roles = [...byRole.entries()]
+    .map(([role, paths]) => ({ role, paths: [...paths].sort() }))
+    .sort((a, b) => a.role.localeCompare(b.role));
+  const gaps = CANONICAL_ROLES.filter((r) => !byRole.has(r));
+  return { roles, gaps };
+}
+
+/**
+ * Render the '## Roles' + '## Missing roles' markdown lines. Empty array when
+ * `summary` is null (nothing to say — omit both sections, not an error).
+ */
+export function rolesMarkdownLines(summary: RolesSummary | null): string[] {
+  if (summary === null) return [];
+  const lines: string[] = ["## Roles", ""];
+  for (const { role, paths } of summary.roles) {
+    lines.push(`- ${role} → ${paths.join(", ")}`);
+  }
+  lines.push("", "## Missing roles", "");
+  lines.push(
+    summary.gaps.length === 0
+      ? "(none — every canonical role has a recognized token)"
+      : `${summary.gaps.join(", ")} (no token — add via 'ui ds change-token' in your own name)`,
+  );
+  lines.push("");
+  return lines;
+}

--- a/src/core/ds-context.ts
+++ b/src/core/ds-context.ts
@@ -9,6 +9,8 @@ import { isAlias } from "./token-model.js";
 import { soulSectionForContext } from "./ds-soul.js";
 import { studioSoulSectionForContext } from "./ds-soul-studio.js";
 import { factorySoulSectionForContext } from "./ds-soul-factory.js";
+import { summarizeRoles, rolesMarkdownLines } from "./ds-context-roles.js";
+import type { RolesSummary } from "./ds-context-roles.js";
 import type { DesignSystem } from "./design-system.js";
 import type { ResolvedToken } from "./token-model.js";
 
@@ -55,6 +57,15 @@ export interface StructuredContext {
   registry: { name: string; category: string; tokensUsed: string[] }[];
   naming: { rule: string }[];
   antiPatterns: string[];
+  /**
+   * Roles recognized (spec 011 P2) from the BAKED `$extensions["design-os.role"]`
+   * annotation — never recomputed here (an owner's `ds set-role` correction must
+   * stick). Empty when the "tokens" section is excluded or no token in the DS
+   * carries a baked role (e.g. imported before this feature shipped).
+   */
+  roles: { role: string; paths: string[] }[];
+  /** Canonical roles with zero recognized tokens; same omission rule as `roles`. */
+  roleGaps: string[];
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -202,6 +213,10 @@ function applyTruncation(
 export function formatMarkdown(ds: DesignSystem, opts: ContextOptions): string {
   const { include, strict, maxBytes, soul, studioSoul } = opts;
   const sem = semanticTokens(ds);
+  // Roles read the BAKED annotation off the full raw tree (not just the
+  // "semantic" filter above — a role can live on a literal-valued token too,
+  // e.g. dana's surface-content). Never recomputed — see ds-context-roles.ts.
+  const rolesSummary = summarizeRoles(ds.tokens);
   const regRows = ds.registry.components.map((c) => ({
     name: c.name,
     category: c.category,
@@ -278,6 +293,17 @@ export function formatMarkdown(ds: DesignSystem, opts: ContextOptions): string {
       );
     }
     prefixLines.push(factorySoulSectionForContext(), "");
+  }
+
+  // Roles + gaps (spec 011 P2) are declared metadata, not variable data — a real
+  // LIVE run on dana's 414-token DS (100 recognized) showed the role list itself
+  // can be large enough to blow the default 4096-byte budget, truncating the
+  // "## Missing roles" gap list right out of the output. Exempt the whole
+  // section from `maxBytes`, same reasoning as the soul chain above: read from
+  // the BAKED annotation, never recomputed, so an owner's `ds set-role`
+  // correction is never silently dropped by a byte budget either.
+  if (include.includes("tokens")) {
+    prefixLines.push(...rolesMarkdownLines(rolesSummary));
   }
 
   // ── Variable tail: token / registry / naming / anti-pattern tables ───────────
@@ -366,6 +392,7 @@ function buildStructured(
   include: ContextSection[],
   soul: string | null,
   studioSoul: string | null,
+  rolesSummary: RolesSummary | null,
   ap: string[],
   reg: { name: string; category: string; tokensUsed: string[] }[],
   tok: ResolvedToken[],
@@ -389,6 +416,13 @@ function buildStructured(
       ? NAMING_RULES.map((r) => ({ rule: r }))
       : [],
     antiPatterns: include.includes("anti-patterns") ? ap : [],
+    // Roles ride the same "tokens" include and the same exemption as the soul
+    // chain — read from the BAKED annotation, never recomputed (see
+    // ds-context-roles.ts), so an owner's `ds set-role` correction always wins.
+    roles: include.includes("tokens") && rolesSummary !== null
+      ? rolesSummary.roles.map((r) => ({ role: r.role, paths: r.paths }))
+      : [],
+    roleGaps: include.includes("tokens") && rolesSummary !== null ? [...rolesSummary.gaps] : [],
   };
 }
 
@@ -434,6 +468,8 @@ export function formatStructured(ds: DesignSystem, opts: ContextOptions): Struct
   // The soul chain is always at full (capped) text — never dropped for budget.
   const soulText = opts.soul !== undefined ? soulSectionForContext(opts.soul) : null;
   const studioSoulText = opts.studioSoul !== undefined ? studioSoulSectionForContext(opts.studioSoul) : null;
+  // Roles ride the same exemption — read from the baked annotation, never recomputed.
+  const rolesSummary = summarizeRoles(ds.tokens);
 
   // Try progressively more aggressive truncation of the VARIABLE rows only —
   // drop rows, never mid-string slice; the soul chain stays whole throughout.
@@ -445,7 +481,7 @@ export function formatStructured(ds: DesignSystem, opts: ContextOptions): Struct
     for (const regLimit of regLimits) {
       for (const tokLimit of tokLimits) {
         const ctx = buildStructured(
-          ds, include, soulText, studioSoulText,
+          ds, include, soulText, studioSoulText, rolesSummary,
           antiPatterns.slice(0, apLimit),
           regRows.slice(0, regLimit),
           sem.slice(0, tokLimit),
@@ -459,7 +495,7 @@ export function formatStructured(ds: DesignSystem, opts: ContextOptions): Struct
 
   // Budget is too small even for zero variable rows — the soul chain still rides
   // through whole (it is exempt); only the row sections collapse to empty.
-  return buildStructured(ds, include, soulText, studioSoulText, [], [], []);
+  return buildStructured(ds, include, soulText, studioSoulText, rolesSummary, [], [], []);
 }
 
 // ─── Include parser ───────────────────────────────────────────────────────────

--- a/src/core/ds-manifest.ts
+++ b/src/core/ds-manifest.ts
@@ -13,11 +13,11 @@ import { readFileSync, writeFileSync } from "node:fs";
 
 export interface DSChangelogEntry {
   ts: string;       // ISO-8601 UTC
-  kind: "init" | "change-token" | "register";
-  by: string;       // "ui ds init" | "ui ds change-token" | "ui registry register"
-  path?: string;    // change-token: token path
-  from?: string;    // change-token: previous serialized $value
-  to?: string;      // change-token: new serialized $value
+  kind: "init" | "change-token" | "register" | "set-role";
+  by: string;       // "ui ds init" | "ui ds change-token" | "ui registry register" | "ui ds set-role"
+  path?: string;    // change-token/set-role: token path
+  from?: string;    // change-token: previous serialized $value; set-role: previous role (absent if none)
+  to?: string;      // change-token: new serialized $value; set-role: new role
   reason?: string;
   note?: string;
 }
@@ -94,7 +94,7 @@ const MANIFEST_ROOT_KEYS = new Set([
 const CHANGELOG_KEYS = new Set([
   "ts", "kind", "by", "path", "from", "to", "reason", "note",
 ]);
-const CHANGELOG_KINDS = new Set(["init", "change-token", "register"]);
+const CHANGELOG_KINDS = new Set(["init", "change-token", "register", "set-role"]);
 const SEMVER_RE = /^[0-9]+\.[0-9]+\.[0-9]+$/;
 const HASH_RE = /^sha256-[A-Za-z0-9_-]+$/;
 const SLUG_RE = /^[a-z][a-z0-9-]*$/;

--- a/src/core/role-recognition.ts
+++ b/src/core/role-recognition.ts
@@ -18,7 +18,7 @@ export type Role =
   | "muted" | "accent" | "border" | "input" | "ring" | "destructive"
   | "success" | "warning" | "info" | "neutral";
 
-const CANONICAL_ROLES: readonly Role[] = [
+export const CANONICAL_ROLES: readonly Role[] = [
   "background", "foreground", "card", "popover", "primary", "secondary", "muted",
   "accent", "border", "input", "ring", "destructive", "success", "warning", "info", "neutral",
 ];

--- a/tests/cmd-ds-context.test.ts
+++ b/tests/cmd-ds-context.test.ts
@@ -507,3 +507,79 @@ describe("ui ds context — soul chain budget exemption", () => {
     expect(Array.isArray(data.semantic)).toBe(true);
   });
 });
+
+// ─── ds context — roles section (spec 011 Phase 2) ───────────────────────────
+// Reads the BAKED $extensions["design-os.role"] annotation ('ds import' or a
+// 'ds set-role' correction) — never recomputes recognition.
+
+describe("ui ds context — roles section", () => {
+  function importDs(tmp: string): void {
+    const src = join(tmp, "src-tokens.json");
+    writeFileSync(
+      src,
+      JSON.stringify({ color: { "surface-content": "#FFFFFF", "zorp-glimble": "#123456" } }),
+      "utf8",
+    );
+    const r = capture(["ds", "import", src, "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(0);
+  }
+
+  it("a DS with baked roles (via 'ds import') emits both '## Roles' and '## Missing roles'", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-ctx-roles-"));
+    importDs(tmp);
+    const r = capture(["ds", "context", "--dir", tmp]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("## Roles");
+    expect(r.stdout).toContain("background → color.surface-content");
+    expect(r.stdout).toContain("## Missing roles");
+    // zorp-glimble is unrecognized by name — "primary" never got a token, so it's a gap.
+    expect(r.stdout).toMatch(/primary/);
+  });
+
+  it("a DS with no baked roles (plain 'ds init') omits both sections — never an error", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-ctx-roles-none-"));
+    initDs(tmp);
+    const r = capture(["ds", "context", "--dir", tmp]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain("## Roles");
+    expect(r.stdout).not.toContain("## Missing roles");
+  });
+
+  it("a 'ds set-role' correction is what context reads — the owner edit sticks, never recomputed", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-ctx-roles-setrole-"));
+    importDs(tmp);
+    const before = capture(["ds", "context", "--dir", tmp]);
+    expect(before.stdout).toContain("background → color.surface-content");
+    expect(before.stdout).toMatch(/foreground.*\(no token/);
+
+    const set = capture(["ds", "set-role", "color.surface-content", "foreground", "--dir", tmp, "--json"]);
+    expect(set.exitCode).toBe(0);
+
+    const after = capture(["ds", "context", "--dir", tmp]);
+    expect(after.exitCode).toBe(0);
+    // background now has zero tokens → it moves to the gap list.
+    expect(after.stdout).toMatch(/background.*\(no token/);
+    expect(after.stdout).toContain("foreground → color.surface-content");
+    expect(after.stdout).not.toContain("background → color.surface-content");
+  });
+
+  it("--format json exposes roles/roleGaps arrays", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-ctx-roles-json-"));
+    importDs(tmp);
+    const r = capture(["ds", "context", "--dir", tmp, "--format", "json", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const data = JSON.parse(r.stdout).data;
+    expect(data.roles).toContainEqual({ role: "background", paths: ["color.surface-content"] });
+    expect(data.roleGaps).toContain("primary");
+  });
+
+  it("--format json: a DS with no baked roles returns empty roles/roleGaps arrays", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-ctx-roles-json-none-"));
+    initDs(tmp);
+    const r = capture(["ds", "context", "--dir", tmp, "--format", "json", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const data = JSON.parse(r.stdout).data;
+    expect(data.roles).toEqual([]);
+    expect(data.roleGaps).toEqual([]);
+  });
+});

--- a/tests/cmd-ds-import.test.ts
+++ b/tests/cmd-ds-import.test.ts
@@ -57,7 +57,11 @@ describe("ui ds import — writes the DS store", () => {
     expect(data.byType.color).toBe(2);
 
     const written = JSON.parse(readFileSync(dtokens, "utf8"));
-    expect(written.colors.primary).toEqual({ $value: "#3366ff", $type: "color" });
+    // spec 011 P2: `ds import` bakes role recognition before sealing — "primary" is a
+    // self-declaring family keyword, so it gains the annotation losslessly.
+    expect(written.colors.primary).toEqual({
+      $value: "#3366ff", $type: "color", $extensions: { "design-os.role": "primary" },
+    });
   });
 });
 
@@ -214,7 +218,10 @@ describe("ui ds import — F2: alias-valued tokens survive import (spec 009 P3 D
     expect(data.imported).toBe(2);
 
     const written = JSON.parse(readFileSync(join(tmp, "design", "design.tokens.json"), "utf8"));
-    expect(written.color["text-primary"]).toEqual({ $value: "{color.gray-900}", $type: "color" });
+    // "text-primary" recognizes via the leading text- prefix → foreground (spec 011 P2).
+    expect(written.color["text-primary"]).toEqual({
+      $value: "{color.gray-900}", $type: "color", $extensions: { "design-os.role": "foreground" },
+    });
 
     const compiled = capture(["tokens", "compile", join(tmp, "design", "design.tokens.json"), "--target", "css"]);
     expect(compiled.code).toBe(0);

--- a/tests/cmd-ds-set-role.test.ts
+++ b/tests/cmd-ds-set-role.test.ts
@@ -1,0 +1,147 @@
+/**
+ * `ui ds set-role <token.path> <role>` — the owner-edit path for role recognition
+ * (spec 011 Phase 2). Covers the reseal round-trip, the no-op branch, both
+ * validation error codes (BAD_TOKEN / BAD_ROLE), and that a correction here is
+ * what `ds context` later reads (cross-checked in cmd-ds-context.test.ts).
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { run } from "../src/cli.js";
+import { loadManifest } from "../src/core/ds-manifest.js";
+
+function capture(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+  let stdout = "";
+  let stderr = "";
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stdout.write = (c: any) => { stdout += String(c); return true; };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stderr.write = (c: any) => { stderr += String(c); return true; };
+  let exitCode: number;
+  try {
+    exitCode = run(args);
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+  return { exitCode, stdout, stderr };
+}
+
+function writeFlat(dir: string, name: string, obj: unknown): string {
+  const p = join(dir, name);
+  writeFileSync(p, JSON.stringify(obj), "utf8");
+  return p;
+}
+
+function importDs(tmp: string): void {
+  const src = writeFlat(tmp, "tokens.json", {
+    color: { "surface-content": "#FFFFFF", "zorp-glimble": "#123456" },
+  });
+  const r = capture(["ds", "import", src, "--dir", tmp, "--json"]);
+  expect(r.exitCode).toBe(0);
+}
+
+describe("ui ds set-role", () => {
+  it("round-trip: sets a role, bumps generation, changed=true, changelog grows", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-"));
+    importDs(tmp);
+    // zorp-glimble is unrecognized by name — the owner names it explicitly.
+    const r = capture(["ds", "set-role", "color.zorp-glimble", "popover", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(0);
+    const data = JSON.parse(r.stdout).data;
+    expect(data.changed).toBe(true);
+    expect(data.role).toBe("popover");
+    expect(data.generation).toBe(2);
+
+    const written = JSON.parse(readFileSync(join(tmp, "design", "design.tokens.json"), "utf8"));
+    expect(written.color["zorp-glimble"].$extensions["design-os.role"]).toBe("popover");
+
+    const manifest = loadManifest(join(tmp, "design", "ds.manifest.json"));
+    expect(manifest.generation).toBe(2);
+    expect(manifest.changelog.at(-1)).toMatchObject({
+      kind: "set-role", path: "color.zorp-glimble", to: "popover",
+    });
+  });
+
+  it("a correction overrides a role recognition already baked by 'ds import'", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-correct-"));
+    importDs(tmp);
+    // surface-content recognized as background by 'ds import' — the owner corrects it.
+    const before = JSON.parse(readFileSync(join(tmp, "design", "design.tokens.json"), "utf8"));
+    expect(before.color["surface-content"].$extensions["design-os.role"]).toBe("background");
+
+    const r = capture(["ds", "set-role", "color.surface-content", "foreground", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(0);
+    expect(JSON.parse(r.stdout).data.changed).toBe(true);
+
+    const after = JSON.parse(readFileSync(join(tmp, "design", "design.tokens.json"), "utf8"));
+    expect(after.color["surface-content"].$extensions["design-os.role"]).toBe("foreground");
+    // Lossless: name and value untouched by the correction.
+    expect(after.color["surface-content"].$value).toBe(before.color["surface-content"].$value);
+  });
+
+  it("no-op: setting the same role again → changed=false, generation unchanged", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-noop-"));
+    importDs(tmp);
+    const manifestPath = join(tmp, "design", "ds.manifest.json");
+    const before = readFileSync(manifestPath);
+    const r = capture(["ds", "set-role", "color.surface-content", "background", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(0);
+    const data = JSON.parse(r.stdout).data;
+    expect(data.changed).toBe(false);
+    expect(data.generation).toBe(1);
+    const after = readFileSync(manifestPath);
+    expect(after.equals(before)).toBe(true);
+  });
+
+  it("errors BAD_TOKEN for a non-existent token path", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-badtoken-"));
+    importDs(tmp);
+    const r = capture(["ds", "set-role", "color.nope", "background", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(r.stdout).error.code).toBe("BAD_TOKEN");
+  });
+
+  it("errors BAD_ROLE for an unknown role name", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-badrole-"));
+    importDs(tmp);
+    const r = capture(["ds", "set-role", "color.surface-content", "wobble", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(r.stdout).error.code).toBe("BAD_ROLE");
+  });
+
+  it("errors BAD_ARG when <role> positional is missing", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-noargs-"));
+    importDs(tmp);
+    const r = capture(["ds", "set-role", "color.surface-content", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(r.stdout).error.code).toBe("BAD_ARG");
+  });
+
+  it("errors BAD_ARG for a non-two-level token path", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-onelevel-"));
+    importDs(tmp);
+    const r = capture(["ds", "set-role", "surface-content", "background", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(r.stdout).error.code).toBe("BAD_ARG");
+  });
+
+  it("errors DS_NOT_FOUND when no design system exists", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-empty-"));
+    const r = capture(["ds", "set-role", "color.primary", "primary", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(r.stdout).error.code).toBe("DS_NOT_FOUND");
+  });
+
+  it("errors UNKNOWN_FLAG for a bogus flag", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-set-role-badflag-"));
+    importDs(tmp);
+    const r = capture(["ds", "set-role", "color.surface-content", "background", "--dir", tmp, "--bogus", "--json"]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(r.stdout).error.code).toBe("UNKNOWN_FLAG");
+  });
+});

--- a/tests/cmd-ingest-css-ds.test.ts
+++ b/tests/cmd-ingest-css-ds.test.ts
@@ -148,7 +148,11 @@ describe("ui ingest-css-ds — UC-03: extract-tokens → ingest-css-ds → ds im
 
     const compiled = JSON.parse(readFileSync(join(dsDir, "design", "design.tokens.json"), "utf8"));
     expect(compiled.color["text-primary"].$value).toBe("{color.gray-900}");
-    expect(compiled.color.bg.$extensions).toEqual({ "mode.dark": { $value: "#111111" } });
+    // spec 011 P2: `ds import` bakes role recognition — "bg" (leading bg- prefix) also
+    // gains its role annotation, merged alongside the pre-existing mode.dark extension.
+    expect(compiled.color.bg.$extensions).toEqual({
+      "mode.dark": { $value: "#111111" }, "design-os.role": "background",
+    });
 
     const css = capture(["tokens", "compile", join(dsDir, "design", "design.tokens.json"), "--target", "css"]);
     expect(css.code).toBe(0);


### PR DESCRIPTION
Makes the recognition core (#85) user-visible. Three wirings, all keeping the mindset: annotate, never rename; gaps reported, never injected.

## 1. `ds import` bakes the annotation
Runs `recognizeRoles` before sealing, so the hash covers the annotated tree. Output gains: `100 roles recognized, 2 gaps: popover, input`. Lossless — names/values unchanged, only `$extensions["design-os.role"]` added (merged alongside any existing `mode.*` extension, never clobbering).

## 2. `ds context` emits Roles + Missing roles
Reads the BAKED annotation (never recomputes — so owner edits stick). Two sections:
```
## Roles
- background → color.surface-content, color.surface-chrome, color.surface-elevated, …
- destructive → color.badge-danger-bg, color.color-danger, color.semantic-error-text, …
- accent → color.citation-accent, color.color-accent, …
## Missing roles
popover, input (no token — add via 'ui ds change-token' in your own name)
```
This is the mindset in output: it maps THEIR tokens (surface-content, citation-accent, badge-danger) to roles **without renaming them**, and the gap list is the help-grow list, in their words.

## 3. `ds set-role <token.path> <role>` — the owner-edit path (decision 2)
Validates the token exists (`BAD_TOKEN`) and the role is canonical (`BAD_ROLE`), sets `$extensions["design-os.role"]`, reseals (shared `reseal()` ceremony, new `set-role` changelog kind). How the owner corrects a mis-recognition — `ds set-role color.surface-overlay popover`.

## Live loop verified end-to-end (on a scratch copy of dana's real tokens)
```
import       → 100 roles recognized, 2 gaps: popover, input
context      → ## Roles (background → surface-content, …) + ## Missing roles (popover, input)
set-role surface-content foreground   (deliberately wrong)
context      → surface-content now under foreground — the edit STUCK (context reads baked)
set-role surface-content background   → reverted
```
Independently re-run and confirmed by the coordinator.

## A real live-data bug caught (Art III)
First run on dana's 414-token DS truncated the Missing-roles list out of the 4096-byte budget (Roles competed with the token table). Fixed by exempting Roles/Missing-roles from `--max-bytes`, same as the soul chain.

## Scope
`ds a11y` untouched (F11 works; generalizing it to consume the baked annotation is a noted follow-up). Two pre-existing import tests updated to assert the new `$extensions` annotation (strengthening, not weakening — baking is now unconditional). New files under Art IX cap (`ds-context-roles.ts` 69, `ds-set-role-impl.ts` 137).

Four gates green, `ui knowledge check` clean, 2136 tests. Report: `specs/011-role-recognition/reports/p2-wiring.md`

**Spec 011 complete**: design:os now understands a project's design system in its own words — the recognition join research proved nobody had built.