### PR TITLE
fix: stop shipping a customer's codebase as generic instruction text

### DIFF
--- a/templates/journeys/onboard.md
+++ b/templates/journeys/onboard.md
@@ -122,7 +122,7 @@ interchangeable:
 not touch any manifest. `ui ds import --name <slug>` is the one that seals
 `design/ds.manifest.json`'s `name` field — and if you omit it, the default is the **literal
 string `imported-ds`**. That string then becomes the identity `ui agents init` names every
-generated agent after (`designer-imported-ds` instead of `designer-vsf-pcp`). Always pass an
+generated agent after (`designer-imported-ds` instead of `designer-<your-ds>`). Always pass an
 explicit, real `--name` on whichever command seals the manifest, before running
 `ui agents init`.
 
@@ -196,7 +196,7 @@ Python source, so the schema below is the ground truth, verified against
     { "id": "preview-pages", "type": "audit-pages", "interval": "1d",
       "params": { "dir": "design/preview" } },
     { "id": "figma-hygiene", "type": "figma-audit", "interval": "7d",
-      "params": { "file": "VSF - PCP" } }
+      "params": { "file": "Design System" } }
   ]
 }
 ```

--- a/templates/workflows/learn.md
+++ b/templates/workflows/learn.md
@@ -221,11 +221,11 @@ merely remembers or infers is GUESS-grade — exclude it and list it under
 #### Step 3d — Component record shape for a code source (D1/D2/D4)
 
 A code source needs three decisions an HTML page never raises, and they are
-RESOLVED — do not re-derive them (spec 009 D1/D2/D4, from measuring dana +
-platform-design-system + the `ds init` kit):
+RESOLVED — do not re-derive them (spec 009 D1/D2/D4, from measuring two real React
+kits + the `ds init` kit):
 
 1. **One record per component, not per variant** (D1). A component's variant ×
-   size × radius matrix is **one** registry entry — dana's `Button` (8 tones ×
+   size × radius matrix is **one** registry entry — a measured React kit's `Button` (8 tones ×
    3 sizes × 3 radii = 72 combinations) is `Control/Button`, not 72 records.
    The matrix lives inside that one record's `variants` array. Name it
    `Category/Component` (`registry-store.ts:74`'s `NAME_PATTERN`,
@@ -236,7 +236,7 @@ platform-design-system + the `ds init` kit):
 2. **Axis names are the source's own prop names, PascalCased** (D2). If the
    component declares a prop literally named `variant`, the axis is
    `Variant=` (`variant="primary"` → `Variant=Primary`); a `size` prop is
-   `Size=`. Do **not** re-interpret a prop name into a house term — dana's
+   `Size=`. Do **not** re-interpret a prop name into a house term — a source's
    `variant` stays `Variant`, it never becomes `Tone`. If a prop name collides
    with `State` (step 3b), the source's own name wins; record the collision
    in the summary.
@@ -246,10 +246,10 @@ platform-design-system + the `ds init` kit):
    it. A specimen sheet (kit-style: a wrapper + rows showing the variant
    matrix) is the honest equivalent for a code source, with one hard rule:
    every cell must trace to a class string the source actually declares —
-   dana's `variantClasses.primary` in `Button.tsx` is right there, copy it
+   a kit's `variantClasses.primary` in `Button.tsx` is right there, copy it
    verbatim. A cell you cannot trace, you do not draw; list it under
    "unverified" (step 3c). **Never render the component** to obtain markup —
-   no jsdom, no testing-library, no dev server, even though dana has the
+   no jsdom, no testing-library, no dev server, even though the source repo has the
    toolchain to do exactly that — rendering a user's code is a No-Go
    (`brainstorm.md` §7).
 

--- a/templates/workflows/why.md
+++ b/templates/workflows/why.md
@@ -50,7 +50,7 @@ Do **not** narrate from imagination. Read only what the ledger returns.
 Compose a short, direct answer that **traces the decision**:
 
 - Cite the event id(s), the date, and the actor for every factual claim
-  ("picked on 2026-07-08 (`e12`, by jang)…").
+  ("picked on 2026-07-08 (`e12`, by `<actor>`)…").
 - For a token question, quote the `from → to` and the recorded `reason`.
 - For a persona/variant question, use the `user_pick` (chosen vs rejected) and
   any `taste_verdict` that explains a rejection (its `lowestAxis`).


### PR DESCRIPTION
`templates/` ships in the npm tarball — it is part of the 116 files every user installs. Five passages in `templates/workflows/learn.md` taught the reader about one specific onboarded project **by name**: its `Button`'s tone × size × radius matrix, its `variantClasses.primary` in `Button.tsx`, the test toolchain it happens to have.

The rules those passages teach are correct and unchanged. Only the customer's identity is removed — the concrete shape (8 tones × 3 sizes × 3 radii = 72 combinations) stays, because the concreteness is what makes the rule land.

Also removed: a real Figma file name from `onboard.md`'s heartbeat example, and a real person's name from `why.md`'s provenance example.

## What is deliberately NOT changed

**Provenance markers** naming a source project (`figma-craft/*`: *"distilled from the VSF-PCP field skill, dogfood 2026-07-13"*, `token-taxonomy.md`: *"VSF dogfood over-pairing"*). `authoring-standard.md` requires provenance; these record **where a fact came from**, they do not instruct the reader about someone else's repo. A check that flagged them would go red on the files that follow the standard best.

**`vsf-pcp` / `JANG` as the worked example for agent genealogy.** Measured before deciding: those strings are woven through `src/commands/agents.ts` help text, `src/core/agents-gen.ts` docstrings, `src/core/ds-soul-studio.ts`'s **scaffold text users receive**, and ~60 test assertions across `agents-gen` / `cmd-agents` / `ds-soul` / `cmd-ds-context`. That is a cross-cutting rename, not a templates edit — filed separately so this PR stays one topic.

## Gates

`typecheck` · `lint` · `build` pass · `ui knowledge check` **0 findings** · `npm pack --dry-run` unchanged at 116 files · the six adapter/template suites that assert on this text: **89/89 pass**.