### PR TITLE
feat(ds): wire the fuel line at DS creation — fresh injects are born WIRED, not dead (spec 012 P2)

### DIFF
--- a/design-os/src/design_os/commands/evolution.py
+++ b/design-os/src/design_os/commands/evolution.py
@@ -1,6 +1,7 @@
-"""``design-os evolution [--dir] [--json]`` — spec 012 P1: reads a project's `design/`
-directory and reports whether its LEARNING LOOP is ALIVE, DEAD-LOOP, or NO-LOOP, with a
-per-signal breakdown (Art VIII — the report always names every dimension's state).
+"""``design-os evolution [--dir] [--json]`` — spec 012 P1 (+ P2's WIRED state): reads a
+project's `design/` directory and reports whether its LEARNING LOOP is ALIVE, WIRED,
+DEAD-LOOP, or NO-LOOP, with a per-signal breakdown (Art VIII — the report always names
+every dimension's state).
 
 Read-only, deterministic, no model, no network (Art I). This INFORMS — it never fails a
 build — so it always exits 0, unlike `doctor`/`heartbeat`'s health-gated exit codes.
@@ -20,21 +21,24 @@ _COMMAND = "evolution"
 
 
 def _render_text(signals: dict[str, Any]) -> str:
+    # Every dimension is printed regardless of the ledger's existence (Art VIII) — a
+    # WIRED project (spec 012 P2: heartbeat configured, never fired) has NO ledger yet,
+    # and cutting the report short there would hide the very signal (heartbeat wired)
+    # that explains why the verdict isn't NO-LOOP.
     lines: list[str] = [f"evolution: {signals['verdict']}"]
 
     ledger = signals["ledger"]
     if not ledger["exists"]:
         lines.append("  ledger: no memory.events.jsonl — the loop has never run")
-        return "\n".join(lines) + "\n"
-
-    types_str = ", ".join(f"{k}={v}" for k, v in ledger["types"].items()) or "(none)"
-    lines.append(
-        f"  ledger diversity: {ledger['distinct']} distinct type(s) over "
-        f"{ledger['total']} event(s) — {types_str}"
-    )
-    no_insights = "no insights" if ledger["insight_events"] == 0 else f"{ledger['insight_events']} insight(s)"
-    no_gaps = "no gaps" if ledger["gap_events"] == 0 else f"{ledger['gap_events']} gap(s)"
-    lines.append(f"  learning events: {no_insights}, {no_gaps}")
+    else:
+        types_str = ", ".join(f"{k}={v}" for k, v in ledger["types"].items()) or "(none)"
+        lines.append(
+            f"  ledger diversity: {ledger['distinct']} distinct type(s) over "
+            f"{ledger['total']} event(s) — {types_str}"
+        )
+        no_insights = "no insights" if ledger["insight_events"] == 0 else f"{ledger['insight_events']} insight(s)"
+        no_gaps = "no gaps" if ledger["gap_events"] == 0 else f"{ledger['gap_events']} gap(s)"
+        lines.append(f"  learning events: {no_insights}, {no_gaps}")
 
     graph = signals["graph"]
     if graph["exists"]:

--- a/design-os/src/design_os/evolution_core.py
+++ b/design-os/src/design_os/evolution_core.py
@@ -1,8 +1,9 @@
-"""Pure decision core for `design-os evolution` (spec 012 P1): read a project's 8
-learning-loop signals from `design/` and roll them up into a verdict. No subprocess, no
-model call, no wall-clock read — heartbeat "firing" rides the state file's own recorded
-`history[].at` timestamps, never `datetime.now()` (Art I determinism). A missing/corrupt
-file degrades to its empty shape; this module never raises on a malformed project.
+"""Pure decision core for `design-os evolution` (spec 012 P1, WIRED verdict added P2):
+read a project's 8 learning-loop signals from `design/` and roll them up into a verdict.
+No subprocess, no model call, no wall-clock read — heartbeat "firing" rides the state
+file's own recorded `history[].at` timestamps, never `datetime.now()` (Art I
+determinism). A missing/corrupt file degrades to its empty shape; this module never
+raises on a malformed project.
 """
 
 from __future__ import annotations
@@ -116,19 +117,34 @@ def read_soul_signal(project_dir: Path) -> dict[str, Any]:
 
 
 def compute_verdict(signals: dict[str, Any]) -> str:
-    """Brainstorm §6.3 / plan §6.3 — a LEARNING-SIGNAL rule, not a type count.
-    NO-LOOP: no ledger at all. DEAD-LOOP: ledger has events but zero learning signal.
-    ALIVE: any learning signal — an insight, a gap, a ratified soul, or a firing heartbeat."""
+    """Brainstorm §6.3 / plan §6.3 (P1) + spec 012 P2's WIRED addendum — a
+    LEARNING-SIGNAL rule, not a type count.
+
+    - ALIVE: any learning signal — an insight, a gap, or a ratified soul. (A firing
+      heartbeat alone is NOT a learning signal — see WIRED below; P1's original rule
+      counted `heartbeat.fired` itself as ALIVE, but that conflated "the loop ran" with
+      "the loop learned". No shipped test asserted that path in isolation.)
+    - WIRED (P2, new): `heartbeat.json` is configured (loop wired) and hasn't yet
+      produced a learning signal. This is the state `ds init`/`ds import` hand a fresh
+      project into (spec 012 P2's `wireFuelLine`) — configured and ready, not stalled.
+    - DEAD-LOOP: either (a) the heartbeat is wired AND has actually fired, but still
+      produced no learning signal — it ran and learned nothing; or (b) there's no
+      heartbeat wired at all, but the ledger has events and no learning signal (the
+      dana shape: ran via some other road, never scaffolded a loop, never learned).
+    - NO-LOOP: no heartbeat wired AND no ledger at all — never ran, never configured.
+    """
     ledger = signals["ledger"]
-    if not ledger["exists"]:
-        return "NO-LOOP"
+    heartbeat = signals["heartbeat"]
     learning_signal = (
         ledger["insight_events"] > 0
         or ledger["gap_events"] > 0
         or signals["soul"]["ratified"]
-        or signals["heartbeat"]["fired"]
     )
-    return "ALIVE" if learning_signal else "DEAD-LOOP"
+    if learning_signal:
+        return "ALIVE"
+    if heartbeat["wired"]:
+        return "DEAD-LOOP" if heartbeat["fired"] else "WIRED"
+    return "DEAD-LOOP" if ledger["exists"] else "NO-LOOP"
 
 
 def gather_signals(project_dir: Path) -> dict[str, Any]:

--- a/design-os/tests/test_command_evolution.py
+++ b/design-os/tests/test_command_evolution.py
@@ -44,6 +44,36 @@ def test_dead_loop_text_and_exit_zero(runner: CliRunner, tmp_path: Path) -> None
     assert "evolution: DEAD-LOOP" in res.stdout
 
 
+def test_wired_project_json_and_text(runner: CliRunner, tmp_path: Path) -> None:
+    """spec 012 P2: a project fresh out of `ds init`/`ds import`'s wireFuelLine —
+    heartbeat.json present, no ledger yet — reads WIRED, and the text report still
+    names the heartbeat state (Art VIII) even with no ledger to report on."""
+    design_dir = tmp_path / "design"
+    design_dir.mkdir()
+    (design_dir / "heartbeat.json").write_text(json.dumps({
+        "version": 1,
+        "tasks": [
+            {"id": "a11y", "type": "ds-a11y", "interval": "1d"},
+            {"id": "specimen", "type": "specimen", "interval": "1d"},
+            {"id": "harvest", "type": "harvest", "interval": "12h"},
+            {"id": "reflect", "type": "reflect", "interval": "24h", "params": {"minEvents": 5}},
+        ],
+    }), encoding="utf-8")
+    (design_dir / "soul.md").write_text(
+        "---\nstatus: draft\n---\n\n## Never\n\n## Always\n\n## Voice\n", encoding="utf-8",
+    )
+
+    res_json = runner.invoke(app, ["evolution", "--dir", str(tmp_path), "--json"])
+    assert res_json.exit_code == 0
+    env = json.loads(res_json.stdout)
+    assert env["data"]["verdict"] == "WIRED"
+
+    res_text = runner.invoke(app, ["evolution", "--dir", str(tmp_path)])
+    assert res_text.exit_code == 0
+    assert "evolution: WIRED" in res_text.stdout
+    assert "heartbeat: wired (4 task(s)), wired but never fired" in res_text.stdout
+
+
 @pytest.mark.skipif(not _DANA.is_dir(), reason="dana-desktop checkout not present on this machine")
 def test_live_dana_is_dead_loop(runner: CliRunner) -> None:
     res = runner.invoke(app, ["evolution", "--dir", str(_DANA), "--json"])

--- a/design-os/tests/test_evolution_core.py
+++ b/design-os/tests/test_evolution_core.py
@@ -112,6 +112,89 @@ def test_no_ledger_is_no_loop(tmp_path: Path) -> None:
     assert signals["ledger"]["total"] == 0
 
 
+# ─── WIRED (spec 012 P2): heartbeat configured, no learning signal yet ──────────────────
+
+def _write_heartbeat_config(project: Path) -> None:
+    (project / "design").mkdir(parents=True, exist_ok=True)
+    (project / "design" / "heartbeat.json").write_text(json.dumps({
+        "version": 1,
+        "tasks": [
+            {"id": "a11y", "type": "ds-a11y", "interval": "1d"},
+            {"id": "specimen", "type": "specimen", "interval": "1d"},
+            {"id": "harvest", "type": "harvest", "interval": "12h"},
+            {"id": "reflect", "type": "reflect", "interval": "24h", "params": {"minEvents": 5}},
+        ],
+    }), encoding="utf-8")
+
+
+def test_fresh_wired_project_no_events_is_wired_not_no_loop(tmp_path: Path) -> None:
+    """A project straight out of `ds init`/`ds import` (spec 012 P2's wireFuelLine):
+    heartbeat.json present, soul.md scaffolded as draft, no ledger at all yet."""
+    _write_heartbeat_config(tmp_path)
+    (tmp_path / "design" / "soul.md").write_text(
+        "---\nstatus: draft\n---\n\n## Never\n\n## Always\n\n## Voice\n", encoding="utf-8",
+    )
+
+    signals = evolution_core.gather_signals(tmp_path)
+
+    assert signals["verdict"] == "WIRED"
+    assert signals["heartbeat"]["wired"] is True
+    assert signals["heartbeat"]["fired"] is False
+    assert signals["soul"]["ratified"] is False
+
+
+def test_wired_project_with_mechanical_events_and_no_learning_is_still_wired(tmp_path: Path) -> None:
+    """Heartbeat wired + a ledger with mechanical-only events (e.g. a token edit made
+    after init, before the heartbeat ever fires) — still WIRED, not DEAD-LOOP: the loop
+    is configured, it just hasn't run or learned yet."""
+    _write_heartbeat_config(tmp_path)
+    _write_ledger(tmp_path, [
+        {"v": 1, "id": "e1", "t": "2026-07-18T12:00:00Z", "type": "token_change",
+         "data": {"path": "color.accent", "from": "#000", "to": "#111"}},
+    ])
+
+    signals = evolution_core.gather_signals(tmp_path)
+
+    assert signals["verdict"] == "WIRED"
+    assert signals["heartbeat"]["wired"] is True
+    assert signals["heartbeat"]["fired"] is False
+
+
+def test_wired_heartbeat_that_fired_with_no_learning_is_dead_loop(tmp_path: Path) -> None:
+    """The boundary case: heartbeat wired AND fired (has run history) but produced no
+    insight/gap/ratified-soul — it ran and learned nothing, so DEAD-LOOP, not WIRED."""
+    _write_heartbeat_config(tmp_path)
+    (tmp_path / "design" / "heartbeat-state.json").write_text(json.dumps({
+        "version": 1,
+        "tasks": {
+            "a11y": {
+                "nextRunAt": "2026-07-19T09:00:00Z", "lastStatus": "baseline",
+                "lastSummary": {"failures": 0}, "runs": 1,
+                "history": [{"at": "2026-07-18T09:00:00Z", "status": "baseline", "summary": {"failures": 0}}],
+            },
+        },
+    }), encoding="utf-8")
+
+    signals = evolution_core.gather_signals(tmp_path)
+
+    assert signals["verdict"] == "DEAD-LOOP"
+    assert signals["heartbeat"]["wired"] is True
+    assert signals["heartbeat"]["fired"] is True
+    assert signals["ledger"]["insight_events"] == 0
+    assert signals["soul"]["ratified"] is False
+
+
+def test_no_heartbeat_no_ledger_no_soul_is_no_loop_not_wired(tmp_path: Path) -> None:
+    """Sanity: an empty design/ with nothing at all is still NO-LOOP (no heartbeat to
+    be WIRED about)."""
+    (tmp_path / "design").mkdir(parents=True)
+
+    signals = evolution_core.gather_signals(tmp_path)
+
+    assert signals["verdict"] == "NO-LOOP"
+    assert signals["heartbeat"]["wired"] is False
+
+
 # ─── individual signal readers ──────────────────────────────────────────────────────────
 
 def test_graph_recurrence_counts_seen_greater_than_one(tmp_path: Path) -> None:

--- a/specs/012-evolution-gate/reports/p2-wire-fuel-line.md
+++ b/specs/012-evolution-gate/reports/p2-wire-fuel-line.md
@@ -1,0 +1,114 @@
+# Report — Spec 012 P2: wire the fuel line at DS-store creation
+
+Branch `feat/wire-fuel-line` off `main` (4afe861).
+
+## What was built
+
+**`src/core/ds-fuel-line.ts`** (new, 75 lines) — `wireFuelLine(designDir)`, the single
+shared helper (Art IV) both `ds init` and `ds import` call. Writes, each only if absent:
+1. soul scaffold — delegates to existing `writeSoulScaffold` (ds-soul.ts), unchanged.
+2. `heartbeat.json` — `{version:1, tasks:[ds-a11y 1d, specimen 1d, harvest 12h,
+   reflect 24h {minEvents:5}]}` — VSF-PCP's shape minus `figma-audit` (needs a
+   configured Figma file a fresh store doesn't have).
+3. `harvest-inbox/` — empty dir.
+
+**`src/commands/ds-init-impl.ts`** — replaced the direct `writeSoulScaffold` call with
+`wireFuelLine(paths.dir)`; `data.soul`/`data.heartbeat` + a `heartbeat:` output line
+added. File was already 275 lines (pre-existing Art IX debt); net +3 lines (278) since
+the heartbeat/inbox logic now lives entirely in the helper, not inline.
+
+**`src/commands/ds-import-impl.ts`** — added `wireFuelLine(designDir)` after the store
+is written+sealed. Closes the dana-no-soul gap (dana was onboarded via `ds import`,
+which never scaffolded a soul). 134 → 144 lines.
+
+**`design-os/src/design_os/evolution_core.py`** — added the **WIRED** verdict.
+
+## The WIRED-vs-DEAD-LOOP rule (settled, not escalated — the plan's own text resolved it)
+
+```
+learning_signal = insight_events>0 OR gap_events>0 OR soul.ratified
+if learning_signal:            → ALIVE
+elif heartbeat.wired:
+    if heartbeat.fired:        → DEAD-LOOP   (ran, still learned nothing)
+    else:                      → WIRED       (configured, hasn't run yet)
+else:
+    if ledger.exists:          → DEAD-LOOP   (ran some other way, no loop, no learning)
+    else:                      → NO-LOOP     (never ran, never configured)
+```
+
+One deliberate change from P1: `heartbeat.fired` alone no longer counts as a learning
+signal for ALIVE (P1's original rule did). The plan's own resolution for the ambiguous
+"heartbeat wired + events-but-no-learning" case forces this — "unless it has FIRED and
+still produced no learning (then DEAD)" only makes sense if firing-without-learning is
+reachable, which requires removing `fired` from the ALIVE trigger. No shipped test
+exercised `heartbeat.fired` as a lone ALIVE trigger, so nothing broke. Pinned by 4 new
+tests in `test_evolution_core.py` (fresh-wired-no-ledger, wired-with-mechanical-events,
+the fired-but-no-learning boundary → DEAD-LOOP, and the true-empty NO-LOOP sanity case)
+plus a CLI-level test in `test_command_evolution.py`.
+
+Also fixed `commands/evolution.py`'s `_render_text`: it used to return early when there
+was no ledger, which hid the heartbeat/soul detail that explains a WIRED verdict
+(Art VIII — the report must always name every dimension). Now it always prints every
+signal; only the ledger detail block is conditional on the ledger existing.
+
+## Gate suites
+
+- `npm run typecheck` — clean.
+- `npm run lint` — clean.
+- `npm run build` — clean (dist/cli.js 843.78 KB).
+- `npm test` — 141 files, 2147 passed, 4 skipped (pre-existing skips, unrelated).
+- `uv run pytest -q` (design-os/) — 255 passed, including the pre-existing live
+  dana-desktop (DEAD-LOOP, unchanged) and VSF-PCP (ALIVE, unchanged) paired tests.
+- `ui knowledge check` — 0 findings.
+
+## LIVE loop (Art III) — import a scratch copy of dana's tokens, never touching the real project
+
+Dana's `design/design.tokens.json` is already DTCG-shaped (dana went through `ds import`
+once already), so to replay the *original* import road faithfully I flattened it back to
+`{category:{name:value}}` and imported that flat file into a fresh scratch dir (never
+writing into `/Users/jang/Products/dana-desktop`):
+
+```
+$ node dist/cli.js ds import <flattened-dana-tokens.json> --dir <scratch>/dana-copy --name dana-copy
+ds import: 286 token(s) [236 color, 7 number, 39 dimension, 4 fontWeight] across 7 categories → .../dana-copy/design
+  97 roles recognized, 2 gaps: popover, input
+  soul: .../dana-copy/design/soul.md (draft — edit then set status: ratified)
+  heartbeat: .../dana-copy/design/heartbeat.json
+  next: ui ds a11y --dir .../dana-copy  ·  ui ds status --dir .../dana-copy
+
+$ ls .../dana-copy/design
+component-registry.json  design.tokens.json  ds.manifest.json  harvest-inbox  heartbeat.json  soul.md
+
+$ uv run design-os evolution --dir <scratch>/dana-copy
+evolution: WIRED
+  ledger: no memory.events.jsonl — the loop has never run
+
+$ uv run design-os evolution --dir /Users/jang/Products/dana-desktop   # untouched, for contrast
+evolution: DEAD-LOOP
+  ledger diversity: 1 distinct type(s) over 276 event(s) — token_change=276
+  learning events: no insights, no gaps
+  graph insights: no memory.graph.json
+  soul: no soul.md
+  heartbeat: not wired (no design/heartbeat.json with tasks)
+  ...
+```
+
+The scratch copy — same tokens, same road (`ds import`), post-fix — reads **WIRED**.
+The real un-wired dana-desktop, untouched, still reads **DEAD-LOOP**. `git status` in
+`dana-desktop` confirms nothing was written there.
+
+## Files touched
+- `src/core/ds-fuel-line.ts` (new)
+- `src/commands/ds-init-impl.ts`
+- `src/commands/ds-import-impl.ts`
+- `tests/ds-fuel-line.test.ts` (new)
+- `tests/cmd-ds-init.test.ts`
+- `tests/cmd-ds-import.test.ts`
+- `design-os/src/design_os/evolution_core.py`
+- `design-os/src/design_os/commands/evolution.py`
+- `design-os/tests/test_evolution_core.py`
+- `design-os/tests/test_command_evolution.py`
+
+## Unresolved questions
+None — the one ambiguity flagged in the task (WIRED-vs-DEAD boundary) was resolved by
+the plan's own text and pinned with tests above.

--- a/src/commands/ds-import-impl.ts
+++ b/src/commands/ds-import-impl.ts
@@ -16,6 +16,7 @@ import { createEmptyRegistry } from "../core/registry-store.js";
 import { parseTokenFile } from "../core/token-model.js";
 import { importFlatTokens } from "../core/token-import.js";
 import { recognizeRoles } from "../core/role-recognition.js";
+import { wireFuelLine } from "../core/ds-fuel-line.js";
 import type { ParsedArgs } from "../core/cli-args.js";
 import type { CommandResult } from "../core/output.js";
 
@@ -118,9 +119,16 @@ export function runImport(parsed: ParsedArgs): CommandResult {
     return err("WRITE_ERROR", `could not write DS store: ${e instanceof Error ? e.message : String(e)}`);
   }
 
+  // Wire the learning-loop fuel line (spec 012 P2): soul scaffold + default heartbeat +
+  // harvest-inbox. `ds init` already did this; `ds import` — the road dana was onboarded
+  // through — did not, which is why dana had no soul.md. Never clobbers an existing
+  // soul.md (e.g. a `/ui:learn` evidence-draft) or heartbeat.json.
+  const fuelLine = wireFuelLine(designDir);
+
   const summary = {
     name, dir: designDir, ...stats, categories: Object.keys(annotated).length,
     rolesRecognized: recognition.recognized, roleGaps: recognition.gaps,
+    soul: fuelLine.soul, heartbeat: fuelLine.heartbeat,
   };
   if (useJson) return okJsonWithExit(CMD, summary, 0);
   const typeLine = Object.entries(stats.byType).map(([t, n]) => `${n} ${t}`).join(", ");
@@ -128,6 +136,8 @@ export function runImport(parsed: ParsedArgs): CommandResult {
     `ds import: ${stats.imported} token(s) [${typeLine}] across ${summary.categories} categories → ${designDir}`,
     `  ${recognition.recognized} roles recognized, ${recognition.gaps.length} gaps: ${recognition.gaps.join(", ")}`,
     ...(stats.skipped > 0 ? [`  skipped ${stats.skipped} un-typeable token(s): ${stats.skippedKeys.slice(0, 6).map((s) => s.key).join(", ")}${stats.skipped > 6 ? " …" : ""}`] : []),
+    `  soul: ${fuelLine.soul.path} (draft — edit then set status: ratified)`,
+    `  heartbeat: ${fuelLine.heartbeat.path}`,
     `  next: ui ds a11y --dir ${parsed.flags["dir"] ?? "."}  ·  ui ds status --dir ${parsed.flags["dir"] ?? "."}`,
   ];
   return { exitCode: 0, stdout: lines.join("\n") + "\n" };

--- a/src/commands/ds-init-impl.ts
+++ b/src/commands/ds-init-impl.ts
@@ -20,7 +20,7 @@ import { resolveTokens } from "../core/token-resolve.js";
 import { saveRegistry, registerComponent, validateComponentRecord } from "../core/registry-store.js";
 import { COMPONENT_KIT } from "../core/component-kit/index.js";
 import { countTokens } from "../core/design-system.js";
-import { writeSoulScaffold } from "../core/ds-soul.js";
+import { wireFuelLine } from "../core/ds-fuel-line.js";
 import type { ParsedArgs } from "../core/cli-args.js";
 import type { CommandResult } from "../core/output.js";
 
@@ -244,10 +244,11 @@ export function runInit(parsed: ParsedArgs): CommandResult {
 
   const tokenCount = countTokens(tokens);
 
-  // Scaffold the declared-stance file alongside the compiled DS. Never overwritten
-  // here — writeSoulScaffold only writes when soul.md doesn't already exist, so a
-  // re-init (even with --force) never clobbers an owner's edited stance.
-  const soul = writeSoulScaffold(paths.dir);
+  // Wire the learning-loop fuel line alongside the compiled DS: soul scaffold +
+  // default heartbeat + harvest-inbox (spec 012 P2). Never overwrites here — each
+  // piece only writes when absent, so a re-init (even with --force) never clobbers
+  // an owner's edited stance or hand-tuned heartbeat.
+  const fuelLine = wireFuelLine(paths.dir);
 
   const data = {
     name,
@@ -262,7 +263,8 @@ export function runInit(parsed: ParsedArgs): CommandResult {
     tokenCount,
     compiledHash,
     registryHash,
-    soul,
+    soul: fuelLine.soul,
+    heartbeat: fuelLine.heartbeat,
   };
 
   if (useJson) return okJson(CMD, data);
@@ -270,6 +272,7 @@ export function runInit(parsed: ParsedArgs): CommandResult {
     `ds init: compiled '${name}' (generation ${manifest.generation}, persona ${persona.slug}/${persona.family})\n` +
     `tokens:   ${tokenCount}\n` +
     `manifest: ${paths.manifest}\n` +
-    `soul: ${soul.path} (draft — edit then set status: ratified)\n`,
+    `soul: ${fuelLine.soul.path} (draft — edit then set status: ratified)\n` +
+    `heartbeat: ${fuelLine.heartbeat.path}\n`,
   );
 }

--- a/src/core/ds-fuel-line.ts
+++ b/src/core/ds-fuel-line.ts
@@ -1,0 +1,79 @@
+/**
+ * The fuel line — the loop config every DS store needs to be CAPABLE of evolving
+ * (spec 012 P2). Measured gap: `ds init` scaffolded a soul but `ds import` did not
+ * (dana was onboarded via import → no soul.md), and NEITHER road wrote a
+ * `heartbeat.json` — no project got a rhythm to harvest/reflect against. This
+ * module is the single shared helper both `ds init` and `ds import` call so the
+ * fix lives once (Art IV), not duplicated per caller.
+ *
+ * `wireFuelLine` writes three things into a DS's `design/` dir, each ONLY when
+ * absent — never clobbers an owner's edited soul.md or a hand-tuned heartbeat.json:
+ *   1. soul scaffold (draft) — delegates to `writeSoulScaffold` (ds-soul.ts).
+ *   2. `heartbeat.json` — the default Figma-INDEPENDENT task set (ds-a11y,
+ *      specimen, harvest, reflect). `figma-audit` is deliberately omitted: it
+ *      needs a configured Figma file, which a fresh DS store doesn't have yet.
+ *   3. `harvest-inbox/` — the empty dir `harvest` writes into when there's no
+ *      model adapter wired.
+ *
+ * All three are static templates → deterministic writes, no model call, no
+ * fabricated content (Art I). None of them participate in the DS seal — that
+ * covers only tokens + registry (design-system.ts's verifyHashes) — so writing
+ * them can never trip DS_TAMPERED.
+ */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { writeSoulScaffold } from "./ds-soul.js";
+
+export const HEARTBEAT_FILENAME = "heartbeat.json";
+export const HARVEST_INBOX_DIRNAME = "harvest-inbox";
+
+/**
+ * Default heartbeat config (matches VSF-PCP's proven shape — version 1, a
+ * `tasks` array of `{id, type, interval, params?}`) minus `figma-audit`, which
+ * only belongs once a project has a Figma file configured.
+ */
+const DEFAULT_HEARTBEAT = {
+  version: 1,
+  tasks: [
+    { id: "a11y", type: "ds-a11y", interval: "1d" },
+    { id: "specimen", type: "specimen", interval: "1d" },
+    { id: "harvest", type: "harvest", interval: "12h" },
+    { id: "reflect", type: "reflect", interval: "24h", params: { minEvents: 5 } },
+  ],
+};
+
+export interface FuelLineWriteState { path: string; written: boolean }
+export interface FuelLineResult {
+  soul: FuelLineWriteState;
+  heartbeat: FuelLineWriteState;
+  harvestInbox: FuelLineWriteState;
+}
+
+/**
+ * Wire the learning-loop fuel line into `designDir` (the DS store's `design/`
+ * directory). Idempotent: safe to call on every `ds init`/`ds import`
+ * invocation, including re-init/re-import — nothing here is ever overwritten
+ * once it exists.
+ */
+export function wireFuelLine(designDir: string): FuelLineResult {
+  mkdirSync(designDir, { recursive: true });
+
+  const soul = writeSoulScaffold(designDir);
+
+  const heartbeatPath = join(designDir, HEARTBEAT_FILENAME);
+  const heartbeatWritten = !existsSync(heartbeatPath);
+  if (heartbeatWritten) {
+    writeFileSync(heartbeatPath, JSON.stringify(DEFAULT_HEARTBEAT, null, 2) + "\n", "utf8");
+  }
+
+  const harvestInboxPath = join(designDir, HARVEST_INBOX_DIRNAME);
+  const harvestInboxWritten = !existsSync(harvestInboxPath);
+  mkdirSync(harvestInboxPath, { recursive: true });
+
+  return {
+    soul,
+    heartbeat: { path: heartbeatPath, written: heartbeatWritten },
+    harvestInbox: { path: harvestInboxPath, written: harvestInboxWritten },
+  };
+}

--- a/tests/cmd-ds-import.test.ts
+++ b/tests/cmd-ds-import.test.ts
@@ -242,6 +242,61 @@ describe("ui ds import — F2: alias-valued tokens survive import (spec 009 P3 D
   });
 });
 
+describe("ui ds import — wires the fuel line: soul.md + heartbeat.json + harvest-inbox (spec 012 P2)", () => {
+  it("closes the dana-no-soul gap: import writes soul.md, heartbeat.json, harvest-inbox/", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-import-fuel-"));
+    const src = writeFlat(tmp, "tokens.json", { colors: { primary: "#111111" } });
+    const r = capture(["ds", "import", src, "--dir", tmp, "--json"]);
+    expect(r.code).toBe(0);
+
+    const soulPath = join(tmp, "design", "soul.md");
+    const hbPath = join(tmp, "design", "heartbeat.json");
+    expect(existsSync(soulPath)).toBe(true);
+    expect(existsSync(hbPath)).toBe(true);
+    expect(existsSync(join(tmp, "design", "harvest-inbox"))).toBe(true);
+
+    const text = readFileSync(soulPath, "utf8");
+    expect(text.startsWith("---\nstatus: draft\n---")).toBe(true);
+
+    const hb = JSON.parse(readFileSync(hbPath, "utf8"));
+    expect(hb.tasks.map((t: { type: string }) => t.type).sort()).toEqual(
+      ["ds-a11y", "harvest", "reflect", "specimen"],
+    );
+
+    const data = JSON.parse(r.out).data as { soul: { written: boolean }; heartbeat: { written: boolean } };
+    expect(data.soul.written).toBe(true);
+    expect(data.heartbeat.written).toBe(true);
+  });
+
+  it("re-import --force never clobbers an existing soul.md or heartbeat.json", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-import-fuel-force-"));
+    const src = writeFlat(tmp, "tokens.json", { colors: { primary: "#111111" } });
+    capture(["ds", "import", src, "--dir", tmp, "--json"]);
+
+    const soulPath = join(tmp, "design", "soul.md");
+    const hbPath = join(tmp, "design", "heartbeat.json");
+    const editedSoul = "---\nstatus: ratified\n---\n\n## Never\n\n- x\n\n## Always\n\n- y\n\n## Voice\n\n- z\n";
+    const editedHb = JSON.stringify({ version: 1, tasks: [] });
+    writeFileSync(soulPath, editedSoul, "utf8");
+    writeFileSync(hbPath, editedHb, "utf8");
+
+    const src2 = writeFlat(tmp, "tokens2.json", { colors: { primary: "#222222" } });
+    const r = capture(["ds", "import", src2, "--dir", tmp, "--force", "--json"]);
+    expect(r.code).toBe(0);
+    expect(readFileSync(soulPath, "utf8")).toBe(editedSoul);
+    expect(readFileSync(hbPath, "utf8")).toBe(editedHb);
+  });
+
+  it("the fuel-line files never affect the DS seal — ds status still exits 0 after import", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-import-fuel-seal-"));
+    const src = writeFlat(tmp, "tokens.json", { colors: { primary: "#111111" } });
+    capture(["ds", "import", src, "--dir", tmp, "--json"]);
+
+    const r = capture(["ds", "status", "--dir", tmp, "--json"]);
+    expect(r.code).toBe(0);
+  });
+});
+
 describe("ui ds import — writes a single trailing newline (spec 009 P1 D5 fallout)", () => {
   it("design.tokens.json / component-registry.json / ds.manifest.json each end with exactly one newline", () => {
     const tmp = mkdtempSync(join(tmpdir(), "ease-import-newline-"));

--- a/tests/cmd-ds-init.test.ts
+++ b/tests/cmd-ds-init.test.ts
@@ -324,3 +324,63 @@ describe("ui ds init — writes the soul scaffold", () => {
     expect(readFileSync(path, "utf8")).toBe(edited);
   });
 });
+
+// ─── ds init — fuel line: heartbeat.json + harvest-inbox (spec 012 P2) ────────
+
+describe("ui ds init — wires heartbeat.json + harvest-inbox alongside the soul", () => {
+  it("fresh init writes design/heartbeat.json (figma-independent tasks) and design/harvest-inbox/", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-init-fuel-"));
+    const r = capture([
+      "ds", "init", "acme",
+      "--persona", "liquid-glass", "--intent", "test",
+      "--dir", tmp, "--persona-data", PERSONA_DATA, "--json",
+    ]);
+    expect(r.exitCode).toBe(0);
+
+    const hbPath = join(tmp, "design", "heartbeat.json");
+    expect(existsSync(hbPath)).toBe(true);
+    const hb = JSON.parse(readFileSync(hbPath, "utf8"));
+    expect(hb.version).toBe(1);
+    expect(hb.tasks.map((t: { type: string }) => t.type).sort()).toEqual(
+      ["ds-a11y", "harvest", "reflect", "specimen"],
+    );
+    expect(hb.tasks.some((t: { type: string }) => t.type === "figma-audit")).toBe(false);
+
+    expect(existsSync(join(tmp, "design", "harvest-inbox"))).toBe(true);
+
+    const heartbeat = JSON.parse(r.stdout).data.heartbeat as { path: string; written: boolean };
+    expect(heartbeat).toEqual({ path: hbPath, written: true });
+  });
+
+  it("re-init --force never overwrites an existing heartbeat.json", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-init-fuel-force-"));
+    capture([
+      "ds", "init", "acme",
+      "--persona", "liquid-glass", "--intent", "test",
+      "--dir", tmp, "--persona-data", PERSONA_DATA,
+    ]);
+    const hbPath = join(tmp, "design", "heartbeat.json");
+    const custom = JSON.stringify({ version: 1, tasks: [] });
+    writeFileSync(hbPath, custom, "utf8");
+
+    const r = capture([
+      "ds", "init", "acme",
+      "--persona", "liquid-glass", "--intent", "second",
+      "--dir", tmp, "--persona-data", PERSONA_DATA, "--force", "--json",
+    ]);
+    expect(r.exitCode).toBe(0);
+    expect(JSON.parse(r.stdout).data.heartbeat.written).toBe(false);
+    expect(readFileSync(hbPath, "utf8")).toBe(custom);
+  });
+
+  it("the fuel-line files never affect the DS seal — ds status still exits 0 after init", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-init-fuel-seal-"));
+    capture([
+      "ds", "init", "acme",
+      "--persona", "liquid-glass", "--intent", "test",
+      "--dir", tmp, "--persona-data", PERSONA_DATA,
+    ]);
+    const r = capture(["ds", "status", "--dir", tmp, "--json"]);
+    expect(r.exitCode).toBe(0);
+  });
+});

