### PR TITLE
feat: govern reference originality and persona counts

### DIFF
--- a/knowledge/persona-index.md
+++ b/knowledge/persona-index.md
@@ -50,8 +50,8 @@ persona is selected.
 | `floating-composition` | product-marketing | landing, portfolio | spacious | both | — | floating, launch, startup, mockup, device, innovation, space, modern |
 
 **Family counts:** material-surface 7 · product-marketing 4 · functional-saas 3 ·
-immersive-cinematic 3 · editorial-minimal 2 · graphic-modernist 2 · retro-digital 2.
-Total **23 personas / 7 families**.
+immersive-cinematic 3 · editorial-minimal 4 · graphic-modernist 3 · retro-digital 2.
+Total **26 personas / 7 families**.
 
 **Legacy name:** "Ambient Glassmorphism" is a rename → resolves to `liquid-glass`.
 
@@ -76,7 +76,7 @@ without the binary.
 
 Keep only personas whose `ui_types` includes the requested UI type. If the requested
 UI type defaults and is `landing`, that is the default. **If the filter yields zero
-personas, fall back to the full set of 23.**
+personas, fall back to the full set of 26.**
 
 ### Stage 2 — Score each persona in the pool
 

--- a/knowledge/prompt-modes.md
+++ b/knowledge/prompt-modes.md
@@ -11,6 +11,46 @@ surprising choice).
 Each mode carries a recommended **creativity setting** — how much latitude the model
 should take. Lower means stay literal; higher means be inventive.
 
+## Reference-led originality boundary
+
+<!-- ease:source ref="references/mengto-skills/generate-reference-inspired-brand-worlds.md" captured="202607" url="https://github.com/MengTo/Skills/tree/21b278c62f49f3ce3d8c8ecbcc84cbcd534f3e49/agent-skills/codex/generate-reference-inspired-brand-worlds" -->
+
+When a task uses a reference to create a **new** visual identity or art direction, decide
+what may transfer before writing the build prompt:
+
+1. **Reusable visual grammar** — abstract relationships such as density, depth, palette
+   relationships, material, lighting temperature, type-scale contrast, human presence, and
+   spatial rhythm. These may inform a new result.
+2. **Protected signature elements** — distinctive composition, poses or choreography,
+   motif arrangement, negative-space shape, marks, slogans, proprietary names, wordmark
+   construction, and recognizable pixel-level arrangement. These must not be reproduced.
+
+Use the following proximity language only to communicate intent between people and the host
+model. The bands are **not measured similarity scores**:
+
+- **Distant inspiration** — retain only abstract mood, density, or contrast principles.
+- **Recognizable influence** — a medium or emotional register may carry over, while palette,
+  composition, subject, and type system materially change.
+- **Adjacent family** — composition logic and material relationships may remain legible, but
+  subjects, actions, arrangement, identity, and letterforms must be independently authored.
+- **Close art-direction neighbor** — preserve high-level grammar while changing several
+  identity-bearing dimensions and reviewing the whole result for recognizability.
+
+As a human review heuristic, change **at least four signature dimensions**—for example identity,
+subject, choreography, environment, motif, composition, negative-space shape, or letterform
+construction. Four superficial substitutions do not pass when the overall artifact remains
+recognizable as the source. This heuristic is non-normative guidance: it is not a linter rule,
+not a numerical originality claim, and not legal assurance.
+
+For every reference-led new work, state one **invariant/variant sentence**: name the abstract
+mechanism that may remain, then name the identity, subject, palette, composition, and signature
+details that must vary. Preserve accessibility, responsive behavior, and performance contracts
+regardless of visual proximity.
+
+This boundary governs reference-inspired **new work** under Enhance and relevant Adapt tasks.
+An expressly authorized Replicate task retains its fidelity contract; do not silently relabel a
+requested reconstruction as an originality exercise.
+
 ---
 
 ## Replicate

