### PR TITLE
feat: expose linters as the ease-design/lint subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ease-design",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Multi-runtime design-cli — describe what you want, get pro-taste UI.",
   "type": "module",
   "keywords": [
@@ -22,6 +22,10 @@
   "homepage": "https://github.com/jangtrinh/design-os#readme",
   "bin": {
     "ui": "./dist/cli.js"
+  },
+  "exports": {
+    "./lint": "./dist/lint.js",
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,0 +1,13 @@
+// Public `ease-design/lint` subpath — the HTML/content linters exposed as a stable
+// library API so downstream consumers (e.g. the Figma-plugin panel gate) can import
+// them from the published package instead of vendoring the kernel by path/submodule.
+//
+// Surface = the content-page linter family: layout, accessibility, taste, the
+// content-copy checks, and design-system-usage. Each module namespaces its own
+// Severity/Finding/Result types, so a flat re-export is collision-free. The `ui`
+// binary is unaffected — this is an additive second entry point, not a CLI change.
+export * from "./core/layout-lint.js";
+export * from "./core/a11y-lint.js";
+export * from "./core/taste-lint.js";
+export * from "./core/content-checks.js";
+export * from "./core/ds-usage-lint.js";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,9 +3,16 @@ import { defineConfig } from "tsup";
 // Bundles the `ui` binary. The shebang is injected here (not in source) so the
 // build output has exactly one, and `src/cli.ts` stays plain TypeScript.
 export default defineConfig({
-  entry: { cli: "src/cli.ts" },
+  // `cli` is the `ui` binary; `lint` is the public `ease-design/lint` library entry
+  // (the shebang banner below applies to every entry, but a library import ignores a
+  // leading shebang line, so it is harmless on `lint`).
+  entry: { cli: "src/cli.ts", lint: "src/lint.ts" },
   format: ["esm"],
   target: "node20",
+  // No `dts` yet: enabling it trips the repo's pre-existing `baseUrl` deprecation
+  // (TS5101) through tsup's stricter dts pass. The sole current consumer imports the
+  // linters untyped by design, so ship the runtime now and add types in a follow-up
+  // once the tsconfig deprecation is addressed on its own.
   clean: true,
   banner: { js: "#!/usr/bin/env node" },
 });


### PR DESCRIPTION
## What
Makes the kernel linters a public library API at `ease-design/lint`, so downstream consumers (starting with the design-os-figma-plugin panel gate, which currently vendors them via a git submodule) can import them from the published package.

- `src/lint.ts` — a barrel re-exporting the content-page linter family: layout, a11y, taste, content-checks, ds-usage. Each module namespaces its own Severity/Finding/Result types, so the flat re-export is collision-free (verified: zero duplicate export names across the five).
- `tsup.config.ts` — adds a `lint` build entry alongside the `ui` bin.
- `package.json` — adds `exports` mapping the `./lint` subpath to the built lint bundle (plus `./package.json`); version 0.1.0 to 0.2.0 (additive minor).

## Verified
- `typecheck` pass, `tsup` build success (emits the lint bundle), `eslint` clean on the changed files.
- The subpath resolves via the exports map and re-exports the exact 4 symbols the plugin panel gate consumes — `lintLayout`, `lintA11y`, `lintTaste`, `allContentChecks` (16 exports total; `allContentChecks` is an array). Confirmed with a self-package `import('ease-design/lint')`.
- Only 3 tracked files changed; the build-output dir is gitignored (built at publish via `prepublishOnly`). The repo's full test suite is long — not run to completion here; CI/reviewer runs it. The change is additive packaging, no existing logic touched.

## Deliberately deferred
- **Types**: no `dts` yet — enabling tsup's dts pass trips the repo's pre-existing `baseUrl` deprecation (TS5101). The sole current consumer imports these untyped by design, so this ships runtime-only; a typed `./lint` is a follow-up once the tsconfig deprecation is addressed separately.
- **`npm publish`**: NOT done here — this PR only stages the export. Publishing `ease-design@0.2.0` is an owner-authorized release. After it publishes, the plugin side (design-os-figma-plugin #9) swaps its `kernel/design-os` submodule for the `ease-design` npm dep.