### PR TITLE
feat(taste-lint): add craft detail warnings

### DIFF
--- a/knowledge/taste-rubric.md
+++ b/knowledge/taste-rubric.md
@@ -36,7 +36,13 @@ composition feels *authored*, not auto-arranged.
 | **High** | Asymmetric, editorial composition. Fractional widths, overlapping elements, intentional negative space as a design element. Strong single focal point per viewport. Right for landing pages, portfolios, marketing. |
 
 **Anti-patterns:** 50/50 hero splits with no reason; three identical cards as the only
-composition idea; every section the same width and rhythm; no clear focal point.
+composition idea; every section the same width and rhythm; no clear focal point;
+"container soup" — decorative wrapper nesting three-plus levels deep with no semantic
+payload at any level (section > card > pill > tag). *Machine floor:* `taste-lint`'s
+`container-nesting-depth` (warning) tag-stack-scans purely-presentational containers
+(`div`/`section`/`article`/`aside`/`main` or a card/panel/rounded-*/border class signal)
+and flags a chain ≥3 deep; landmarks, lists/tables/forms, elements carrying a semantic
+role/aria, and a grid/flex parent's direct track children are exempt.
 
 ### Scoring 0–10
 
@@ -312,6 +318,12 @@ once tokens and components exist, every subsequent generation is held to it.
 **Score against:** Does every color/spacing/type value resolve to an existing token?
 Were registered components reused rather than re-built? Do all names match the project's
 canonical vocabulary? Are new additions deliberate and named, or accidental drift?
+
+*Machine floor:* `taste-lint`'s `radius-sprawl` (warning at > 4 distinct non-zero
+border-radius values — a drift signal, warning-only, not a hard ceiling and never an
+error) counts distinct corner radii across `<style>`/inline CSS and Tailwind
+`rounded-*` scale steps; `50%`/`9999px`/`rounded-full` pill radii collapse into one
+bucket regardless of how many elements use them.
 
 ---
 