--- a/references/mengto-skills/generate-reference-inspired-brand-worlds.md
+++ b/references/mengto-skills/generate-reference-inspired-brand-worlds.md
@@ -1,0 +1,29 @@
+# MengTo/Skills extraction note — reference-inspired brand worlds
+
+- **Source:** <https://github.com/MengTo/Skills/tree/21b278c62f49f3ce3d8c8ecbcc84cbcd534f3e49/agent-skills/codex/generate-reference-inspired-brand-worlds>
+- **Captured:** 2026-07
+- **Source commit:** `21b278c62f49f3ce3d8c8ecbcc84cbcd534f3e49`
+- **Repository license:** MIT
+- **Disposition:** independently adapted guidance; no source prose, tables, prompts, or assets vendored
+
+## Portable capability observed
+
+The source separates reusable high-level visual relationships from identity-bearing signature details, uses coarse closeness bands to communicate art-direction intent, and asks the maker to vary several signature dimensions before treating a reference-inspired result as distinct.
+
+## What DESIGN:OS keeps
+
+- A non-metric vocabulary for discussing desired reference proximity.
+- A required split between reusable visual grammar and protected signature elements.
+- A multi-dimension change heuristic for human review.
+- Explicit context boundaries and counterexamples.
+
+## What DESIGN:OS removes
+
+- Source-specific labels, prompt templates, example brand names, and assets.
+- Any implication that a percentage measures visual similarity.
+- Any implication that counting changed elements proves originality or provides legal assurance.
+- Runtime- or provider-specific image-generation instructions.
+
+## Counterexample
+
+Changing four superficial details while preserving a distinctive composition, choreography, silhouette, wordmark construction, or motif arrangement is not an original adaptation. The human reviewer must judge the result as a whole.

--- a/src/core/knowledge-persona-check.ts
+++ b/src/core/knowledge-persona-check.ts
@@ -56,6 +56,83 @@ function parseJson(raw: string | null): SlugFamily | null {
   return out;
 }
 
