### PR TITLE
fix(ds-a11y): a zero-pair audit is a false green, not a clean pass (Art VIII)

### DIFF
--- a/src/core/ds-a11y.ts
+++ b/src/core/ds-a11y.ts
@@ -47,6 +47,13 @@ export interface A11yTokenResult {
   failures: ContrastPair[];
   /** Tokens that look like text but carry no hex value → couldn't be checked. */
   unresolved: string[];
+  /**
+   * False means checkedPairs === 0 AND checkedStatePairs === 0 — NOTHING was measured (no
+   * recognized roles, no {role}/{role}-foreground pairs, no --pairs). A zero-failure result with
+   * measured=false is NOT a clean pass — it is an unmeasurable store (false-green risk). Callers
+   * MUST branch on this before treating `failures.length === 0` as "passed".
+   */
+  measured: boolean;
 }
 
 /** Interaction-state surface suffixes audited against the SAME {role}-foreground. */
@@ -93,7 +100,7 @@ export function checkTokenContrast(
     }
     pairs.sort((a, b) => a.ratio - b.ratio || a.text.localeCompare(b.text));
     const failures = pairs.filter((p) => !p.passesNormalText);
-    return { checkedPairs: pairs.length, checkedStatePairs: 0, inferred: false, mode: "explicit", pairs, statePairs: [], failures, unresolved: unresolved.sort() };
+    return { checkedPairs: pairs.length, checkedStatePairs: 0, inferred: false, mode: "explicit", pairs, statePairs: [], failures, unresolved: unresolved.sort(), measured: pairs.length > 0 };
   }
 
   // Paired path (shadcn standard): check {role}-foreground on its {role} surface — the intended
@@ -125,7 +132,7 @@ export function checkTokenContrast(
     statePairs.sort((a, b) => a.ratio - b.ratio || a.text.localeCompare(b.text) || a.surface.localeCompare(b.surface));
     // Base failures first, then state failures — both gate (exit 1) via runA11y.
     const failures = [...pairs, ...statePairs].filter((p) => !p.passesNormalText);
-    return { checkedPairs: pairs.length, checkedStatePairs: statePairs.length, inferred: false, mode: "paired", pairs, statePairs, failures, unresolved: unresolved.sort() };
+    return { checkedPairs: pairs.length, checkedStatePairs: statePairs.length, inferred: false, mode: "paired", pairs, statePairs, failures, unresolved: unresolved.sort(), measured: pairs.length > 0 || statePairs.length > 0 };
   }
 
   // Legacy inference fallback (no paired tokens): every text-role token × every surface-role token.
@@ -147,13 +154,19 @@ export function checkTokenContrast(
   }
   pairs.sort((a, b) => a.ratio - b.ratio || a.text.localeCompare(b.text) || a.surface.localeCompare(b.surface));
   const failures = pairs.filter((p) => !p.passesNormalText);
-  return { checkedPairs: pairs.length, checkedStatePairs: 0, inferred: true, mode: "inferred", pairs, statePairs: [], failures, unresolved: [...new Set(unresolved)].sort() };
+  return { checkedPairs: pairs.length, checkedStatePairs: 0, inferred: true, mode: "inferred", pairs, statePairs: [], failures, unresolved: [...new Set(unresolved)].sort(), measured: pairs.length > 0 };
 }
 
 export function renderA11yReport(r: A11yTokenResult): string {
   const lines: string[] = [];
-  if (r.checkedPairs === 0) {
-    lines.push("ds a11y: no text×surface token pairs to check (name roles: text*/fg*/… vs bg*/surface*/…, or use --pairs).");
+  // measured=false is NOT a clean pass — it is an unmeasurable store (Art VIII honesty floor:
+  // zero findings on zero pairs must never read identical to a genuinely-clean store). Never
+  // print a success line here.
+  if (!r.measured) {
+    lines.push(
+      "⚠ a11y: 0 contrast pairs measurable — this store has no recognized roles and no {role}/{role}-foreground pairs; nothing was checked (false-green risk).",
+      '  Run role recognition (ui ds import bakes roles) or pass --pairs "text:surface,...".',
+    );
     return lines.join("\n") + "\n";
   }
   const modeNote = r.mode === "paired" ? " ({role}/{role}-foreground pairs)" : r.mode === "inferred" ? " (roles inferred from token names — cartesian; prefer -foreground pairing or --pairs)" : "";

--- a/tests/ds-a11y.test.ts
+++ b/tests/ds-a11y.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { run } from "../src/cli.js";
-import { checkTokenContrast, parsePairs } from "../src/core/ds-a11y.js";
+import { checkTokenContrast, parsePairs, renderA11yReport } from "../src/core/ds-a11y.js";
 import type { ResolvedToken } from "../src/core/token-model.js";
 
 const tok = (path: string, value: string): ResolvedToken => ({ path, type: "color", value });
@@ -79,6 +79,34 @@ describe("ds-a11y — checkTokenContrast", () => {
     expect(r.inferred).toBe(true);
     expect(r.unresolved).toContain("color.text-ghost");
   });
+
+  // ── false-green fix: measured=false must never read as a clean pass ────────
+  it("(measured=false) colors with no recognized roles and no --pairs measure NOTHING — not a clean pass", () => {
+    const opaque: ResolvedToken[] = [
+      tok("brand.one", "#123456"),
+      tok("brand.two", "#abcdef"),
+    ];
+    const r = checkTokenContrast(opaque);
+    expect(r.measured).toBe(false);
+    expect(r.checkedPairs).toBe(0);
+    expect(r.checkedStatePairs).toBe(0);
+    const out = renderA11yReport(r);
+    expect(out).toContain("false-green risk");
+    expect(out.toLowerCase()).not.toContain("all checked pairs pass aa");
+  });
+
+  it("(measured=true) a store WITH {role}/{role}-foreground pairs measures normally — unchanged behavior", () => {
+    const paired: ResolvedToken[] = [
+      tok("color.background", "#ffffff"),
+      tok("color.foreground", "#111111"),
+    ];
+    const r = checkTokenContrast(paired);
+    expect(r.measured).toBe(true);
+    expect(r.checkedPairs).toBeGreaterThan(0);
+    const out = renderA11yReport(r);
+    expect(out).not.toContain("false-green risk");
+    expect(out).toContain("All checked pairs pass AA");
+  });
 });
 
 // ─── command ─────────────────────────────────────────────────────────────────