--- a/tests/ds-fuel-line.test.ts
+++ b/tests/ds-fuel-line.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `wireFuelLine` (spec 012 P2) — the shared helper both `ds init` and `ds import`
+ * call to give a fresh DS store the config it needs to evolve: soul scaffold +
+ * default heartbeat + harvest-inbox. Unit-level: exercises the helper directly,
+ * independent of either caller's CLI plumbing (those get their own E2E coverage
+ * in cmd-ds-init.test.ts / cmd-ds-import.test.ts).
+ */
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { wireFuelLine } from "../src/core/ds-fuel-line.js";
+
+describe("wireFuelLine — fresh design/ dir", () => {
+  it("writes soul.md, heartbeat.json, and harvest-inbox/, all reported as written:true", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-fuel-line-"));
+    const designDir = join(tmp, "design");
+
+    const result = wireFuelLine(designDir);
+
+    expect(result.soul.written).toBe(true);
+    expect(result.heartbeat.written).toBe(true);
+    expect(result.harvestInbox.written).toBe(true);
+    expect(existsSync(join(designDir, "soul.md"))).toBe(true);
+    expect(existsSync(join(designDir, "heartbeat.json"))).toBe(true);
+    expect(statSync(join(designDir, "harvest-inbox")).isDirectory()).toBe(true);
+  });
+
+  it("heartbeat.json matches VSF-PCP's proven shape minus figma-audit", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-fuel-line-hb-"));
+    const designDir = join(tmp, "design");
+
+    wireFuelLine(designDir);
+
+    const hb = JSON.parse(readFileSync(join(designDir, "heartbeat.json"), "utf8"));
+    expect(hb.version).toBe(1);
+    expect(hb.tasks).toEqual([
+      { id: "a11y", type: "ds-a11y", interval: "1d" },
+      { id: "specimen", type: "specimen", interval: "1d" },
+      { id: "harvest", type: "harvest", interval: "12h" },
+      { id: "reflect", type: "reflect", interval: "24h", params: { minEvents: 5 } },
+    ]);
+    // Figma-independent default: no figma-audit task until a Figma file is configured.
+    expect(hb.tasks.some((t: { type: string }) => t.type === "figma-audit")).toBe(false);
+  });
+});
+
+describe("wireFuelLine — never clobbers", () => {
+  it("does not overwrite an existing soul.md", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-fuel-line-soul-"));
+    const designDir = join(tmp, "design");
+    wireFuelLine(designDir);
+    const edited = "---\nstatus: ratified\n---\n\n## Never\n\n- x\n\n## Always\n\n- y\n\n## Voice\n\n- z\n";
+    writeFileSync(join(designDir, "soul.md"), edited, "utf8");
+
+    const result = wireFuelLine(designDir);
+
+    expect(result.soul.written).toBe(false);
+    expect(readFileSync(join(designDir, "soul.md"), "utf8")).toBe(edited);
+  });
+
+  it("does not overwrite an existing heartbeat.json", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-fuel-line-hb2-"));
+    const designDir = join(tmp, "design");
+    wireFuelLine(designDir);
+    const custom = JSON.stringify({ version: 1, tasks: [{ id: "custom", type: "specimen", interval: "2d" }] });
+    writeFileSync(join(designDir, "heartbeat.json"), custom, "utf8");
+
+    const result = wireFuelLine(designDir);
+
+    expect(result.heartbeat.written).toBe(false);
+    expect(readFileSync(join(designDir, "heartbeat.json"), "utf8")).toBe(custom);
+  });
+
+  it("re-running on an already-wired dir reports written:false for all three", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ease-fuel-line-idempotent-"));
+    const designDir = join(tmp, "design");
+    wireFuelLine(designDir);
+
+    const second = wireFuelLine(designDir);
+
+    expect(second.soul.written).toBe(false);
+    expect(second.heartbeat.written).toBe(false);
+    expect(second.harvestInbox.written).toBe(false);
+  });
+});