--- a/src/core/taste-checks-nesting.ts
+++ b/src/core/taste-checks-nesting.ts
@@ -1,0 +1,199 @@
+/**
+ * container-nesting-depth (Layout axis, WARNING) — the machine floor under the
+ * rubric's Layout anti-pattern "container soup": decorative wrapper divs nested
+ * inside decorative wrapper divs inside decorative wrapper divs, three-plus
+ * levels deep, with no semantic payload at any level (section > card > pill >
+ * tag). Each wrap adds DOM weight and paint cost without adding structure.
+ *
+ * Detection: a pure-static tag-stack walk. Elements are classified as:
+ *   - a CONTAINER candidate  — `div`/`section`/`article`/`aside`/`main`, or any
+ *     element whose `class` carries a presentational-wrapper signal
+ *     (`card`/`panel`/`rounded-*`/`border`);
+ *   - a BREAK — a landmark tag (`main`/`nav`/`header`/`footer`), a list/table/
+ *     form element (`ul`/`ol`/`li`/`table`/`tr`/`td`/`th`/`form`/…), or any
+ *     element carrying `role="…"` or an `aria-*` attribute. A break resets the
+ *     running nesting count to zero for its own subtree — it is semantic, not
+ *     "purely presentational", so it (and anything above it) never contributes
+ *     to a container-soup chain.
+ *   - otherwise a pass-through (e.g. `<p>`, `<span>`, `<button>` with no wrapper
+ *     class) — it neither adds nor resets depth; the chain runs through it.
+ *
+ * A CONTAINER's depth is its parent's depth + 1, UNLESS the parent establishes a
+ * grid/flex track (`class` contains `grid`/`flex`, or `style="display:grid|flex"`)
+ * — a grid/flex parent's DIRECT children are track cells, not an extra wrap
+ * layer, so they inherit the parent's own depth rather than incrementing it.
+ *
+ * A chain is flagged once, at its deepest terminal point (a container with no
+ * flagged descendant), when that depth reaches 3. This reports exactly one
+ * finding per independent branch of container soup rather than one per level.
+ *
+ * Pure string/regex — no DOM, no deps.
+ */
+import type { TasteFinding } from "./taste-lint.js";
+import { lineOf } from "./taste-checks-shared.js";
+
+const CHECK_ID = "container-nesting-depth";
+const FLAG_AT = 3; // a chain of this many purely-presentational containers is "soup"
+
+const BASE_CONTAINER_TAGS = new Set(["div", "section", "article", "aside", "main"]);
+const LANDMARK_TAGS = new Set(["main", "nav", "header", "footer"]);
+const LIST_TABLE_FORM_TAGS = new Set([
+  "ul", "ol", "li", "dl", "dt", "dd",
+  "table", "thead", "tbody", "tfoot", "tr", "td", "th",
+  "form", "fieldset",
+]);
+/** Void elements never wrap children — skip them entirely (never pushed). */
+const VOID_TAGS = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input",
+  "link", "meta", "param", "source", "track", "wbr",
+]);
+
+const CONTAINER_CLASS_SIGNAL = /\b(?:card|panel)\b|\brounded(?:-[a-z0-9-]+)?\b|\bborder(?:-[a-z0-9-]+)?\b/i;
+const TRACK_CLASS_SIGNAL = /\b(?:inline-)?(?:grid|flex)\b/;
+const TRACK_STYLE_SIGNAL = /display\s*:\s*(?:inline-)?(?:grid|flex)\b/i;
+const ROLE_OR_ARIA = /\brole\s*=\s*["'][^"']*["']|\baria-[a-z-]+\s*=/i;
+
+/** Extract the `class="…"` value from a tag's attribute string; "" when absent. */
+function classOf(attrs: string): string {
+  return /\bclass\s*=\s*["']([^"']*)["']/i.exec(attrs)?.[1] ?? "";
+}
+
+/** Extract the `style="…"` value from a tag's attribute string; "" when absent. */
+function styleOf(attrs: string): string {
+  return /\bstyle\s*=\s*["']([^"']*)["']/i.exec(attrs)?.[1] ?? "";
+}
+
+function isBreak(tag: string, attrs: string): boolean {
+  if (LANDMARK_TAGS.has(tag) || LIST_TABLE_FORM_TAGS.has(tag)) return true;
+  return ROLE_OR_ARIA.test(attrs);
+}
+
+function isContainerCandidate(tag: string, attrs: string): boolean {
+  if (BASE_CONTAINER_TAGS.has(tag)) return true;
+  return CONTAINER_CLASS_SIGNAL.test(classOf(attrs));
+}
+
+function establishesTrack(attrs: string): boolean {
+  return TRACK_CLASS_SIGNAL.test(classOf(attrs)) || TRACK_STYLE_SIGNAL.test(styleOf(attrs));
+}
+
+/** A short human label for a frame, used to name the flagged chain. */
+function labelOf(tag: string, attrs: string): string {
+  const cls = classOf(attrs).trim().split(/\s+/)[0];
+  return cls ? `${tag}.${cls}` : tag;
+}
+
+interface Frame {
+  tag: string;
+  isBreak: boolean;
+  isContainer: boolean;
+  isTrack: boolean;
+  depth: number;
+  chainLabel: string;
+  hasFlaggedDescendant: boolean;
+  openIndex: number;
+}
+
+/** Blank out <script>/<style> contents (preserving offsets) — irrelevant to markup nesting. */
+function stripNonMarkup(html: string): string {
+  return html.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, (m) => " ".repeat(m.length));
+}
+
+const TAG_RE = /<\/([a-zA-Z][\w-]*)\s*>|<([a-zA-Z][\w-]*)\b([^>]*?)(\/)?>/g;
+
+export function checkContainerNestingDepth(html: string): TasteFinding[] {
+  const scan = stripNonMarkup(html);
+  const findings: TasteFinding[] = [];
+  const stack: Frame[] = [];
+
+  const closeFrame = (frame: Frame): void => {
+    let selfFlagged = false;
+    if (!frame.isBreak && frame.isContainer && frame.depth >= FLAG_AT && !frame.hasFlaggedDescendant) {
+      findings.push({
+        checkId: CHECK_ID,
+        axis: "Layout",
+        severity: "warning",
+        message: `container-soup chain ${frame.depth} levels deep (${frame.chainLabel}) — decorative wrappers nested past 2 levels (rubric Layout anti-pattern: "container soup") add DOM weight with no structural payload; flatten via a single element with combined utility classes or drop the non-semantic wrapper`,
+        line: lineOf(html, frame.openIndex),
+      });
+      selfFlagged = true;
+    }
+    const propagate = frame.isBreak ? false : frame.hasFlaggedDescendant || selfFlagged;
+    const parent = stack[stack.length - 1];
+    if (parent && propagate) parent.hasFlaggedDescendant = true;
+  };
+
+  let m: RegExpExecArray | null;
+  while ((m = TAG_RE.exec(scan)) !== null) {
+    const closeTag = m[1];
+    if (closeTag !== undefined) {
+      const tag = closeTag.toLowerCase();
+      // Close the nearest matching open frame, implicitly closing any unclosed
+      // descendants above it (mirrors how real parsers handle optional-close tags).
+      let idx = -1;
+      for (let i = stack.length - 1; i >= 0; i--) {
+        if (stack[i]?.tag === tag) { idx = i; break; }
+      }
+      if (idx === -1) continue; // stray/unmatched closing tag — ignore
+      while (stack.length > idx) {
+        const frame = stack.pop();
+        if (frame) closeFrame(frame);
+      }
+      continue;
+    }
+
+    const openTag = (m[2] ?? "").toLowerCase();
+    const attrs = m[3] ?? "";
+    const selfClosing = m[4] === "/";
+    if (VOID_TAGS.has(openTag)) continue; // never wraps children — irrelevant
+
+    const parent = stack[stack.length - 1];
+    const parentDepth = parent ? parent.depth : 0;
+    const parentIsTrack = parent ? parent.isTrack : false;
+    const parentLabel = parent ? parent.chainLabel : "";
+    const parentIsBreakOrRoot = !parent || parent.isBreak;
+
+    const brk = isBreak(openTag, attrs);
+    const container = isContainerCandidate(openTag, attrs);
+
+    let depth: number;
+    let chainLabel: string;
+    if (brk) {
+      depth = 0;
+      chainLabel = "";
+    } else if (container) {
+      depth = parentIsTrack ? parentDepth : (parentIsBreakOrRoot ? 0 : parentDepth) + 1;
+      chainLabel = parentLabel ? `${parentLabel} > ${labelOf(openTag, attrs)}` : labelOf(openTag, attrs);
+    } else {
+      depth = parentDepth;
+      chainLabel = parentLabel;
+    }
+
+    const frame: Frame = {
+      tag: openTag,
+      isBreak: brk,
+      isContainer: container,
+      isTrack: establishesTrack(attrs),
+      depth,
+      chainLabel,
+      hasFlaggedDescendant: false,
+      openIndex: m.index,
+    };
+
+    if (selfClosing) {
+      closeFrame(frame); // no children possible — evaluate and discard immediately
+    } else {
+      stack.push(frame);
+    }
+  }
+
+  // Any elements left open at EOF (malformed/truncated markup) — close them in
+  // document order so a deep unterminated chain still gets evaluated.
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame) closeFrame(frame);
+  }
+
+  findings.sort((a, b) => (a.line ?? 0) - (b.line ?? 0));
+  return findings;
+}

