### PR TITLE
fix: bump CLI VERSION to 0.2.0 (match package.json)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ import { promptPlanCommand } from "./commands/prompt-plan.js";
 
 // Keep in sync with package.json "version". A test (tests/cli-version.test.ts)
 // asserts these match, so drift fails CI rather than shipping silently.
-const VERSION = "0.1.0";
+const VERSION = "0.2.0";
 
 // ─── Command registry ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-up to #113 (which bumped package.json to 0.2.0). `src/cli.ts`'s hardcoded `VERSION` — which its own comment flags must stay in sync with package.json — was left at 0.1.0, so `tests/cli-version.test.ts` ('`ui --version` matches package.json version, no drift') fails and blocks `prepublishOnly`. One-line bump to 0.2.0. typecheck clean.