+function isEscapedBacktick(content: string, index: number): boolean {
+  let slashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && content[cursor] === "\\"; cursor -= 1) slashes += 1;
+  return slashes % 2 === 1;
+}
+
+function stripInlineCodeBlock(content: string): string {
+  let output = "";
+  let cursor = 0;
+  while (cursor < content.length) {
+    if (content[cursor] !== "`" || isEscapedBacktick(content, cursor)) {
+      output += content[cursor];
+      cursor += 1;
+      continue;
+    }
+
+    const openerStart = cursor;
+    while (cursor < content.length && content[cursor] === "`") cursor += 1;
+    const width = cursor - openerStart;
+    let search = cursor;
+    let closerEnd: number | undefined;
+    while (search < content.length) {
+      if (content[search] !== "`" || isEscapedBacktick(content, search)) { search += 1; continue; }
+      const runStart = search;
+      while (search < content.length && content[search] === "`") search += 1;
+      if (search - runStart === width) { closerEnd = search; break; }
+    }
+
+    if (closerEnd === undefined) {
+      output += "`".repeat(width);
+    } else {
+      cursor = closerEnd;
+    }
+  }
+  return output;
+}
+
+function stripInlineCode(content: string): string {
+  // Inline spans may cross soft line breaks inside a paragraph, but never a
+  // blank-line Markdown block boundary.
+  return content
+    .split(/(\n[ \t]*\n)/)
+    .map((block, index) => index % 2 === 0 ? stripInlineCodeBlock(block) : block)
+    .join("");
+}
+
+function stripMarkdownCode(content: string): string {
+  const out: string[] = [];
+  const normalized = content.replace(/\r\n?/g, "\n");
+  const withoutComments = normalized.replace(/<!--[\s\S]*?-->/g, "");
+  let fence: { marker: "`" | "~"; width: number } | undefined;
+  for (const line of withoutComments.split("\n")) {
+    if (fence === undefined && /^(?: {4}|\t)/.test(line)) { out.push(""); continue; }
+
+    if (fence !== undefined) {
+      const closer = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/)?.[1];
+      if (closer !== undefined && closer[0] === fence.marker && closer.length >= fence.width) fence = undefined;
+      out.push("");
+      continue;
+    }
+
+    const opener = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (opener?.[1] !== undefined) {
+      const marker = opener[1];
+      const info = opener[2] ?? "";
+      // CommonMark backtick-fence info strings cannot themselves contain a
+      // backtick; such a line is prose, not a fence opener.
+      if (marker[0] === "`" && info.includes("`")) { out.push(line); continue; }
+      fence = { marker: marker[0] as "`" | "~", width: marker.length };
+      out.push("");
+      continue;
+    }
+    out.push(line);
+  }
+  return stripInlineCode(out.join("\n"));
+}
+
 export function personaChecks(
   indexMd: string | undefined,
   personaFiles: Record<string, string>,
@@ -70,6 +147,30 @@ export function personaChecks(
 
   const index = parseIndex(indexMd);
   const md = parseMarkdown(personaFiles);
+
+  const claimedCounts = new Set<number>();
+  const scannableIndex = stripMarkdownCode(indexMd);
+  const number = String.raw`\*{0,2}(\d+)\*{0,2}`;
+  const claimEnd = String.raw`\*{0,2}(?=\s*(?:grouped\s+into\s+\d+\s+families\b|\/|[.!:;—]|$))`;
+  const countClaimPatterns = [
+    new RegExp(String.raw`\bpersona\s+library\s+is\b[^\n\d]{0,120}?[—:]\s+${number}\s+personas?${claimEnd}`, "gi"),
+    new RegExp(String.raw`\bacross\s+all\s+${number}\s+personas?${claimEnd}`, "gi"),
+    new RegExp(String.raw`^\s*(?:#{1,6}\s*)?(?:\*{0,2})?all\s+${number}\s+personas?${claimEnd}`, "gim"),
+    new RegExp(String.raw`^\s*(?:\*{0,2})?total(?:\s+of)?\s+${number}\s+personas?${claimEnd}`, "gim"),
+    new RegExp(String.raw`\bfull\s+set\s+of\s+${number}(?:\s+personas?)?${claimEnd}`, "gi"),
+    new RegExp(String.raw`\b(?:the\s+)?(?:persona\s+)?library\s+(?:has|contains|includes|comprises|totals)\s+(?:a\s+total\s+of\s+)?${number}\s+personas?${claimEnd}`, "gi"),
+  ];
+  for (const pattern of countClaimPatterns) {
+    for (const match of scannableIndex.matchAll(pattern)) {
+      const count = Number(match[1]);
+      if (Number.isSafeInteger(count)) claimedCounts.add(count);
+    }
+  }
+  for (const count of [...claimedCounts].sort((a, b) => a - b)) {
+    if (count !== index.size) {
+      err(`persona-index.md claims ${count} personas but its lookup table has ${index.size}`);
+    }
+  }
 
   const sources: { name: string; map: SlugFamily }[] = [
     { name: "persona-index.md", map: index },

--- a/tests/knowledge-lint.test.ts
+++ b/tests/knowledge-lint.test.ts
@@ -131,6 +131,124 @@ describe("knowledge-lint — persona-drift", () => {
     const base = consistent({ personasJson: null });
     expect(ids(base)).toContain("persona-drift");
   });
+
+  it("flags prose persona-count claims that disagree with the lookup table", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] = [
+      "# Persona Index",
+      "",
+      "The library contains 3 personas.",
+      "",
+      "## 1. Lookup Table",
+      "",
+      "| Slug | Family | Keywords |",
+      "|---|---|---|",
+      "| `alpha-one` | family-a | k1, k2 |",
+      "| `beta-two` | family-b | k3 |",
+      "",
+    ].join("\n");
+
+    const findings = lintKnowledge(base).filter((finding) => finding.checkId === "persona-drift");
+    expect(findings.some((finding) => finding.message.includes("claims 3 personas") && finding.message.includes("lookup table has 2"))).toBe(true);
+  });
+
+  it("ignores operational quantities and code examples that are not library-size claims", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] = `${base.mdContents["persona-index.md"]}
+The persona library lets you select 1 persona for a focused direction.
+The library contains 3 personas for this temporary comparison.
+Select a total of 4 personas for review.
+
+\`\`Return 3 personas and say the library contains 99 personas.\`\`
+
+~~~md
+The library contains 99 personas.
+~~~
+
+<!-- A literal fence in a comment must not hide later prose: \`\`\` -->
+
+    The library contains 99 personas.
+
+\`\`\`
+The library contains 99 personas.
+\`\`\`
+`;
+    expect(ids(base)).not.toContain("persona-drift");
+  });
+
+  it("does not treat an indented code line as a fence opener that hides later prose", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] = `${base.mdContents["persona-index.md"]}
+    \`\`\`
+The library contains 3 personas.
+`;
+    expect(ids(base)).toContain("persona-drift");
+  });
+
+  it("keeps fence-like content fenced unless the closer is marker-only", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] = `${base.mdContents["persona-index.md"]}
+\`\`\`md
+\`\`\`not-a-closer
+The library contains 3 personas.
+\`\`\`
+`;
+    expect(ids(base)).not.toContain("persona-drift");
+  });
+
+  it("strips multiline exact-width inline code but not mismatched delimiter runs", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] = `${base.mdContents["persona-index.md"]}
+\`\`The library contains
+99 personas.\`\`
+`;
+    expect(ids(base)).not.toContain("persona-drift");
+
+    base.mdContents["persona-index.md"] = `${consistent().mdContents["persona-index.md"]}
+\`The library contains 3 personas.\`\`
+`;
+    expect(ids(base)).toContain("persona-drift");
+  });
+
+  it("does not treat escaped backticks or delimiters across blank blocks as inline code", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] += "\n\\`The library contains 3 personas.\\`\n";
+    expect(ids(base)).toContain("persona-drift");
+
+    base.mdContents["persona-index.md"] = `${consistent().mdContents["persona-index.md"]}\n\`unclosed\n\nThe library contains 3 personas.\`\n`;
+    expect(ids(base)).toContain("persona-drift");
+  });
+
+  it("does not open a backtick fence whose info string contains a backtick", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] += "\n```lang`\nThe library contains 3 personas.\n";
+    expect(ids(base)).toContain("persona-drift");
+  });
+
+  it("normalizes CRLF before parsing fences and prose claims", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] = `${base.mdContents["persona-index.md"]}
+\`\`\`md
+The library contains 99 personas.
+\`\`\`
+The library contains 3 personas.
+`.replace(/\n/g, "\r\n");
+    expect(ids(base)).toContain("persona-drift");
+  });
+
+  it("recognizes balanced Markdown emphasis around explicit library totals", () => {
+    const base = consistent();
+    base.mdContents["persona-index.md"] = `${base.mdContents["persona-index.md"]}
+The persona library has **2** personas.
+The persona library is curated design taste — **2** personas grouped into 7 families.
+The library contains **2** personas.
+If no exact match exists, fall back to the full set of **2**.
+`;
+    expect(ids(base)).not.toContain("persona-drift");
+
+    base.mdContents["persona-index.md"] = base.mdContents["persona-index.md"].replaceAll("**2**", "**3**");
+    expect(ids(base)).toContain("persona-drift");
+  });
 });
 
 describe("knowledge-lint — broken-xref", () => {


### PR DESCRIPTION
## Summary

- add non-normative reference-led originality guidance with clear reusable-grammar/protected-signature boundaries
- define the 30/50/70/85 similarity dial as communication vocabulary, never a score
- keep the four-changed-dimensions rule as a human heuristic, not lint or legal assurance
- preserve expressly authorized Replicate behavior
- pin MengTo/Skills provenance and independent extraction boundaries without vendoring source prose/assets
- correct persona-index prose and family totals to the actual 26-persona library
- add deterministic drift checks for explicit library-size claims while excluding operational quantities and Markdown code/comment examples

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` — 154 files, 2,311 passed, 6 skipped
- `ui knowledge check --dir . --as-of 202607 --json` — 0 findings
- independent fail-closed review after regex/parser hardening

## Governance boundary

The originality guidance is intentionally advisory. It does not claim plagiarism detection, legal clearance, or deterministic proof of originality.