--- a/src/core/taste-checks-radius.ts
+++ b/src/core/taste-checks-radius.ts
@@ -1,0 +1,146 @@
+/**
+ * radius-sprawl (Consistency axis, WARNING at > 4 distinct — warning-only) — the
+ * machine floor under the rubric's Consistency axis ("every value resolves to an
+ * existing token"). Mirrors `font-scale-sprawl`'s sprawl-count shape exactly: this
+ * is a drift signal, NOT a hard ceiling (a true ceiling needs family/token
+ * context this static check does not have).
+ *
+ * A designed surface picks a small radius scale (e.g. sm/md/lg + one pill value)
+ * and reuses it. A sprawl of many distinct hand-picked corner radii reads as
+ * unauthored — every card, chip, and input rounding itself independently.
+ *
+ * What is counted: distinct NON-ZERO border-radius magnitudes, gathered from
+ * `<style>` rules + inline `style="…"` (`border-radius: …`, reusing
+ * `taste-checks-shared`'s CSS-region extraction) and Tailwind `rounded-*` scale
+ * steps (named steps `sm/md/lg/xl/2xl/3xl` map to their default px value; bare
+ * `rounded`/`rounded-t`/… map to the 4px default; `rounded-[…]` arbitrary values
+ * are read literally). Values are canonicalized to px (rem/em/pt normalized, like
+ * `font-scale-sprawl`) so the same magnitude expressed two ways dedupes to one.
+ *
+ * Pill exemption: `50%`, `9999px`, and `rounded-full` all denote "fully round" —
+ * they collapse into a single "pill" bucket that counts once no matter how many
+ * elements use it, since a pill is one design decision, not a per-element pick.
+ *
+ * Threshold: > 4 distinct → warning (a drift nudge — never an error, never blocks CI).
+ * One whole-document finding; no line number (corpus-only, like font-scale-sprawl).
+ *
+ * Pure string/regex — no DOM, no deps.
+ */
+import type { TasteFinding } from "./taste-lint.js";
+import { cssRegions } from "./taste-checks-shared.js";
+
+const CHECK_ID = "radius-sprawl";
+const WARN_OVER = 4;
+const PILL = "pill";
+
+/** Tailwind's default radius scale (v3), in px; "full" is handled separately as PILL. */
+const TAILWIND_RADIUS_PX: Record<string, number> = {
+  none: 0, sm: 2, md: 6, lg: 8, xl: 12, "2xl": 16, "3xl": 24,
+};
+const DEFAULT_RADIUS_PX = 4; // bare `rounded` / `rounded-t` / … with no named step
+
+/** Normalize a numeric length + unit to px (2-dp), matching font-scale-sprawl's convention. */
+function toPx(value: string, unit: string): number | null {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n) || n < 0) return null;
+  const u = unit.toLowerCase();
+  const px =
+    u === "px" ? n :
+    u === "rem" || u === "em" ? n * 16 :
+    u === "pt" ? n * (96 / 72) :
+    null;
+  return px === null ? null : Math.round(px * 100) / 100;
+}
+
+/** Canonicalize one raw radius token (from CSS or an arbitrary Tailwind value) into a dedup key. Null = unparsable/zero (both skipped). */
+function canonicalize(raw: string): { key: string; isPill: boolean } | null {
+  const v = raw.trim().toLowerCase();
+  if (v === "50%" || v === "9999px") return { key: PILL, isPill: true };
+
+  const lenM = /^(\d+(?:\.\d+)?)(px|rem|em|pt)$/.exec(v);
+  if (lenM) {
+    const px = toPx(lenM[1] ?? "0", lenM[2] ?? "px");
+    if (px === null || px === 0) return null;
+    return { key: `${px}px`, isPill: false };
+  }
+
+  const pctM = /^(\d+(?:\.\d+)?)%$/.exec(v);
+  if (pctM) {
+    const n = parseFloat(pctM[1] ?? "0");
+    if (n === 0) return null;
+    return { key: `${n}%`, isPill: false };
+  }
+
+  return null; // not a recognizable length (e.g. `inherit`, `var(--…)`) — ignore
+}
+
+/** Collect distinct non-zero radius keys (see module doc) from the whole document. */
+function distinctRadii(html: string): Set<string> {
+  const keys = new Set<string>();
+
+  // Source 1 — CSS `border-radius:` declarations in <style> blocks + inline style attrs.
+  // border-radius can carry up to 4 space-separated corner values; each is its own datum.
+  const css = cssRegions(html);
+  const declRe = /border-radius\s*:\s*([^;}"']+)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = declRe.exec(css)) !== null) {
+    const tokens = (m[1] ?? "").trim().split(/\s+/).filter((t) => t.length > 0);
+    for (const t of tokens) {
+      const c = canonicalize(t);
+      if (c) keys.add(c.key);
+    }
+  }
+
+  // Source 2 — Tailwind named scale steps: rounded, rounded-{t,r,b,l,tl,tr,br,bl}-{none,sm,md,lg,xl,2xl,3xl,full}.
+  const namedRe = /\brounded(?:-(?:t|r|b|l|tl|tr|br|bl))?(?:-(none|sm|md|lg|xl|2xl|3xl|full))?(?=[\s"'>]|$)/gi;
+  while ((m = namedRe.exec(html)) !== null) {
+    const step = (m[1] ?? "").toLowerCase();
+    if (step === "full") { keys.add(PILL); continue; }
+    if (step === "none") continue; // 0 — not counted
+    const px = step === "" ? DEFAULT_RADIUS_PX : TAILWIND_RADIUS_PX[step];
+    if (px !== undefined && px > 0) keys.add(`${px}px`);
+  }
+
+  // Source 3 — Tailwind arbitrary values: rounded-[12px] / rounded-tl-[0.75rem] / rounded-[50%].
+  const arbRe = /\brounded(?:-(?:t|r|b|l|tl|tr|br|bl))?-\[([^\]]+)\]/gi;
+  while ((m = arbRe.exec(html)) !== null) {
+    const c = canonicalize(m[1] ?? "");
+    if (c) keys.add(c.key);
+  }
+
+  return keys;
+}
+
+/** Sort keys for a stable, readable message: numeric px ascending, percents after, "pill" last. */
+function sortedLabels(keys: Set<string>): string[] {
+  const arr = [...keys];
+  const rank = (k: string): number => {
+    if (k === PILL) return 2;
+    if (k.endsWith("%")) return 1;
+    return 0;
+  };
+  arr.sort((a, b) => {
+    const r = rank(a) - rank(b);
+    if (r !== 0) return r;
+    return parseFloat(a) - parseFloat(b);
+  });
+  return arr;
+}
+
+/**
+ * radius-sprawl: count the distinct non-zero border-radius magnitudes in the
+ * document (pill values collapsed to one). More than 4 distinct trips a warning
+ * (a drift nudge, never an error). A document holding to a small radius scale
+ * trips nothing.
+ */
+export function checkRadiusSprawl(html: string): TasteFinding[] {
+  const keys = distinctRadii(html);
+  const count = keys.size;
+  if (count <= WARN_OVER) return [];
+  return [{
+    checkId: CHECK_ID,
+    axis: "Consistency",
+    severity: "warning",
+    message: `${count} distinct non-zero border-radius values (${sortedLabels(keys).join(", ")}) — rubric Consistency: "every value resolves to an existing token" — collapse onto a small radius scale (e.g. sm/md/lg + one pill value)`,
+  }];
+}

--- a/src/core/taste-lint.ts
+++ b/src/core/taste-lint.ts
@@ -31,10 +31,12 @@
  *                   keyframes-layout-props
  *   Motion        → overshoot-easing, focus-ring-animates-in
  *   Consistency   → raw-hex-when-token-exists (needs DS token set)
+ *   Consistency   → radius-sprawl            (> 4 distinct border-radius values; warning-only)
+ *   Layout        → container-nesting-depth  (≥ 3 nested purely-presentational wrappers; warning)
  *
- * Axes intentionally NOT covered (subjective — left to the model): Layout in
- * full, plus the qualitative dimensions of every axis (is the scale on one
- * ratio? is the composition authored? is the elevation ramp coherent?).
+ * Axes intentionally NOT covered (subjective — left to the model): the
+ * qualitative dimensions of every axis (is the scale on one ratio? is the
+ * composition authored? is the elevation ramp coherent?).
  */
 import {
   checkTinyBodyText,
@@ -56,6 +58,8 @@ import { checkTapTargetUndersized } from "./taste-checks-tap-target.js";
 import { checkAiClicheGradient } from "./taste-checks-gradient.js";
 import { checkFontScaleSprawl } from "./taste-checks-font-scale.js";
 import { checkModeInvisibleSurface } from "./taste-checks-invisible-surface.js";
+import { checkContainerNestingDepth } from "./taste-checks-nesting.js";
+import { checkRadiusSprawl } from "./taste-checks-radius.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -149,6 +153,9 @@ export function lintTaste(html: string, opts: TasteLintOptions = {}): TasteLintR
     // (font-scale escalates to error past 10 sizes); mode-invisible-surface is an error.
     ...checkFontScaleSprawl(stripped),
     ...checkModeInvisibleSurface(stripped),
+    // Craft-lint graduation (spec CRAFT-LINT). Both new checks default warning.
+    ...checkContainerNestingDepth(stripped),
+    ...checkRadiusSprawl(stripped),
   ];
 
   // Sort by rubric axis order, then by line (undefined lines last).

--- a/tests/taste-checks-nesting.test.ts
+++ b/tests/taste-checks-nesting.test.ts
@@ -1,0 +1,130 @@
+/**
+ * container-nesting-depth (Layout, warning) — taste-checks-nesting.ts
+ * Fixtures cover: a tripping chain, a clean fixture, each exemption path
+ * (landmark / list / grid-track-children / aria-role), and the depth-2-clean
+ * vs depth-3-flag boundary. A final block drives it through lintTaste() to
+ * prove registration.
+ */
+import { describe, expect, it } from "vitest";
+import { checkContainerNestingDepth } from "../src/core/taste-checks-nesting.js";
+import { lintTaste } from "../src/core/taste-lint.js";
+
+describe("container-nesting-depth", () => {
+  it("flags a container-soup wrapper chain (section > card > pill > tag, 4 levels deep)", () => {
+    const html = [
+      "<section>",
+      '  <div class="card">',
+      '    <div class="rounded-full pill">',
+      '      <div class="border tag">x</div>',
+      "    </div>",
+      "  </div>",
+      "</section>",
+    ].join("\n");
+    const f = checkContainerNestingDepth(html);
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("container-nesting-depth");
+    expect(f[0]?.axis).toBe("Layout");
+    expect(f[0]?.severity).toBe("warning");
+    expect(f[0]?.message).toContain("4 levels deep"); // section, card, pill, tag
+    expect(f[0]?.line).toBe(4); // the innermost <div class="border tag"> line
+  });
+
+  it("does NOT flag clean markup (plain content, no wrapper soup)", () => {
+    const html = '<main><h1>Title</h1><p class="prose">Body copy.</p></main>';
+    expect(checkContainerNestingDepth(html)).toHaveLength(0);
+  });
+
+  it("boundary: exactly 2 nested containers is clean", () => {
+    const html = '<div class="card"><div class="panel">x</div></div>';
+    expect(checkContainerNestingDepth(html)).toHaveLength(0);
+  });
+
+  it("boundary: exactly 3 nested containers flags", () => {
+    const html = '<div class="card"><div class="panel"><div class="border">x</div></div></div>';
+    const f = checkContainerNestingDepth(html);
+    expect(f).toHaveLength(1);
+    expect(f[0]?.message).toContain("3 levels deep");
+  });
+
+  it("exemption: a landmark (<main>/<nav>/<header>/<footer>) resets the chain", () => {
+    const html = [
+      '<div class="card"><div class="panel">',
+      '  <main class="rounded">',
+      '    <div class="card"><div class="panel">clean, only 2 deep past the landmark</div></div>',
+      "  </main>",
+      "</div></div>",
+    ].join("\n");
+    expect(checkContainerNestingDepth(html)).toHaveLength(0);
+  });
+
+  it("exemption: a list/table container breaks the chain", () => {
+    const html = [
+      '<div class="card"><div class="panel">',
+      "  <ul>",
+      '    <li><div class="card"><div class="panel">x</div></div></li>',
+      "  </ul>",
+      "</div></div>",
+    ].join("\n");
+    expect(checkContainerNestingDepth(html)).toHaveLength(0);
+  });
+
+  it("exemption: a grid's direct children are track cells, not extra nesting", () => {
+    // Grid parent (depth 1) has 3 direct .card children — each inherits depth 1,
+    // not 2/3/4, because siblings-in-a-track are not "wrapping".
+    const html = [
+      '<div class="card grid grid-cols-3">',
+      '  <div class="panel">a</div>',
+      '  <div class="panel">b</div>',
+      '  <div class="panel">c</div>',
+      "</div>",
+    ].join("\n");
+    expect(checkContainerNestingDepth(html)).toHaveLength(0);
+  });
+
+  it("grid exemption only covers DIRECT children — deeper nesting inside a track cell still counts", () => {
+    const html = [
+      '<div class="grid">',
+      '  <div class="card">', // depth 1 (track child of grid, inherits grid's depth 0->1 as first container)
+      '    <div class="panel">', // depth 2
+      '      <div class="border">too deep</div>', // depth 3 — flags
+      "    </div>",
+      "  </div>",
+      "</div>",
+    ].join("\n");
+    const f = checkContainerNestingDepth(html);
+    expect(f).toHaveLength(1);
+  });
+
+  it("exemption: an element carrying role= or aria-* breaks the chain", () => {
+    const html = [
+      '<div class="card"><div class="panel">',
+      '  <div role="region" aria-label="Widget" class="border">',
+      '    <div class="card"><div class="panel">clean past the aria boundary</div></div>',
+      "  </div>",
+      "</div></div>",
+    ].join("\n");
+    expect(checkContainerNestingDepth(html)).toHaveLength(0);
+  });
+
+  it("does not flag when a non-container element (e.g. <p>) sits between wrappers, but the chain still runs through it", () => {
+    const html = '<div class="card"><p><div class="panel"><div class="border">x</div></div></p></div>';
+    const f = checkContainerNestingDepth(html);
+    expect(f).toHaveLength(1); // pass-through <p> doesn't reset the count
+  });
+});
+
+describe("lintTaste — container-nesting-depth wired", () => {
+  it("registers the check as a warning and never bumps errorCount", () => {
+    const html = '<div class="card"><div class="panel"><div class="border">x</div></div></div>';
+    const r = lintTaste(html);
+    const finding = r.findings.find((f) => f.checkId === "container-nesting-depth");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("warning");
+    expect(r.warningCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("a clean document trips no container-nesting-depth finding", () => {
+    const r = lintTaste('<main><h1>Title</h1><p class="prose">Body copy.</p></main>');
+    expect(r.findings.some((f) => f.checkId === "container-nesting-depth")).toBe(false);
+  });
+});

--- a/tests/taste-checks-radius.test.ts
+++ b/tests/taste-checks-radius.test.ts
@@ -1,0 +1,100 @@
+/**
+ * radius-sprawl (Consistency, warning > 4 distinct — warning-only) — taste-checks-radius.ts
+ * Fixtures cover: a tripping fixture, a clean fixture, the pill exemption
+ * (50%/9999px/rounded-full collapsing to one bucket), and the boundary
+ * (4 clean, 5 warn, 8 still warn — never errors).
+ */
+import { describe, expect, it } from "vitest";
+import { checkRadiusSprawl } from "../src/core/taste-checks-radius.js";
+import { lintTaste } from "../src/core/taste-lint.js";
+
+/** Build markup with `n` distinct non-zero arbitrary Tailwind radii (2px, 4px, 6px, …). */
+function nRadii(n: number): string {
+  return Array.from({ length: n }, (_, i) => `<div class="rounded-[${2 + i * 2}px]">x</div>`).join("\n");
+}
+
+describe("radius-sprawl", () => {
+  it("flags a document with a sprawl of distinct radii and reports the count + values", () => {
+    const html = nRadii(6); // 2,4,6,8,10,12px -> 6 distinct, > 4 -> warning
+    const f = checkRadiusSprawl(html);
+    expect(f).toHaveLength(1);
+    expect(f[0]?.checkId).toBe("radius-sprawl");
+    expect(f[0]?.axis).toBe("Consistency");
+    expect(f[0]?.severity).toBe("warning");
+    expect(f[0]?.message).toContain("6 distinct");
+    expect(f[0]?.message).toContain("2px");
+    expect(f[0]?.message).toContain("12px");
+  });
+
+  it("does NOT flag a clean document using a small, consistent radius scale", () => {
+    const html = '<div class="rounded-sm">a</div><div class="rounded-md">b</div><div class="rounded-lg">c</div>';
+    expect(checkRadiusSprawl(html)).toHaveLength(0);
+  });
+
+  it("does NOT count a zero radius (rounded-none / border-radius:0)", () => {
+    const html = '<div class="rounded-none">a</div><style>.b{border-radius:0}</style>';
+    expect(checkRadiusSprawl(html)).toHaveLength(0);
+  });
+
+  it("dedupes the same magnitude expressed via CSS, inline, and Tailwind named steps", () => {
+    // rounded-lg == 8px == border-radius:8px inline — one distinct value, not three.
+    const html = [
+      '<div class="rounded-lg">a</div>',
+      '<div style="border-radius:8px">b</div>',
+      "<style>.c{border-radius:0.5rem}</style>", // 0.5rem == 8px
+      '<div class="rounded-sm">d</div>', // 2px, distinct
+      '<div class="rounded-md">e</div>', // 6px, distinct
+      '<div class="rounded-xl">f</div>', // 12px, distinct
+    ].join("\n");
+    expect(checkRadiusSprawl(html)).toHaveLength(0); // 4 distinct total (8, 2, 6, 12) — clean boundary
+  });
+
+  it("exemption: 50% / 9999px / rounded-full all collapse into ONE pill bucket", () => {
+    const html = [
+      '<div class="rounded-full">a</div>',
+      '<div style="border-radius:50%">b</div>',
+      '<div style="border-radius:9999px">c</div>',
+      '<div class="rounded-sm">d</div>', // 2px
+      '<div class="rounded-md">e</div>', // 6px
+      '<div class="rounded-lg">f</div>', // 8px
+      '<div class="rounded-xl">g</div>', // 12px
+      // total distinct = pill, 2px, 6px, 8px, 12px = 5 -> warning, NOT more from the 3 pill forms
+    ].join("\n");
+    const f = checkRadiusSprawl(html);
+    expect(f).toHaveLength(1);
+    expect(f[0]?.severity).toBe("warning");
+    expect(f[0]?.message).toContain("5 distinct");
+    expect(f[0]?.message).toContain("pill");
+  });
+
+  it("boundary: exactly 4 distinct non-zero radii is clean", () => {
+    expect(checkRadiusSprawl(nRadii(4))).toHaveLength(0);
+  });
+
+  it("boundary: exactly 5 distinct non-zero radii warns", () => {
+    const f = checkRadiusSprawl(nRadii(5));
+    expect(f).toHaveLength(1);
+    expect(f[0]?.severity).toBe("warning");
+  });
+
+  it("boundary: 8 distinct non-zero radii still warns (warning-only, never errors)", () => {
+    const f = checkRadiusSprawl(nRadii(8));
+    expect(f).toHaveLength(1);
+    expect(f[0]?.severity).toBe("warning");
+  });
+});
+
+describe("lintTaste — radius-sprawl wired", () => {
+  it("registers the check and keeps warning severity", () => {
+    const r = lintTaste(nRadii(6));
+    const finding = r.findings.find((f) => f.checkId === "radius-sprawl");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("warning");
+    expect(r.warningCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("a clean document trips no radius-sprawl finding", () => {
+    const r = lintTaste('<div class="rounded-sm">a</div><div class="rounded-md">b</div>');
+    expect(r.findings.some((f) => f.checkId === "radius-sprawl")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add warning-only detection for excessive presentational container nesting
- add warning-only detection for border-radius sprawl
- document the machine floor and cover both checks with focused tests

## Safety
- add-only warnings; no previously passing artifact becomes an error
- no model-routing or owner-preference policy changes

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npm test (2,254 passed, 6 skipped)
- ui knowledge check
- git diff --check
- independent Fable review: APPROVE