### PR TITLE
docs: point figma-agent-hand.md at Slides (companion to plugin PR #28)

### DIFF
--- a/knowledge/figma-agent-hand.md
+++ b/knowledge/figma-agent-hand.md
@@ -211,16 +211,25 @@ The plugin repo (github.com/jangtrinh/design-os-figma-plugin) carries its own
   `ui.componentSet`, …) refuse there** naming FigJam vs. the editor they need — the
   same `requireEditor` guard every `ui.figjam.*` helper carries in reverse; a design
   file behaves exactly as before this phase (regression-checked).
+- `knowledge/slides.md` — `ui.slides.*` (list/grid/content, create/remove/duplicate/
+  reorder, transitions, viewMode/focused/focus/skip, background, addText/addShape):
+  the Slides deck surface (`editorType` now widens to `["figma","figjam","slides"]`).
+  **Design-only commands refuse there too**, same reverse `requireEditor` guard as
+  FigJam — a design file and a FigJam board both behave exactly as before this phase
+  (regression-checked). Also documents that `viewMode`/`focus`'s view-change side
+  effect is NOT covered by `--undo-group` — a script that navigates and then throws
+  leaves the user on a different slide even though `rolledBack: true` covers content.
 
 **`status` shape, additive field (absorption phase-02):** `plugin.editorType` —
 `'figma' | 'figjam' | 'slides' | 'dev' | null`, read directly off `figma.editorType`;
 `null` (never a silent `'figma'` default) when an older host reports nothing. Consumed
 by the plugin repo's `shared/editor-surface.ts` guard (phase 03: FigJam, wired;
-phase 04: Slides, not yet).
+phase 04: Slides, wired — this absorption track's baskets A+B are now complete).
 
-**`status` shape, additive field (absorption phase-03):** `plugin.bootSkipped` — a
-string array naming which design-only boot capabilities this session consciously
-skipped (present only once non-empty, same contract as the broker's
-`senderMismatchCount`/`legacyMigrationDeferred`). Empty today: the phase-03 boot-path
-trace found nothing in the current boot sequence needs skipping in FigJam — the
-live-sync capture path already reports FigJam node types honestly by construction.
+**`status` shape, additive field (absorption phase-03, extended phase-04):**
+`plugin.bootSkipped` — a string array naming which design-only boot capabilities this
+session consciously skipped (present only once non-empty, same contract as the
+broker's `senderMismatchCount`/`legacyMigrationDeferred`). Empty today: neither the
+phase-03 (FigJam) nor phase-04 (Slides) boot-path trace found anything in the current
+boot sequence that needs skipping — the live-sync capture path reports both editors'
+native node types honestly by construction.


### PR DESCRIPTION
Small companion doc PR for design-os-figma-plugin#28 (absorption phase-04: Figma
Slides, the last phase of the capability-absorption track), mirroring the pattern
used for the phase-02 (#109) and phase-03 (#110) companions.

## What changed

knowledge/figma-agent-hand.md's "More recipes" section:

- New bullet pointing at the plugin repo's knowledge/slides.md: ui.slides.*
  (list/grid/content, create/remove/duplicate/reorder, transitions, viewMode/
  focused/focus/skip, background, addText/addShape), the reverse requireEditor
  refusal for design-only commands, and the "navigation is not undoable" caveat for
  viewMode/focus.
- Updated the existing plugin.editorType status-shape note: phase 04 (Slides) is
  now wired, not "not yet" -- this absorption track's baskets A+B are complete.
- Updated the plugin.bootSkipped status-shape note to reflect BOTH the phase-03
  (FigJam) and phase-04 (Slides) boot-path traces finding nothing to skip.

No code changes -- this repo only carries the knowledge pointer, per the existing
split between this monorepo and design-os-figma-plugin.

## Verification

- Doc-only change, no other surface affected here.
- Merges independently of design-os-figma-plugin#28; not sequenced.