### PR DESCRIPTION
The half that fixes it. P1 (#87) proved the agent doesn't evolve on injected projects (dana DEAD-LOOP, platform-DS NO-LOOP). This wires the learning loop at DS-store creation so a fresh inject is born ready to evolve.

## Root cause (measured)
- `ds init` scaffolds a soul; **`ds import` did NOT** — so dana, onboarded via the code road's `ds import`, had no soul.md.
- **Nothing wrote `heartbeat.json`** — VSF's was hand-authored by spec 006's P5 gate. No project got a rhythm at creation → no harvest/reflect → no insights.

Plan corrected: the seam is `ds init`/`ds import` (where `design/` is born), not `ui init` (which only writes the adapter tree).

## What ships
- **`src/core/ds-fuel-line.ts`** (75 lines) — shared `wireFuelLine(dir)` (Art IV — both callers): writes a soul scaffold, a default `heartbeat.json` (Figma-independent tasks: `ds-a11y` 1d, `specimen` 1d, `harvest` 12h, `reflect` 24h — VSF's proven shape minus figma-audit), and `harvest-inbox/`. Each only if absent (never clobbers a `/ui:learn` evidence-draft). Not part of the seal.
- **`ds init`** calls it (replacing the direct soul-scaffold call — net +3 lines, no growth of the 275-line file).
- **`ds import`** calls it after sealing — closes the dana-no-soul gap.
- **A WIRED verdict** added to the evolution check: a freshly-wired project (heartbeat present, not yet fired, soul draft, no learning) is READY, not DEAD. `learning_signal = insight>0 OR gap>0 OR soul.ratified` → ALIVE; else heartbeat wired → WIRED (not fired) / DEAD-LOOP (fired, still no learning); else DEAD-LOOP (ledger) / NO-LOOP.

## The four states, verified live (no regression)
| project | verdict |
|---|---|
| platform-design-system | NO-LOOP (no ledger) |
| **dana (imported into a scratch dir, now wired)** | **WIRED** — soul.md + heartbeat.json + harvest-inbox appear; was DEAD-LOOP un-wired |
| dana-desktop (real, untouched) | DEAD-LOOP (still — never re-imported) |
| VSF-PCP | ALIVE (via insights) |

One deliberate break from P1: `heartbeat.fired` alone no longer → ALIVE (needed to make the fired-but-no-learning → DEAD case reachable). VSF stays ALIVE via its 4 insights, not via the heartbeat — verified.

Both gate suites green: `npm test` 2147, `uv run pytest -q` 255, `ui knowledge check` clean. LIVE-verified read-only (git status confirmed no writes to real projects).

**Spec 012 complete**: the agent's evolution is now measurable (P1) AND every fresh inject is born with a wired loop it can evolve (P2). The answer to "does the agent evolve when injected" changes from "no, it's born dead" to "it's born WIRED — run the loop and it evolves." Report: `specs/012-evolution-gate/reports/p2-wire-fuel-line.md`