### PR TITLE
fix(test): copy the whole build dir, not cli.js alone

### DIFF
--- a/tests/cmd-init-built-binary.test.ts
+++ b/tests/cmd-init-built-binary.test.ts
@@ -21,12 +21,25 @@ import {
   rmSync,
   readFileSync,
   writeFileSync,
-  copyFileSync,
+  cpSync,
   symlinkSync,
 } from "node:fs";
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const DIST_CLI = join(REPO_ROOT, "dist", "cli.js");
+const DIST_DIR = join(REPO_ROOT, "dist");
+const DIST_CLI = join(DIST_DIR, "cli.js");
+
+/**
+ * Copy the WHOLE build directory, never `cli.js` alone. tsup code-splits: `cli.js`
+ * carries a bare `import "./chunk-<hash>.js"`, so a lone copy dies with
+ * ERR_MODULE_NOT_FOUND before it writes a byte to stdout — which reads here as
+ * "exit 1, empty output", i.e. a fake product bug. The npm package ships the same
+ * way (`files: ["dist"]`), so copying the directory is also the faithful shape.
+ */
+function copyBuiltCli(destDistDir: string): string {
+  cpSync(DIST_DIR, destDistDir, { recursive: true });
+  return join(destDistDir, "cli.js");
+}
 
 const tmpDirs: string[] = [];
 function makeTmpDir(): string {
@@ -198,7 +211,7 @@ describe("templates walk: sentinel sniff rejects decoy and finds real templates"
     const fakePkgDir = join(root, "fake-pkg");
     const fakeDistDir = join(fakePkgDir, "dist");
     mkdirSync(fakeDistDir, { recursive: true });
-    copyFileSync(DIST_CLI, join(fakeDistDir, "cli.js"));
+    copyBuiltCli(fakeDistDir);
 
     // Decoy templates inside fake-pkg/ — exists but lacks workflows/generate.md
     const decoyTemplates = join(fakePkgDir, "templates");
@@ -233,7 +246,7 @@ describe("templates walk: sentinel sniff rejects decoy and finds real templates"
     // fake-pkg/dist/cli.js — isolated binary with no real templates above it
     const fakeDistDir = join(root, "fake-pkg", "dist");
     mkdirSync(fakeDistDir, { recursive: true });
-    copyFileSync(DIST_CLI, join(fakeDistDir, "cli.js"));
+    copyBuiltCli(fakeDistDir);
 
     // Decoy only — no workflows/generate.md anywhere above the binary
     const decoy = join(root, "fake-pkg", "templates");


### PR DESCRIPTION
Two of the six tests failing on `main`'s CI since at least 2026-08-01.

## Cause

`tsup` code-splits. The build emits `cli.js`, `chunk-<hash>.js`, and `lint.js`, and `cli.js` carries a bare `import "./chunk-ZFDNAKGR.js"`.

Two tests copy the real binary into a fake package to prove the templates sentinel sniff skips a decoy `templates/`. They copied **only `cli.js`**, so the copy died with `ERR_MODULE_NOT_FOUND` before writing a byte to stdout. That surfaced as `expected exit 0 but got 1; stdout: (empty)` and `SyntaxError: Unexpected end of JSON input` — reading like a product bug rather than a copy that was never runnable.

Reproduced deterministically:

```
$ cp dist/cli.js $TMP/ && node $TMP/cli.js --version
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../chunk-ZFDNAKGR.js'

$ cp -R dist/. $TMP2/ && node $TMP2/cli.js --version
0.2.0
```

## Fix

One `copyBuiltCli()` helper that copies the whole build directory, used at both sites. The npm package ships `files: ["dist"]`, so the chunk always travels with the binary — copying the directory is also the faithful shape of what a user installs. The comment says why, so the next split does not re-open this.

**The product was never broken.** Only the test's assumption of a single-file bundle was.

## Not fixed here

The other four failing tests (`change-log-stream`, `figma-apply-map`, `scale-baseline`) share a different cause: they read a baseline at `plans/260730-0847-registry-integrity/scale-baseline.json`, and `plans/` is gitignored (`.gitignore:57`), so the file can never reach a clean clone or CI. That needs a design decision, filed separately.

## Verification

`tests/cmd-init-built-binary.test.ts`: **7 passed / 2 failed** on clean `origin/main` before → **9 passed** after. `typecheck` and `lint` pass.