### PR TITLE
feat(design-os): conductor auto-uses the init-wired model adapter (spec 013 P2+P3)

### DIFF
--- a/design-os/src/design_os/commands/harvest.py
+++ b/design-os/src/design_os/commands/harvest.py
@@ -114,7 +114,7 @@ def harvest(
         _skip(dir_, json_, reason="emit-packet", deferred=deferred, reports_read=len(to_harvest), packet=path)
         return
 
-    cmd = resolve_model_cmd()
+    cmd = resolve_model_cmd(dir_)
     if cmd is None:
         path = _write_inbox(dir_, packet, to_harvest)
         _skip(dir_, json_, reason="no-model-adapter", deferred=deferred, reports_read=len(to_harvest), packet=path)

--- a/design-os/src/design_os/commands/heartbeat_runners_learning.py
+++ b/design-os/src/design_os/commands/heartbeat_runners_learning.py
@@ -70,7 +70,7 @@ def _run_harvest(project_dir: Path, params: dict[str, Any]) -> dict[str, Any]:
         return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-new-reports"}
 
     packet = harvest_core.build_packet(_PROMPT_PATH.read_text(encoding="utf-8"), to_harvest)
-    cmd = resolve_model_cmd()
+    cmd = resolve_model_cmd(project_dir)
     if cmd is None:
         _write_inbox(project_dir, packet, to_harvest)
         return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-model-adapter"}
@@ -176,7 +176,7 @@ def _run_reflect(project_dir: Path, params: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(packet, dict) or "instruction" not in packet:
         return {"status": "error", "summary": {"failures": 1}, "detail": "reflect: `recall reflect` printed no valid packet"}
     prompt = reflect_core.build_reflect_prompt(packet)
-    cmd = resolve_model_cmd()
+    cmd = resolve_model_cmd(project_dir)
     if cmd is None:
         return {"status": "skipped", "summary": {}, "detail": "", "skipReason": "no-model-adapter"}
 

--- a/design-os/src/design_os/harvest_model.py
+++ b/design-os/src/design_os/harvest_model.py
@@ -14,9 +14,11 @@ librarian veto-chain + human merge into `knowledge/`, not this adapter or the ga
 
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import subprocess
+from pathlib import Path
 
 
 class ModelUnavailable(Exception):
@@ -24,12 +26,58 @@ class ModelUnavailable(Exception):
     never crashes the heartbeat."""
 
 
-def resolve_model_cmd() -> list[str] | None:
-    """`DESIGN_OS_MODEL_CMD` split with `shlex`; `None` when unset or blank."""
-    raw = os.environ.get("DESIGN_OS_MODEL_CMD")
-    if not raw or not raw.strip():
+# Per-runtime manifests written by `ui init` (spec 013), each may carry a
+# `modelAdapter.wrapper` — the executable that normalizes that host's model to our
+# stdin contract. `(manifest rel path, env markers that mean THIS host is running)`.
+# Order is the stable precedence when several manifests exist (a project init'd `--all`);
+# the host actually running wins over declared order via its env markers.
+_RUNTIME_MANIFESTS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (".claude/ease-design.json", ("CLAUDECODE", "CLAUDE_CODE", "CLAUDE_")),
+    ("AGENTS.ease-design.json", ("CODEX_", "OPENAI_CODEX")),
+    (".agent/ease-design.json", ("ANTIGRAVITY", "AGY_")),
+)
+
+
+def _wrapper_from_manifest(project_dir: Path) -> list[str] | None:
+    """Resolve the model wrapper from a project's `ui init` manifest(s). When several
+    runtimes were init'd, the host whose env markers are present wins; otherwise the
+    declared order above breaks the tie. Returns `None` if no wired, existing wrapper."""
+    candidates: list[tuple[int, str]] = []
+    for rel, env_markers in _RUNTIME_MANIFESTS:
+        path = project_dir / rel
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        adapter = data.get("modelAdapter") if isinstance(data, dict) else None
+        wrapper = adapter.get("wrapper") if isinstance(adapter, dict) else None
+        if not isinstance(wrapper, str) or not wrapper:
+            continue
+        wrapper_path = project_dir / wrapper
+        if not wrapper_path.is_file():
+            continue
+        host_running = any(any(k.startswith(m) for k in os.environ) for m in env_markers)
+        candidates.append((0 if host_running else 1, str(wrapper_path)))
+    if not candidates:
         return None
-    return shlex.split(raw)
+    candidates.sort(key=lambda c: c[0])  # stable: host-running first, else declared order
+    return [candidates[0][1]]
+
+
+def resolve_model_cmd(project_dir: Path | None = None) -> list[str] | None:
+    """The model command, in precedence order (spec 013 P2):
+    1. `DESIGN_OS_MODEL_CMD` (shlex-split) — the operator's explicit override always wins.
+    2. else the wrapper `ui init` wired into `project_dir`'s runtime manifest — so a freshly
+       injected project harvests with the user's own host model, zero manual config.
+    3. else `None` — the caller degrades to `skipped` (`no-model-adapter`), unchanged."""
+    raw = os.environ.get("DESIGN_OS_MODEL_CMD")
+    if raw and raw.strip():
+        return shlex.split(raw)
+    if project_dir is not None:
+        return _wrapper_from_manifest(project_dir)
+    return None
 
 
 def extract(packet: str, *, cmd: list[str], timeout: float = 300.0) -> str:

--- a/design-os/tests/test_harvest_model.py
+++ b/design-os/tests/test_harvest_model.py
@@ -51,3 +51,74 @@ def test_extract_raises_model_unavailable_on_timeout(tmp_path: Path) -> None:
     script.chmod(0o755)
     with pytest.raises(ModelUnavailable):
         extract("packet", cmd=[str(script)], timeout=0.2)
+
+
+# ─── spec 013 P2: resolve from the ui-init manifest when env is unset ────────────────────
+
+def _wire(project: Path, manifest_rel: str, wrapper_rel: str) -> Path:
+    """Write a runtime manifest with a modelAdapter + an executable wrapper (as `ui init` does)."""
+    import json
+    mf = project / manifest_rel
+    mf.parent.mkdir(parents=True, exist_ok=True)
+    mf.write_text(json.dumps({"version": 1, "runtime": "x", "status": "ready",
+                              "modelAdapter": {"wrapper": wrapper_rel, "mode": "stdin"}}))
+    wp = project / wrapper_rel
+    wp.parent.mkdir(parents=True, exist_ok=True)
+    wp.write_text("#!/usr/bin/env sh\nexec claude -p\n")
+    wp.chmod(0o755)
+    return wp
+
+
+def test_resolve_reads_the_manifest_wrapper_when_env_is_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DESIGN_OS_MODEL_CMD", raising=False)
+    wp = _wire(tmp_path, ".claude/ease-design.json", ".claude/design-os-model.sh")
+    assert resolve_model_cmd(tmp_path) == [str(wp)]
+
+
+def test_env_override_wins_over_the_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(tmp_path, ".claude/ease-design.json", ".claude/design-os-model.sh")
+    monkeypatch.setenv("DESIGN_OS_MODEL_CMD", "my-model -q")
+    assert resolve_model_cmd(tmp_path) == ["my-model", "-q"]
+
+
+def test_resolve_is_none_when_no_manifest_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DESIGN_OS_MODEL_CMD", raising=False)
+    assert resolve_model_cmd(tmp_path) is None
+
+
+def test_resolve_is_none_when_the_wrapper_file_is_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DESIGN_OS_MODEL_CMD", raising=False)
+    import json
+    mf = tmp_path / ".claude" / "ease-design.json"
+    mf.parent.mkdir(parents=True, exist_ok=True)
+    mf.write_text(json.dumps({"modelAdapter": {"wrapper": ".claude/gone.sh", "mode": "stdin"}}))
+    assert resolve_model_cmd(tmp_path) is None  # manifest names a wrapper that isn't there
+
+
+def test_running_host_marker_wins_over_declared_order(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+    monkeypatch.delenv("DESIGN_OS_MODEL_CMD", raising=False)
+    # Isolate: the test process itself runs under a host (CLAUDE_* set), which would otherwise
+    # make claude detect as "running". Clear every configured marker, then set only agy's.
+    for prefix in ("CLAUDECODE", "CLAUDE_CODE", "CLAUDE_", "CODEX_", "OPENAI_CODEX", "ANTIGRAVITY", "AGY_"):
+        for k in list(os.environ):
+            if k.startswith(prefix):
+                monkeypatch.delenv(k, raising=False)
+    # both claude (declared first) and antigravity wired; only the agy host env is present
+    _wire(tmp_path, ".claude/ease-design.json", ".claude/design-os-model.sh")
+    agy = _wire(tmp_path, ".agent/ease-design.json", ".agent/design-os-model.sh")
+    monkeypatch.setenv("ANTIGRAVITY_SESSION", "1")
+    assert resolve_model_cmd(tmp_path) == [str(agy)]
+
+
+def test_declared_order_breaks_the_tie_when_no_host_marker_is_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+    monkeypatch.delenv("DESIGN_OS_MODEL_CMD", raising=False)
+    for prefix in ("CLAUDECODE", "CLAUDE_CODE", "CLAUDE_", "CODEX_", "OPENAI_CODEX", "ANTIGRAVITY", "AGY_"):
+        for k in list(os.environ):
+            if k.startswith(prefix):
+                monkeypatch.delenv(k, raising=False)
+    # no host marker (the cron case) → the declared order (claude first) wins deterministically
+    claude = _wire(tmp_path, ".claude/ease-design.json", ".claude/design-os-model.sh")
+    _wire(tmp_path, ".agent/ease-design.json", ".agent/design-os-model.sh")
+    assert resolve_model_cmd(tmp_path) == [str(claude)]

--- a/specs/013-host-model-fuel-line/plan.md
+++ b/specs/013-host-model-fuel-line/plan.md
@@ -55,13 +55,14 @@ contract (packet on stdin, argv is fixed config). A guessed invocation = a silen
   has all 3; `init --runtime {claude,codex,antigravity}` writes an executable wrapper + manifest
   `modelAdapter`; the arg-mode wrapper (agy) contains the stdin→arg normalization, the stdin ones
   don't; `--all` writes all three. A wrapper-shape lint (like the existing adapter-wrapper-lint) if cheap.
-- **P2** — Python: `resolve_model_cmd` reads the manifest (env still wins); harvest/heartbeat pick up
-  the wrapper with NO env set. **Tests**: a project with a wired manifest → `resolve_model_cmd`
-  returns the wrapper argv; env override still wins; multi-manifest host-detection picks correctly;
-  no manifest → None.
-- **P3 (Art III)** — LIVE end-to-end: `ui init --runtime claude` on a scratch project with a design
-  store + a real report, run `design-os harvest` with **NO `DESIGN_OS_MODEL_CMD` in env** → the
-  wrapper is used, a real insight lands, `design-os evolution` → ALIVE. The whole point, proven once.
+- **P2 (DONE)** — Python: `resolve_model_cmd(project_dir)` reads the manifest (env still wins); all
+  three call sites (harvest, heartbeat harvest, heartbeat reflect) pass `project_dir`. 6 new tests
+  (manifest wrapper resolved; env override wins; no manifest → None; missing wrapper file → None;
+  running host marker wins; declared order breaks the tie). Full design-os suite 263 green.
+- **P3 (DONE, Art III)** — LIVE end-to-end proved: `ui init --runtime claude` → `ds init` store →
+  a real report → `design-os harvest` with **NO `DESIGN_OS_MODEL_CMD` in env** → the wrapper
+  (`exec claude -p`) was auto-used, 1 real insight landed, `design-os evolution` → **ALIVE**. A
+  freshly-injected project reaches ALIVE with zero manual model config. The whole point, proven.
 
 ## Constraints & risks
 - Art I: the kernel writing a static wrapper + manifest field is deterministic (like the existing


### PR DESCRIPTION
## What (spec 013 P2 + P3)

Completes the host-model fuel line. P1 made `ui init` WRITE a model-adapter wrapper + record it in the manifest. This makes the conductor USE it.

`resolve_model_cmd(project_dir)` resolves in precedence order:
1. `DESIGN_OS_MODEL_CMD` — explicit operator override (unchanged).
2. the wrapper `ui init` wired into the project's runtime manifest (P1) — so a fresh inject harvests with the **user's own host model, zero manual config**.
3. `None` → the caller degrades to `skipped` (`no-model-adapter`), unchanged.

All three call sites (harvest, heartbeat harvest, heartbeat reflect) now pass the project dir. Multi-manifest (a `--all` project) resolves by the running host's env markers, else a stable declared order.

This closes the gap spec 012 measured: `DESIGN_OS_MODEL_CMD` was unset on every real project, so no injected project could self-evolve. Now injection alone wires the loop's model.

## P3 — the live end-to-end proof (Art III)

`ui init --runtime claude` → `ds init` store → a real end-of-phase report → `design-os harvest` with **NO `DESIGN_OS_MODEL_CMD` in env**:
- the wrapper (`exec claude -p`) was auto-resolved from the manifest and used,
- 1 real insight landed (*"Disabled state must gate the event handler, not just styling…"*),
- `design-os evolution` → **ALIVE**.

A freshly-injected project reaches ALIVE with **zero manual model config** — the whole point of the spec.

## Tests

6 new in `tests/test_harvest_model.py`: manifest wrapper resolved when env unset; env override wins; no manifest → None; missing wrapper file → None; running-host marker wins over declared order; declared order breaks the tie. Full design-os suite: **263 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)