@@ -132,5 +160,32 @@ describe("ui ds a11y", () => {
   it("bad --pairs → BAD_ARG; unknown flag → UNKNOWN_FLAG", () => {
     expect(JSON.parse(capture(["ds", "a11y", "--dir", dir, "--pairs", "oops", "--json"]).out).error.code).toBe("BAD_ARG");
     expect(JSON.parse(capture(["ds", "a11y", "--dir", dir, "--nope", "--json"]).out).error.code).toBe("UNKNOWN_FLAG");
+  });
+
+  // ── false-green fix: an unmeasurable store must warn loudly, never pass silently ───────────
+  it("(measured=false) a store with no recognized roles exits 0 but warns — never a clean pass", () => {
+    const unmeasurable = mkdtempSync(join(tmpdir(), "ease-a11y-unmeasurable-"));
+    mkdirSync(join(unmeasurable, "design"), { recursive: true });
+    writeFileSync(join(unmeasurable, "design", "design.tokens.json"), JSON.stringify({
+      brand: { one: { $value: "#123456", $type: "color" }, two: { $value: "#abcdef", $type: "color" } },
+    }), "utf8");
+    const r = capture(["ds", "a11y", "--dir", unmeasurable]);
+    expect(r.code).toBe(0); // a11y exit-1 contract is reserved for actual contrast failures
+    expect(r.out).toContain("false-green risk");
+    expect(r.out.toLowerCase()).not.toContain("all checked pairs pass aa");
+  });
+
+  it("(measured=false) --json carries measured:false and checkedPairs:0", () => {
+    const unmeasurable = mkdtempSync(join(tmpdir(), "ease-a11y-unmeasurable-json-"));
+    mkdirSync(join(unmeasurable, "design"), { recursive: true });
+    writeFileSync(join(unmeasurable, "design", "design.tokens.json"), JSON.stringify({
+      brand: { one: { $value: "#123456", $type: "color" }, two: { $value: "#abcdef", $type: "color" } },
+    }), "utf8");
+    const r = capture(["ds", "a11y", "--dir", unmeasurable, "--json"]);
+    expect(r.code).toBe(0);
+    const d = JSON.parse(r.out).data as { measured: boolean; checkedPairs: number; checkedStatePairs: number };
+    expect(d.measured).toBe(false);
+    expect(d.checkedPairs).toBe(0);
+    expect(d.checkedStatePairs).toBe(0);
   });
 });


### PR DESCRIPTION
## What

`ui ds a11y` (token-pair contrast audit) infers text:surface pairs from token roles/names. When a store has **no recognized roles**, no `{role}/{role}-foreground` pairs, and no `--pairs` flag, it infers **zero pairs** → zero failures → exit 0 → reads identical to a genuinely-clean store, though it **measured nothing**. That is a false green.

**Surfaced by design:os's own learning loop.** When the flagship `platform-design-system` (654 tokens, 0 recognized roles) was harvested, one distilled insight was: *"Role recognition must run at onboarding, otherwise role-driven checks silently pass with nothing to measure — a zero-finding audit on an unannotated store is a false green, not a clean pass."* This fixes exactly that. (Art II: a standard needs an honest linter; Art VIII: honesty floors.)

## The fix

- `A11yTokenResult` gains `measured: boolean` — `false` iff `checkedPairs === 0 && checkedStatePairs === 0`. Set at all three inference return sites (explicit / paired / inferred).
- `renderA11yReport`: the zero-pair branch now emits a loud `⚠ a11y: 0 contrast pairs measurable — … (false-green risk). Run role recognition or pass --pairs …` and **never prints a success line**.
- The `--json` envelope carries `measured` automatically (whole result is serialized).
- **Unchanged**: exit code (0 unless a real contrast failure — a11y stays a health report), and all measured-pair pass/fail behavior.

## Tests

Extended `tests/ds-a11y.test.ts` (no new file): `measured=false` core + command (text warning, `--json` carries `measured:false`/`checkedPairs:0`), and `measured=true` unchanged-behavior. 

## Verify (re-run in the worktree by the auditor, not just the author)

`npm run build` ✓ · `npx tsc --noEmit` ✓ · `npm test` → **2151 passed | 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)