### PR TITLE
feat(knowledge): emit a routing index so an agent picks a file without reading the table

### DIFF
--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -5,7 +5,18 @@ deterministic `ui` binary). These are **plain-Markdown files the host AI model r
 directly** while designing UI — curated design taste that sets the quality floor.
 
 > **Selective reading.** Open only the file(s) a task needs — never load the whole core.
-> Each file is self-contained; the task map below routes you to the right one.
+> Each file is self-contained.
+
+## Routing — start at `index.json`, not at this table
+
+`knowledge/index.json` is the machine-read map: one entry per file with its `id`, `path`,
+a one-sentence `description`, and the `when` tags a task matches on. It is a few kilobytes
+— read it, pick the file, open that file. **Prefer it over the table below**, whose cells
+run past a thousand characters each and cost far more to load than the file they point to.
+
+The index is emitted from each file's front-matter by `ui knowledge index --emit`, and
+`ui knowledge check` fails if it drifts from the files it came from. The table below stays
+for a human reading top to bottom.
 
 ## The files
 

--- a/knowledge/accessibility.md
+++ b/knowledge/accessibility.md
@@ -1,3 +1,9 @@
+---
+id: accessibility
+description: "The two-tier a11y model — what static checks can and cannot prove, and the never-claim-compliant rule."
+when: [accessibility, a11y, contrast, wcag, screen-reader, focus, aria]
+---
+
 # Accessibility — the two-tier model, and why neither tier is a conformance claim
 
 Accessibility is a property of a real person's *experience* of a UI — not a checkbox a tool

--- a/knowledge/asset-production-orchestration.md
+++ b/knowledge/asset-production-orchestration.md
@@ -1,3 +1,9 @@
+---
+id: asset-production-orchestration
+description: "Ordering and gating a multi-asset production run so generated media arrives usable."
+when: [asset-production, media-pipeline, batch-generation, orchestration]
+---
+
 # Asset Production Orchestration
 
 ## Purpose

--- a/knowledge/authoring-standard.md
+++ b/knowledge/authoring-standard.md
@@ -1,3 +1,9 @@
+---
+id: authoring-standard
+description: "The meta-standard for writing knowledge/ files — file frame, constraint language, provenance grammar."
+when: [authoring, knowledge-file, writing-standard, provenance, ease-source]
+---
+
 # Authoring Standard — how to write a knowledge/ file
 
 ## Purpose
@@ -24,6 +30,43 @@ host model as its brain; they carry the quality floor.
 **Do NOT** apply it to code comments, to `plans/**`, to spec/PR prose, or to anything the
 model does not read as standing knowledge. Those have their own conventions; forcing this
 frame onto them adds ceremony without a reader who benefits.
+
+## Routing front-matter
+
+Every top-level `knowledge/*.md` opens with a three-key block. It is what makes the file
+**findable** — without it the file exists but no task can route to it:
+
+```markdown
+---
+id: motion-craft
+description: "The animation decision ladder T1 CSS to T6 WebGL, and the motion floors."
+when: [motion, animation, transition, reduced-motion, motion-tier, easing]
+---
+```
+
+- **`id`** MUST equal the filename without `.md`. That is how another file refers to this
+  one without hard-coding a path, so a later move does not break the reference.
+- **`description`** is ONE sentence — what a reader gets by opening the file. It is the
+  line a router shows next to the path, not a summary of the contents.
+- **`when`** is the routing signal: the words a *task* uses, not the words the file's own
+  headings use. Lowercase and hyphenated, so a match is exact and a diff is stable. Write
+  the terms a person would actually type ("scroll-animation", "contrast"), and include the
+  ones that should land here rather than somewhere adjacent.
+
+Three keys, no more. `tier`, `status`, `scope`, and `requires` were all considered and
+cut: each was a field a linter would have to keep honest, and none of them changed which
+file a task should open. Add a fourth key only when a routing decision cannot be made
+without it.
+
+`ui knowledge index --emit` compiles these blocks into `knowledge/index.json` — one small
+machine-read map, so an agent picks a file without loading the README's prose table. The
+emitter is deterministic; the checker (`index-frontmatter-missing`, `index-frontmatter-bad`,
+`index-drift`) fails the moment a block is absent, malformed, or the committed index stops
+matching the files it came from. **Edit a block, re-run `--emit`, commit both.**
+
+`personas/**`, `figma-craft/**`, `canvas-ui/**`, and `benchmarks/**` carry no block on
+purpose: they route through their own entry file or are data rather than prose. Tagging
+them individually would grow the index without giving a task a new place to land.
 
 ## The standard file frame
 

--- a/knowledge/canvas-effect-direction.md
+++ b/knowledge/canvas-effect-direction.md
@@ -1,3 +1,9 @@
+---
+id: canvas-effect-direction
+description: "The T6 external-effect direction for Canvas UI — 25 named WebGL effects, the one-per-viewport cap, and the install handoff."
+when: [canvas, webgl, shader, effect, t6, canvas-ui, external-effect]
+---
+
 # Canvas UI External-Effect Direction
 
 ## Purpose

--- a/knowledge/color-science.md
+++ b/knowledge/color-science.md
@@ -1,3 +1,9 @@
+---
+id: color-science
+description: "OKLCH reasoning, WCAG contrast targets, 11-stop scale generation, semantic role mapping."
+when: [color, palette, oklch, contrast, color-scale, hue, semantic-color]
+---
+
 # Color Science
 
 How to reason about color for UI design: which color space to think in, how

--- a/knowledge/component-catalog.md
+++ b/knowledge/component-catalog.md
@@ -1,3 +1,9 @@
+---
+id: component-catalog
+description: "32 reusable components across 8 categories, with a generation spec for each."
+when: [component, catalog, button, form, navigation, card, table]
+---
+
 # Component Catalog
 
 A curated library of **32 reusable UI components** organized into **8 categories**. Each

--- a/knowledge/content-design.md
+++ b/knowledge/content-design.md
@@ -1,3 +1,9 @@
+---
+id: content-design
+description: "Voice, tone, the error-message standard, i18n readiness, and the deterministic microcopy floor."
+when: [copy, microcopy, tone, voice, error-message, i18n, content]
+---
+
 # Content design — voice, tone, and the microcopy floor
 
 Copy is half the interface. This is the *thinking* (voice + tone + patterns); the deterministic floor

--- a/knowledge/delivery-assets.md
+++ b/knowledge/delivery-assets.md
@@ -1,3 +1,9 @@
+---
+id: delivery-assets
+description: "Resolving reproduced images to originals — the ladder that ends at screenshot-crop as last resort."
+when: [asset, image-resolution, logo, screenshot-crop, asset-map, clone]
+---
+
 # Delivery Assets — resolve to originals, never screenshot crops
 
 ## Purpose

--- a/knowledge/design-agents.md
+++ b/knowledge/design-agents.md
@@ -1,3 +1,9 @@
+---
+id: design-agents
+description: "Soul-bound, task-scoped project agents — roles, boundaries, naming, and the opt-in roster."
+when: [agent, roster, designer-agent, curator-agent, figma-hand, agent-identity]
+---
+
 # Design Agents — soul-bound, task-scoped identities
 
 A design agent is a **soul-bound identity with a task scope**, generated as a real

--- a/knowledge/design-review.md
+++ b/knowledge/design-review.md
@@ -1,3 +1,9 @@
+---
+id: design-review
+description: "The git-native design review and engineering handoff flow."
+when: [review, design-pr, handoff, release-notes, diff]
+---
+
 # Design review & handoff — the git-native flow
 
 ease-design's artefacts are **text in git** — `design/design.tokens.json` (DTCG),

--- a/knowledge/design-soul.md
+++ b/knowledge/design-soul.md
@@ -1,3 +1,9 @@
+---
+id: design-soul
+description: "The declared design stance — Never/Always/Voice and its place in the precedence chain."
+when: [soul, stance, brand-voice, never-always, design-principles]
+---
+
 # Design Soul — the declared stance
 
 `design/soul.md` is the project's **declared** design stance: a short, owner-ratified

--- a/knowledge/designmd-format.md
+++ b/knowledge/designmd-format.md
@@ -1,3 +1,9 @@
+---
+id: designmd-format
+description: "The DESIGN.md contract — the YAML token front-matter plus the eight fixed sections."
+when: [designmd, design-md, token-frontmatter, google-labs]
+---
+
 # DESIGN.md format (Google Labs alpha)
 
 Pinned on-disk reference for the open-source DESIGN.md spec authored by

--- a/knowledge/figma-agent-hand.md
+++ b/knowledge/figma-agent-hand.md
@@ -1,3 +1,9 @@
+---
+id: figma-agent-hand
+description: "Driving the figma-agent CLI — the optional Figma hand outside the deterministic binary."
+when: [figma-agent, figma-cli, figma-hand, plugin]
+---
+
 # figma-agent CLI — hands & eyes on the Figma canvas
 
 Drive Figma from Claude Code via the `figma-agent` CLI (no MCP) — create

--- a/knowledge/flow-craft.md
+++ b/knowledge/flow-craft.md
@@ -1,3 +1,9 @@
+---
+id: flow-craft
+description: "Designing a multi-screen flow — the flow.json model and the deterministic flow lint."
+when: [flow, multi-screen, user-flow, screen-states, transition, journey]
+---
+
 # Flow craft — designing a multi-screen flow
 
 A single screen is a frame; a product is a **flow**. `flow.json` is the smallest true model of

--- a/knowledge/generation-craft-defaults.md
+++ b/knowledge/generation-craft-defaults.md
@@ -1,3 +1,9 @@
+---
+id: generation-craft-defaults
+description: "Implementation-grade generation defaults — asset policy, responsive rules, motion and loading floors."
+when: [generation-defaults, responsive, icons, loading-state, custom-control]
+---
+
 # Generation Craft Defaults
 
 Read this with `qualified-delivery.md` when generating code. These defaults raise the

--- a/knowledge/gsap-motion-direction.md
+++ b/knowledge/gsap-motion-direction.md
@@ -1,3 +1,9 @@
+---
+id: gsap-motion-direction
+description: "The T5 GSAP direction and implementation contract — timelines, ScrollTrigger, lifecycle, reduced motion."
+when: [gsap, scrolltrigger, timeline, scroll-animation, motion-t5, pin]
+---
+
 # GSAP Motion Direction
 
 > Adapted from the official [GreenSock GSAP Skills](https://github.com/greensock/gsap-skills)

--- a/knowledge/index.json
+++ b/knowledge/index.json
@@ -1,0 +1,420 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "accessibility",
+      "path": "knowledge/accessibility.md",
+      "description": "The two-tier a11y model — what static checks can and cannot prove, and the never-claim-compliant rule.",
+      "when": [
+        "accessibility",
+        "a11y",
+        "contrast",
+        "wcag",
+        "screen-reader",
+        "focus",
+        "aria"
+      ]
+    },
+    {
+      "id": "asset-production-orchestration",
+      "path": "knowledge/asset-production-orchestration.md",
+      "description": "Ordering and gating a multi-asset production run so generated media arrives usable.",
+      "when": [
+        "asset-production",
+        "media-pipeline",
+        "batch-generation",
+        "orchestration"
+      ]
+    },
+    {
+      "id": "authoring-standard",
+      "path": "knowledge/authoring-standard.md",
+      "description": "The meta-standard for writing knowledge/ files — file frame, constraint language, provenance grammar.",
+      "when": [
+        "authoring",
+        "knowledge-file",
+        "writing-standard",
+        "provenance",
+        "ease-source"
+      ]
+    },
+    {
+      "id": "canvas-effect-direction",
+      "path": "knowledge/canvas-effect-direction.md",
+      "description": "The T6 external-effect direction for Canvas UI — 25 named WebGL effects, the one-per-viewport cap, and the install handoff.",
+      "when": [
+        "canvas",
+        "webgl",
+        "shader",
+        "effect",
+        "t6",
+        "canvas-ui",
+        "external-effect"
+      ]
+    },
+    {
+      "id": "color-science",
+      "path": "knowledge/color-science.md",
+      "description": "OKLCH reasoning, WCAG contrast targets, 11-stop scale generation, semantic role mapping.",
+      "when": [
+        "color",
+        "palette",
+        "oklch",
+        "contrast",
+        "color-scale",
+        "hue",
+        "semantic-color"
+      ]
+    },
+    {
+      "id": "component-catalog",
+      "path": "knowledge/component-catalog.md",
+      "description": "32 reusable components across 8 categories, with a generation spec for each.",
+      "when": [
+        "component",
+        "catalog",
+        "button",
+        "form",
+        "navigation",
+        "card",
+        "table"
+      ]
+    },
+    {
+      "id": "content-design",
+      "path": "knowledge/content-design.md",
+      "description": "Voice, tone, the error-message standard, i18n readiness, and the deterministic microcopy floor.",
+      "when": [
+        "copy",
+        "microcopy",
+        "tone",
+        "voice",
+        "error-message",
+        "i18n",
+        "content"
+      ]
+    },
+    {
+      "id": "delivery-assets",
+      "path": "knowledge/delivery-assets.md",
+      "description": "Resolving reproduced images to originals — the ladder that ends at screenshot-crop as last resort.",
+      "when": [
+        "asset",
+        "image-resolution",
+        "logo",
+        "screenshot-crop",
+        "asset-map",
+        "clone"
+      ]
+    },
+    {
+      "id": "design-agents",
+      "path": "knowledge/design-agents.md",
+      "description": "Soul-bound, task-scoped project agents — roles, boundaries, naming, and the opt-in roster.",
+      "when": [
+        "agent",
+        "roster",
+        "designer-agent",
+        "curator-agent",
+        "figma-hand",
+        "agent-identity"
+      ]
+    },
+    {
+      "id": "design-review",
+      "path": "knowledge/design-review.md",
+      "description": "The git-native design review and engineering handoff flow.",
+      "when": [
+        "review",
+        "design-pr",
+        "handoff",
+        "release-notes",
+        "diff"
+      ]
+    },
+    {
+      "id": "design-soul",
+      "path": "knowledge/design-soul.md",
+      "description": "The declared design stance — Never/Always/Voice and its place in the precedence chain.",
+      "when": [
+        "soul",
+        "stance",
+        "brand-voice",
+        "never-always",
+        "design-principles"
+      ]
+    },
+    {
+      "id": "designmd-format",
+      "path": "knowledge/designmd-format.md",
+      "description": "The DESIGN.md contract — the YAML token front-matter plus the eight fixed sections.",
+      "when": [
+        "designmd",
+        "design-md",
+        "token-frontmatter",
+        "google-labs"
+      ]
+    },
+    {
+      "id": "figma-agent-hand",
+      "path": "knowledge/figma-agent-hand.md",
+      "description": "Driving the figma-agent CLI — the optional Figma hand outside the deterministic binary.",
+      "when": [
+        "figma-agent",
+        "figma-cli",
+        "figma-hand",
+        "plugin"
+      ]
+    },
+    {
+      "id": "flow-craft",
+      "path": "knowledge/flow-craft.md",
+      "description": "Designing a multi-screen flow — the flow.json model and the deterministic flow lint.",
+      "when": [
+        "flow",
+        "multi-screen",
+        "user-flow",
+        "screen-states",
+        "transition",
+        "journey"
+      ]
+    },
+    {
+      "id": "generation-craft-defaults",
+      "path": "knowledge/generation-craft-defaults.md",
+      "description": "Implementation-grade generation defaults — asset policy, responsive rules, motion and loading floors.",
+      "when": [
+        "generation-defaults",
+        "responsive",
+        "icons",
+        "loading-state",
+        "custom-control"
+      ]
+    },
+    {
+      "id": "gsap-motion-direction",
+      "path": "knowledge/gsap-motion-direction.md",
+      "description": "The T5 GSAP direction and implementation contract — timelines, ScrollTrigger, lifecycle, reduced motion.",
+      "when": [
+        "gsap",
+        "scrolltrigger",
+        "timeline",
+        "scroll-animation",
+        "motion-t5",
+        "pin"
+      ]
+    },
+    {
+      "id": "librarian-loop",
+      "path": "knowledge/librarian-loop.md",
+      "description": "The graduation procedure — the veto chain that turns a recorded gap into shared knowledge.",
+      "when": [
+        "librarian",
+        "gap",
+        "graduate",
+        "knowledge-evolution",
+        "insight"
+      ]
+    },
+    {
+      "id": "mode-constraints",
+      "path": "knowledge/mode-constraints.md",
+      "description": "The eight UI-mode constraint sets plus the universal hard style guide.",
+      "when": [
+        "ui-mode",
+        "mobile",
+        "desktop",
+        "dashboard",
+        "slide",
+        "admin",
+        "ecommerce",
+        "constraints"
+      ]
+    },
+    {
+      "id": "motion-craft",
+      "path": "knowledge/motion-craft.md",
+      "description": "The animation decision ladder T1 CSS to T6 WebGL, persona tier caps, and the motion floors.",
+      "when": [
+        "motion",
+        "animation",
+        "transition",
+        "reduced-motion",
+        "motion-tier",
+        "easing"
+      ]
+    },
+    {
+      "id": "page-structures",
+      "path": "knowledge/page-structures.md",
+      "description": "Shape before dress — the macrostructure catalog and the diversification rule.",
+      "when": [
+        "page-structure",
+        "layout-shape",
+        "landing-page",
+        "macrostructure",
+        "composition"
+      ]
+    },
+    {
+      "id": "persona-index",
+      "path": "knowledge/persona-index.md",
+      "description": "Compact lookup for all personas plus the auto-selection algorithm.",
+      "when": [
+        "persona",
+        "persona-pick",
+        "aesthetic",
+        "style-direction"
+      ]
+    },
+    {
+      "id": "prompt-modes",
+      "path": "knowledge/prompt-modes.md",
+      "description": "The replicate / enhance / adapt strategy modifiers for reference-driven generation.",
+      "when": [
+        "prompt-mode",
+        "replicate",
+        "enhance",
+        "adapt",
+        "reference-driven"
+      ]
+    },
+    {
+      "id": "prompt-plan-orchestration",
+      "path": "knowledge/prompt-plan-orchestration.md",
+      "description": "Weak request to production strategy — provenance-bound facets, structural directions, builder packet.",
+      "when": [
+        "prompt-plan",
+        "brief",
+        "facet",
+        "structural-direction",
+        "region-brief"
+      ]
+    },
+    {
+      "id": "qualified-delivery",
+      "path": "knowledge/qualified-delivery.md",
+      "description": "Weak prompt to evidence-qualified delivery — typed brief, generation contract, curator, honest statuses.",
+      "when": [
+        "qualified-delivery",
+        "generation-contract",
+        "curator",
+        "repair",
+        "delivery-status"
+      ]
+    },
+    {
+      "id": "recall-mind",
+      "path": "knowledge/recall-mind.md",
+      "description": "Driving the recall CLI — the semantic memory over the design ledger.",
+      "when": [
+        "recall",
+        "memory",
+        "semantic-search",
+        "ledger",
+        "rank"
+      ]
+    },
+    {
+      "id": "signature-devices",
+      "path": "knowledge/signature-devices.md",
+      "description": "The composable signature-move library — the one memorable gesture a persona layers on top.",
+      "when": [
+        "signature",
+        "signature-device",
+        "memorable",
+        "texture",
+        "marquee",
+        "grain"
+      ]
+    },
+    {
+      "id": "taste-rubric",
+      "path": "knowledge/taste-rubric.md",
+      "description": "The 6+1 axis taste model and the critique-gate pass thresholds.",
+      "when": [
+        "taste",
+        "critique",
+        "score",
+        "rubric",
+        "quality-gate",
+        "axis"
+      ]
+    },
+    {
+      "id": "token-taxonomy",
+      "path": "knowledge/token-taxonomy.md",
+      "description": "The DTCG token model — primitive vs semantic tiers, aliasing, and the paired role/foreground standard.",
+      "when": [
+        "token",
+        "design-token",
+        "semantic-token",
+        "alias",
+        "dtcg",
+        "token-naming"
+      ]
+    },
+    {
+      "id": "user-evidence",
+      "path": "knowledge/user-evidence.md",
+      "description": "Grounding design in real user evidence — the ledger and its anti-fabrication gate.",
+      "when": [
+        "evidence",
+        "user-research",
+        "quote",
+        "metric",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "id": "ux-psychology",
+      "path": "knowledge/ux-psychology.md",
+      "description": "UX laws, Gestalt perception, cognitive biases, trust, and cognitive-load management.",
+      "when": [
+        "ux-law",
+        "psychology",
+        "hicks-law",
+        "fitts-law",
+        "gestalt",
+        "cognitive-load",
+        "persuasion"
+      ]
+    },
+    {
+      "id": "versioning-semver",
+      "path": "knowledge/versioning-semver.md",
+      "description": "Semver for a design system — how a DS diff classifies breaking, additive, and patch changes.",
+      "when": [
+        "semver",
+        "versioning",
+        "breaking-change",
+        "ds-diff",
+        "release"
+      ]
+    },
+    {
+      "id": "visual-regression",
+      "path": "knowledge/visual-regression.md",
+      "description": "The rendered-output floor — what a VR gate catches that a code diff cannot, and why it flakes.",
+      "when": [
+        "visual-regression",
+        "vr",
+        "screenshot-diff",
+        "baseline",
+        "pixelmatch"
+      ]
+    },
+    {
+      "id": "world-class-learning-loop",
+      "path": "knowledge/world-class-learning-loop.md",
+      "description": "Qualification, art direction, and reusable learning — controlled trials and anti-overfitting promotion.",
+      "when": [
+        "learning-loop",
+        "trial",
+        "benchmark",
+        "art-direction",
+        "lesson"
+      ]
+    }
+  ]
+}

--- a/knowledge/librarian-loop.md
+++ b/knowledge/librarian-loop.md
@@ -1,3 +1,9 @@
+---
+id: librarian-loop
+description: "The graduation procedure — the veto chain that turns a recorded gap into shared knowledge."
+when: [librarian, gap, graduate, knowledge-evolution, insight]
+---
+
 # The librarian loop — graduating gaps into knowledge
 
 ## Purpose

--- a/knowledge/mode-constraints.md
+++ b/knowledge/mode-constraints.md
@@ -1,3 +1,9 @@
+---
+id: mode-constraints
+description: "The eight UI-mode constraint sets plus the universal hard style guide."
+when: [ui-mode, mobile, desktop, dashboard, slide, admin, ecommerce, constraints]
+---
+
 # Mode Constraints
 
 This file defines the **hard structural rules** for UI generation. Every design output

--- a/knowledge/motion-craft.md
+++ b/knowledge/motion-craft.md
@@ -1,3 +1,9 @@
+---
+id: motion-craft
+description: "The animation decision ladder T1 CSS to T6 WebGL, persona tier caps, and the motion floors."
+when: [motion, animation, transition, reduced-motion, motion-tier, easing]
+---
+
 # Motion Craft — the animation decision ladder
 
 Motion is persona-led: a data tool wants near-instant feedback, a marketing hero wants

--- a/knowledge/page-structures.md
+++ b/knowledge/page-structures.md
@@ -1,3 +1,9 @@
+---
+id: page-structures
+description: "Shape before dress — the macrostructure catalog and the diversification rule."
+when: [page-structure, layout-shape, landing-page, macrostructure, composition]
+---
+
 # Page Structures — shape before dress
 
 A persona decides how a page *looks*; a macrostructure decides how it is *shaped*. Two

--- a/knowledge/persona-index.md
+++ b/knowledge/persona-index.md
@@ -1,3 +1,9 @@
+---
+id: persona-index
+description: "Compact lookup for all personas plus the auto-selection algorithm."
+when: [persona, persona-pick, aesthetic, style-direction]
+---
+
 # Persona Index & Auto-Selection Rules
 
 The persona library is **curated design taste** — 26 personas grouped into 7 families.

--- a/knowledge/prompt-modes.md
+++ b/knowledge/prompt-modes.md
@@ -1,3 +1,9 @@
+---
+id: prompt-modes
+description: "The replicate / enhance / adapt strategy modifiers for reference-driven generation."
+when: [prompt-mode, replicate, enhance, adapt, reference-driven]
+---
+
 # Prompt Modes
 
 When a design is being generated **from an input** — a screenshot, a Figma frame, or any

--- a/knowledge/prompt-plan-orchestration.md
+++ b/knowledge/prompt-plan-orchestration.md
@@ -1,3 +1,9 @@
+---
+id: prompt-plan-orchestration
+description: "Weak request to production strategy — provenance-bound facets, structural directions, builder packet."
+when: [prompt-plan, brief, facet, structural-direction, region-brief]
+---
+
 # Prompt-plan orchestration
 
 ## Purpose

--- a/knowledge/qualified-delivery.md
+++ b/knowledge/qualified-delivery.md
@@ -1,3 +1,9 @@
+---
+id: qualified-delivery
+description: "Weak prompt to evidence-qualified delivery — typed brief, generation contract, curator, honest statuses."
+when: [qualified-delivery, generation-contract, curator, repair, delivery-status]
+---
+
 # Qualified Delivery
 
 Read this before generating a marketing or landing-page design from a plain-language request.

--- a/knowledge/recall-mind.md
+++ b/knowledge/recall-mind.md
@@ -1,3 +1,9 @@
+---
+id: recall-mind
+description: "Driving the recall CLI — the semantic memory over the design ledger."
+when: [recall, memory, semantic-search, ledger, rank]
+---
+
 # recall — semantic memory over the design ledger
 
 Where `figma-agent` is the **hands**, `recall` is the **mind**: it makes the design memory

--- a/knowledge/signature-devices.md
+++ b/knowledge/signature-devices.md
@@ -1,3 +1,9 @@
+---
+id: signature-devices
+description: "The composable signature-move library — the one memorable gesture a persona layers on top."
+when: [signature, signature-device, memorable, texture, marquee, grain]
+---
+
 # Signature Devices
 
 ## Purpose

--- a/knowledge/taste-rubric.md
+++ b/knowledge/taste-rubric.md
@@ -1,3 +1,9 @@
+---
+id: taste-rubric
+description: "The 6+1 axis taste model and the critique-gate pass thresholds."
+when: [taste, critique, score, rubric, quality-gate, axis]
+---
+
 # Taste Rubric — The 6+1 Axis Model
 
 This file is the design taste model the host model uses to **shape** a UI generation and

--- a/knowledge/token-taxonomy.md
+++ b/knowledge/token-taxonomy.md
@@ -1,3 +1,9 @@
+---
+id: token-taxonomy
+description: "The DTCG token model — primitive vs semantic tiers, aliasing, and the paired role/foreground standard."
+when: [token, design-token, semantic-token, alias, dtcg, token-naming]
+---
+
 # Token Taxonomy — The Two-Tier DTCG Model
 
 This file is the **reasoning** the host model uses when working with design tokens:

--- a/knowledge/user-evidence.md
+++ b/knowledge/user-evidence.md
@@ -1,3 +1,9 @@
+---
+id: user-evidence
+description: "Grounding design in real user evidence — the ledger and its anti-fabrication gate."
+when: [evidence, user-research, quote, metric, acceptance-criteria]
+---
+
 # User evidence — grounding design in what users actually said
 
 A design should be traceable to *evidence*, not assertion. "Users want a dashboard" is an

--- a/knowledge/ux-psychology.md
+++ b/knowledge/ux-psychology.md
@@ -1,3 +1,9 @@
+---
+id: ux-psychology
+description: "UX laws, Gestalt perception, cognitive biases, trust, and cognitive-load management."
+when: [ux-law, psychology, hicks-law, fitts-law, gestalt, cognitive-load, persuasion]
+---
+
 # UX Psychology Reference
 
 > Deep dive into UX laws, emotional design, trust building, and behavioral psychology.

--- a/knowledge/versioning-semver.md
+++ b/knowledge/versioning-semver.md
@@ -1,3 +1,9 @@
+---
+id: versioning-semver
+description: "Semver for a design system — how a DS diff classifies breaking, additive, and patch changes."
+when: [semver, versioning, breaking-change, ds-diff, release]
+---
+
 # Versioning — semver for a design system
 
 `ui ds diff <base-dir> <head-dir>` classifies the change between two design-system states and

--- a/knowledge/visual-regression.md
+++ b/knowledge/visual-regression.md
@@ -1,3 +1,9 @@
+---
+id: visual-regression
+description: "The rendered-output floor — what a VR gate catches that a code diff cannot, and why it flakes."
+when: [visual-regression, vr, screenshot-diff, baseline, pixelmatch]
+---
+
 # Visual regression — catching the pixels a diff review misses
 
 A code diff shows *what the source changed*; it can't show that a token tweak three layers

--- a/knowledge/world-class-learning-loop.md
+++ b/knowledge/world-class-learning-loop.md
@@ -1,3 +1,9 @@
+---
+id: world-class-learning-loop
+description: "Qualification, art direction, and reusable learning — controlled trials and anti-overfitting promotion."
+when: [learning-loop, trial, benchmark, art-direction, lesson]
+---
+
 # World-Class Learning Loop
 
 Read this after `qualified-delivery.md`. Qualification establishes the delivery floor. This loop

--- a/src/commands/knowledge.ts
+++ b/src/commands/knowledge.ts
@@ -5,7 +5,7 @@
  * content to the linter, which returns findings. Free, no model call, runs on
  * every commit (CI). See knowledge/authoring-standard.md for the conventions.
  */
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { errJson, errText, okJsonWithExit } from "../core/output.js";
@@ -13,6 +13,8 @@ import type { CommandResult } from "../core/output.js";
 import type { ParsedArgs } from "../core/cli-args.js";
 import { findUnknownFlag, unknownFlagMessage } from "../core/flag-guard.js";
 import { lintKnowledge } from "../core/knowledge-lint.js";
+import { buildIndex, emitIndex } from "../core/knowledge-index-emit.js";
+import { topLevelMarkdown } from "../core/knowledge-frontmatter-check.js";
 import type { KnowledgeFinding } from "../core/knowledge-lint.js";
 import { runEffectMatrix } from "./knowledge-effect-matrix.js";
 
@@ -23,9 +25,14 @@ export const KNOWLEDGE_HELP = `ui knowledge — governance checks over the knowl
 Usage:
   ui knowledge check [--dir <repo-root>] [--as-of <YYYYMM>] [--json]
   ui knowledge effect-matrix [--dir <repo-root>] [--json]
+  ui knowledge index [--dir <repo-root>] [--emit]
 
 Subcommands:
   check          Findings-linter over knowledge/; exit 1 on error-severity findings
+  index          Emit the routing index (id / description / when) over knowledge/*.md.
+                 Without --emit it prints to stdout; with --emit it writes
+                 knowledge/index.json — one small map an agent reads to pick a
+                 knowledge file, instead of loading README's prose table
   effect-matrix  Emit the Canvas UI effect matrix's machine columns (Effect/slug/family)
                  from knowledge/canvas-ui/catalog.json to stdout — never writes into
                  knowledge/canvas-effect-direction.md
@@ -46,6 +53,9 @@ Checks:
   effect-catalog-field-empty     (error)   a matrix row's Narrative job/Anti-use/Required fallback is empty
   effect-catalog-draco-missing   (error)   a ledger object-family row's fallback has no Draco clause
   effect-catalog-stale           (warning) knowledge/canvas-ui/catalog.json captured > 6 months ago
+  index-frontmatter-missing      (error)   a top-level knowledge/*.md with no routing front-matter
+  index-frontmatter-bad          (error)   a routing block unparseable, or whose id != filename
+  index-drift                    (error)   knowledge/index.json differs from the emitted index
 
 Options:
   --dir <path>     Repo root holding knowledge/ (default: current working directory)
@@ -61,6 +71,7 @@ Error codes (check):
   NO_KNOWLEDGE  No knowledge/ directory under --dir
   BAD_AS_OF     --as-of is not a YYYYMM month
   READ_ERROR    A knowledge file could not be read
+  WRITE_ERROR   knowledge/index.json could not be written (--emit)
 
 Error codes (effect-matrix):
   BAD_ARG       Missing/unknown subcommand
@@ -136,8 +147,13 @@ function runCheck(parsed: ParsedArgs): CommandResult {
   if (existsSync(ledgerPath)) {
     try { canvasCatalogJson = readFileSync(ledgerPath, "utf8"); } catch { canvasCatalogJson = null; }
   }
+  const indexPath = join(knowledgeDir, "index.json");
+  let committedIndex: string | null = null;
+  if (existsSync(indexPath)) {
+    try { committedIndex = readFileSync(indexPath, "utf8"); } catch { committedIndex = null; }
+  }
 
-  const findings: KnowledgeFinding[] = lintKnowledge({ files, mdContents, personasJson, repoFiles, asOf, canvasCatalogJson });
+  const findings: KnowledgeFinding[] = lintKnowledge({ files, mdContents, personasJson, repoFiles, asOf, canvasCatalogJson, committedIndex });
   const errorCount = findings.filter((f) => f.severity === "error").length;
   const warningCount = findings.length - errorCount;
   const exitCode = errorCount > 0 ? 1 : 0;
@@ -153,6 +169,42 @@ function runCheck(parsed: ParsedArgs): CommandResult {
   return { exitCode, stdout: lines.join("\n") + "\n" };
 }
 
+function runIndex(parsed: ParsedArgs): CommandResult {
+  const sub = "knowledge index";
+  const useJson = parsed.json;
+  const err = (code: string, msg: string): CommandResult =>
+    useJson ? errJson(sub, code, msg) : errText(`ui: ${msg}\n`);
+
+  const unknown = findUnknownFlag(parsed.flags, ["dir", "emit"]);
+  if (unknown !== null) return err("UNKNOWN_FLAG", unknownFlagMessage(unknown));
+
+  const repoRoot = typeof parsed.flags["dir"] === "string" ? resolve(parsed.flags["dir"]) : process.cwd();
+  const knowledgeDir = join(repoRoot, "knowledge");
+  if (!existsSync(knowledgeDir)) {
+    return err("NO_KNOWLEDGE", `no knowledge/ directory under '${repoRoot}' — run from a repo root, or pass --dir`);
+  }
+
+  const mdContents: Record<string, string> = {};
+  try {
+    for (const rel of walk(knowledgeDir)) {
+      if (rel.endsWith(".md")) mdContents[rel] = readFileSync(join(knowledgeDir, rel), "utf8");
+    }
+  } catch (e) {
+    return err("READ_ERROR", `cannot read knowledge/: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  const json = emitIndex(buildIndex(topLevelMarkdown(mdContents)));
+  if (parsed.flags["emit"] !== true) return { exitCode: 0, stdout: json };
+
+  const outPath = join(knowledgeDir, "index.json");
+  try {
+    writeFileSync(outPath, json, "utf8");
+  } catch (e) {
+    return err("WRITE_ERROR", `cannot write ${outPath}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  return { exitCode: 0, stdout: `knowledge index: wrote ${outPath}\n` };
+}
+
 export const knowledgeCommand = {
   name: CMD,
   summary: "Governance checks over the knowledge core (index / persona / xref / provenance / effect-catalog drift)",
@@ -162,8 +214,9 @@ export const knowledgeCommand = {
     switch (parsed.subcommand) {
       case "check": return runCheck(parsed);
       case "effect-matrix": return runEffectMatrix(parsed);
+      case "index": return runIndex(parsed);
       case undefined: {
-        const msg = "ui knowledge requires a subcommand (check, effect-matrix). Run 'ui knowledge --help'.";
+        const msg = "ui knowledge requires a subcommand (check, effect-matrix, index). Run 'ui knowledge --help'.";
         return parsed.json ? errJson(CMD, "BAD_ARG", msg) : errText(`ui: ${msg}\n`);
       }
       default: {

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -886,7 +886,7 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
   },
 
   knowledge: {
-    summary: "Governance checks over the knowledge core (index / persona / xref / provenance / effect-catalog drift)",
+    summary: "Governance checks over the knowledge core (index / persona / xref / provenance / effect-catalog drift) + the routing index emitter",
     subcommands: {
       check: {
         summary: "Findings-linter over knowledge/; exit 1 on error-severity findings, including Canvas UI effect-catalog drift (ledger↔matrix row drift, Draco)",
@@ -904,6 +904,15 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
           { name: "dir", type: "string", summary: "Repo root holding knowledge/canvas-ui/catalog.json (default: current working directory)" },
         ],
         errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "NO_LEDGER", "BAD_LEDGER", "READ_ERROR"],
+      },
+      index: {
+        summary: "Emit the routing index (id / description / when) over knowledge/*.md — stdout, or knowledge/index.json with --emit",
+        positionals: [],
+        flags: [
+          { name: "dir", type: "string", summary: "Repo root holding knowledge/ (default: current working directory)" },
+          { name: "emit", type: "boolean", summary: "Write knowledge/index.json instead of printing to stdout" },
+        ],
+        errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "NO_KNOWLEDGE", "READ_ERROR", "WRITE_ERROR"],
       },
     },
   },

--- a/src/core/knowledge-frontmatter-check.ts
+++ b/src/core/knowledge-frontmatter-check.ts
@@ -1,0 +1,91 @@
+/**
+ * Routing front-matter checks — the LINTER half of the `ui knowledge index` pair
+ * (the emitter half is knowledge-index-emit.ts).
+ *
+ *   index-frontmatter-missing  error  a top-level knowledge/*.md with no block
+ *   index-frontmatter-bad      error  a block present but not parseable
+ *   index-drift                error  committed index.json ≠ what the emitter produces
+ *
+ * Scope is deliberately the TOP LEVEL of knowledge/ only. `personas/**` route
+ * through `persona-index.md`, `figma-craft/**` through its own entry file, and
+ * `benchmarks/*.json` are data, not prose — tagging each of them individually
+ * would grow the index without giving a task a new place to land. Widen this
+ * only when a subdirectory file becomes a routing destination in its own right.
+ *
+ * FS-free, like every other knowledge check: content in, findings out.
+ */
+import { buildIndex, emitIndex, parseFrontMatter } from "./knowledge-index-emit.js";
+import type { KnowledgeFinding } from "./knowledge-lint.js";
+
+/** README is the map itself, not a destination — it carries no routing block. */
+const EXEMPT = new Set(["README.md"]);
+
+/** Top-level `.md` files only (no `/` in the knowledge-relative path). */
+export function topLevelMarkdown(
+  mdContents: Readonly<Record<string, string>>,
+): ReadonlyMap<string, string> {
+  const out = new Map<string, string>();
+  for (const rel of Object.keys(mdContents).sort()) {
+    if (rel.includes("/") || EXEMPT.has(rel)) continue;
+    out.set(rel, mdContents[rel] ?? "");
+  }
+  return out;
+}
+
+/**
+ * `committedIndex` is the raw bytes of `knowledge/index.json`, or null when the
+ * file is absent. Absent counts as drift: the emitted map is part of the core,
+ * and a missing one silently sends every consumer back to the prose table.
+ */
+export function frontMatterChecks(
+  mdContents: Readonly<Record<string, string>>,
+  committedIndex: string | null,
+): KnowledgeFinding[] {
+  const findings: KnowledgeFinding[] = [];
+  const files = topLevelMarkdown(mdContents);
+
+  for (const [rel, content] of files) {
+    const parsed = parseFrontMatter(content);
+    if (parsed === null) {
+      findings.push({
+        checkId: "index-frontmatter-missing",
+        severity: "error",
+        message: `'${rel}' has no routing front-matter — add an id/description/when block so 'ui knowledge index' can route to it`,
+      });
+      continue;
+    }
+    if (!parsed.ok) {
+      findings.push({
+        checkId: "index-frontmatter-bad",
+        severity: "error",
+        message: `'${rel}' front-matter is unparseable: ${parsed.reason}`,
+      });
+      continue;
+    }
+    const expectedId = rel.replace(/\.md$/, "");
+    if (parsed.id !== expectedId) {
+      findings.push({
+        checkId: "index-frontmatter-bad",
+        severity: "error",
+        message: `'${rel}' declares id '${parsed.id}' — the id must match the filename ('${expectedId}'), it is how a ref resolves without a path`,
+      });
+    }
+  }
+
+  const expected = emitIndex(buildIndex(files));
+  if (committedIndex === null) {
+    findings.push({
+      checkId: "index-drift",
+      severity: "error",
+      message: "knowledge/index.json is missing — run 'ui knowledge index --emit' and commit the result",
+    });
+  } else if (committedIndex !== expected) {
+    findings.push({
+      checkId: "index-drift",
+      severity: "error",
+      message: "knowledge/index.json does not match the front-matter it is emitted from — run 'ui knowledge index --emit' and commit the result",
+    });
+  }
+
+  return findings;
+}

--- a/src/core/knowledge-index-emit.ts
+++ b/src/core/knowledge-index-emit.ts
@@ -1,0 +1,109 @@
+/**
+ * `ui knowledge index` core — the routing index over the knowledge core.
+ *
+ * Why it exists: `knowledge/README.md`'s table is the only map an agent has, and
+ * its cells run past a thousand characters each. Routing a task through it means
+ * loading the whole prose table. This emits the same map as a small, machine-read
+ * file: one entry per knowledge file, carrying the `when` tags a task matches on.
+ *
+ * Pure, FS-free, deterministic (Art I.2): same `files` in → same bytes out. No
+ * clock, no fs, no network. Entries sort by `id`, tags keep their authored order,
+ * and the JSON is emitted with a fixed 2-space indent so a drift check can compare
+ * bytes rather than parse trees.
+ *
+ * The EMITTER half of the Art II pair; the linter half is knowledge-index-check.ts
+ * (`index-frontmatter-missing`, `index-frontmatter-bad`, `index-drift`).
+ */
+
+/** One knowledge file's routing record, as it appears in the emitted index. */
+export interface KnowledgeIndexEntry {
+  readonly id: string;
+  readonly path: string;
+  readonly description: string;
+  readonly when: readonly string[];
+}
+
+export interface KnowledgeIndex {
+  readonly version: 1;
+  readonly entries: readonly KnowledgeIndexEntry[];
+}
+
+/** A parsed front-matter block, or the reason it could not be parsed. */
+export type FrontMatterResult =
+  | { readonly ok: true; readonly id: string; readonly description: string; readonly when: readonly string[] }
+  | { readonly ok: false; readonly reason: string };
+
+const OPEN = "---\n";
+
+/**
+ * Parse the routing front-matter at the top of a knowledge file.
+ *
+ * Deliberately NOT a general YAML parser: the block is three known scalar keys in
+ * any order, and a real YAML dependency would break Art I.2's zero-runtime-deps
+ * rule. Anything the grammar does not cover is rejected by name rather than
+ * guessed at, so a malformed block fails loudly instead of emitting a half entry.
+ */
+export function parseFrontMatter(content: string): FrontMatterResult | null {
+  if (!content.startsWith(OPEN)) return null; // no block at all — caller reports it
+  const end = content.indexOf("\n---", OPEN.length);
+  if (end === -1) return { ok: false, reason: "front-matter block is never closed" };
+  const body = content.slice(OPEN.length, end + 1);
+
+  let id: string | null = null;
+  let description: string | null = null;
+  let when: string[] | null = null;
+
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (line === "") continue;
+    const sep = line.indexOf(":");
+    if (sep === -1) return { ok: false, reason: `front-matter line is not 'key: value' — '${line}'` };
+    const key = line.slice(0, sep).trim();
+    const value = line.slice(sep + 1).trim();
+    if (key === "id") id = value;
+    else if (key === "description") description = unquote(value);
+    else if (key === "when") {
+      if (!value.startsWith("[") || !value.endsWith("]")) {
+        return { ok: false, reason: "'when' must be an inline list, e.g. when: [motion, easing]" };
+      }
+      when = value
+        .slice(1, -1)
+        .split(",")
+        .map((t) => unquote(t.trim()))
+        .filter((t) => t !== "");
+    } else return { ok: false, reason: `unknown front-matter key '${key}' (allowed: id, description, when)` };
+  }
+
+  if (id === null || id === "") return { ok: false, reason: "front-matter is missing 'id'" };
+  if (description === null || description === "") return { ok: false, reason: "front-matter is missing 'description'" };
+  if (when === null || when.length === 0) return { ok: false, reason: "front-matter is missing a non-empty 'when'" };
+  return { ok: true, id, description, when };
+}
+
+function unquote(value: string): string {
+  const quoted =
+    (value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"));
+  return quoted && value.length >= 2 ? value.slice(1, -1) : value;
+}
+
+/**
+ * Build the index from already-read files. `files` maps a knowledge-relative path
+ * (`motion-craft.md`) to its full content. Files without a parseable block are
+ * skipped here and reported by the linter — an emitter that invented an entry for
+ * an untagged file would hide exactly what the check exists to surface.
+ */
+export function buildIndex(files: ReadonlyMap<string, string>): KnowledgeIndex {
+  const entries: KnowledgeIndexEntry[] = [];
+  for (const [rel, content] of files) {
+    const parsed = parseFrontMatter(content);
+    if (parsed === null || !parsed.ok) continue;
+    entries.push({ id: parsed.id, path: `knowledge/${rel}`, description: parsed.description, when: parsed.when });
+  }
+  entries.sort((a, b) => a.id.localeCompare(b.id));
+  return { version: 1, entries };
+}
+
+/** Serialize the index to the exact bytes `knowledge/index.json` must hold. */
+export function emitIndex(index: KnowledgeIndex): string {
+  return JSON.stringify(index, null, 2) + "\n";
+}

--- a/src/core/knowledge-lint.ts
+++ b/src/core/knowledge-lint.ts
@@ -3,7 +3,7 @@
  * every commit, no model call. It answers one question deterministically: has
  * the knowledge core drifted from its own conventions?
  *
- * Eight checks (findings-linter shape, per constitution Art II):
+ * Eleven checks (findings-linter shape, per constitution Art II):
  *   index-missing-row             error    a knowledge/*.md with no README table row
  *   index-dead-row                 error    a table row pointing to a missing file
  *   persona-drift                   error    index ↔ family md ↔ personas.json disagree
@@ -14,6 +14,9 @@
  *                                             (fires on the ref prefix, never on resolution)
  *   effect-catalog-*                mixed    Canvas UI ledger↔matrix drift (see
  *                                             knowledge-effect-catalog-check.ts)
+ *   index-frontmatter-missing       error    a top-level knowledge/*.md with no routing block
+ *   index-frontmatter-bad           error    a routing block unparseable, or id != filename
+ *   index-drift                     error    knowledge/index.json != what the emitter produces
  *
  * This module is FS-FREE: it receives already-read content and returns findings,
  * so the command layer owns all IO and the checks stay pure and testable.
@@ -22,6 +25,7 @@ import { indexChecks } from "./knowledge-index-check.js";
 import { personaChecks } from "./knowledge-persona-check.js";
 import { xrefChecks, provenanceChecks } from "./knowledge-link-check.js";
 import { effectCatalogChecks } from "./knowledge-effect-catalog-check.js";
+import { frontMatterChecks } from "./knowledge-frontmatter-check.js";
 
 export interface KnowledgeFinding {
   checkId: string;
@@ -40,6 +44,8 @@ export interface KnowledgeLintInput {
   repoFiles: readonly string[];
   /** Staleness reference month, `YYYYMM`. */
   asOf: string;
+  /** Raw knowledge/index.json bytes, or null when the file is missing. */
+  committedIndex?: string | null;
   /** knowledge/canvas-ui/catalog.json content, or null/absent when missing.
    * Optional so existing fixtures that predate the Canvas UI adoption (spec 028)
    * keep typechecking without an edit — absent is treated identically to null. */
@@ -115,6 +121,7 @@ export function lintKnowledge(input: KnowledgeLintInput): KnowledgeFinding[] {
       catalogJson: input.canvasCatalogJson ?? null,
       asOf: input.asOf,
     }),
+    ...frontMatterChecks(input.mdContents, input.committedIndex ?? null),
   ];
   return sortFindings(findings);
 }

--- a/tests/cmd-knowledge.test.ts
+++ b/tests/cmd-knowledge.test.ts
@@ -4,11 +4,13 @@
  * own IO (walk + read) is exercised end-to-end against the pure linter.
  */
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { run } from "../src/cli.js";
+import { buildIndex, emitIndex } from "../src/core/knowledge-index-emit.js";
+import { topLevelMarkdown } from "../src/core/knowledge-frontmatter-check.js";
 
 function capture(args: string[]): { exitCode: number; stdout: string; stderr: string } {
   let stdout = "";
@@ -55,8 +57,8 @@ function scaffoldConsistent(): void {
     "| `benchmarks/*.dna.json` | Measured DNA |",
     "",
   ].join("\n"));
-  write("knowledge/taste-rubric.md", "# Taste\n");
-  write("knowledge/persona-index.md", [
+  write("knowledge/taste-rubric.md", fm("taste-rubric", "The taste model.", ["taste"]) + "# Taste\n");
+  write("knowledge/persona-index.md", fm("persona-index", "Persona lookup.", ["persona"]) + [
     "# Persona Index", "", "## 1. Lookup Table", "",
     "| Slug | Family |", "|---|---|",
     "| `alpha-one` | family-a |", "",
@@ -64,6 +66,27 @@ function scaffoldConsistent(): void {
   write("knowledge/personas/family-a.md", "# Family A\n\n## Alpha One\n\n- **Slug:** `alpha-one`\n- **Family:** family-a\n");
   write("knowledge/personas/personas.json", JSON.stringify([{ slug: "alpha-one", family: "family-a" }]));
   write("knowledge/benchmarks/stripe--202607.dna.json", "{}");
+  emitIndexInto(root);
+}
+
+/** A routing front-matter block, the shape authoring-standard.md specifies. */
+function fm(id: string, description: string, when: string[]): string {
+  return `---\nid: ${id}\ndescription: "${description}"\nwhen: [${when.join(", ")}]\n---\n\n`;
+}
+
+/**
+ * Compile knowledge/index.json from whatever the scaffold just wrote. Called after
+ * the last write, and again by any case that rewrites a top-level file — an
+ * out-of-date index is itself an error, so a case that skipped this would trip
+ * index-drift instead of exercising its own check.
+ */
+function emitIndexInto(repoRoot: string): void {
+  const dir = join(repoRoot, "knowledge");
+  const md: Record<string, string> = {};
+  for (const name of readdirSync(dir)) {
+    if (name.endsWith(".md")) md[name] = readFileSync(join(dir, name), "utf8");
+  }
+  writeFileSync(join(dir, "index.json"), emitIndex(buildIndex(topLevelMarkdown(md))), "utf8");
 }
 
 beforeEach(() => {
@@ -129,8 +152,12 @@ describe("ui knowledge check", () => {
 
   it("provenance: accepts a well-formed marker whose ref resolves", () => {
     scaffoldConsistent();
+    // Rewriting a top-level file drops its routing block, so restore it and
+    // re-emit — otherwise this case reports front-matter drift, not provenance.
     write("knowledge/taste-rubric.md",
+      fm("taste-rubric", "The taste model.", ["taste"]) +
       "# Taste\n\n<!-- ease:source ref=\"knowledge/benchmarks/stripe--202607.dna.json\" -->\n");
+    emitIndexInto(root);
     const r = capture(["knowledge", "check", "--dir", root, "--as-of", "202607", "--json"]);
     expect(r.exitCode).toBe(0);
     expect(checkIds(r)).not.toContain("provenance-bad-grammar");

--- a/tests/knowledge-effect-matrix-emit.test.ts
+++ b/tests/knowledge-effect-matrix-emit.test.ts
@@ -10,6 +10,8 @@ import { describe, expect, it } from "vitest";
 
 import { emitEffectMatrix } from "../src/core/knowledge-effect-matrix-emit.js";
 import { lintKnowledge } from "../src/core/knowledge-lint.js";
+import { buildIndex, emitIndex } from "../src/core/knowledge-index-emit.js";
+import { topLevelMarkdown } from "../src/core/knowledge-frontmatter-check.js";
 
 const REVISION = "728550d4523e1b8bef834b64b3e936c215cad630";
 
@@ -138,7 +140,12 @@ describe("emitEffectMatrix — M6 round-trip (pair-coherence proof)", () => {
     expect(emitted.ok).toBe(true);
     if (!emitted.ok) return;
 
+    // Top-level knowledge files carry routing front-matter (authoring-standard.md),
+    // and the committed index is compiled from it below — without both, this case
+    // would report index-drift instead of the pair-coherence it exists to prove.
     const canvasEffectDirection = [
+      fm("canvas-effect-direction", "The T6 external-effect direction.", ["canvas", "webgl"]).trimEnd(),
+      "",
       "# Canvas UI External-Effect Direction",
       "",
       `Pinned revision: \`${REVISION}\``,
@@ -158,17 +165,20 @@ describe("emitEffectMatrix — M6 round-trip (pair-coherence proof)", () => {
       "",
     ].join("\n");
 
-    const personaIndex = ["# Persona Index", "", "## 1. Lookup Table", "", "| Slug | Family |", "|---|---|", ""].join(
+    const personaIndex = [fm("persona-index", "Persona lookup.", ["persona"]).trimEnd(), "", "# Persona Index", "", "## 1. Lookup Table", "", "| Slug | Family |", "|---|---|", ""].join(
       "\n",
     );
 
+    const mdContents = {
+      "README.md": readme,
+      "persona-index.md": personaIndex,
+      "canvas-effect-direction.md": canvasEffectDirection,
+    };
+
     const findings = lintKnowledge({
       files: ["README.md", "persona-index.md", "canvas-effect-direction.md"],
-      mdContents: {
-        "README.md": readme,
-        "persona-index.md": personaIndex,
-        "canvas-effect-direction.md": canvasEffectDirection,
-      },
+      mdContents,
+      committedIndex: emitIndex(buildIndex(topLevelMarkdown(mdContents))),
       personasJson: "[]",
       repoFiles: [
         "knowledge/README.md",
@@ -187,3 +197,8 @@ describe("emitEffectMatrix — M6 round-trip (pair-coherence proof)", () => {
     expect(fieldEmpty.length).toBe(FIXTURE_CATALOG.effects.length);
   });
 });
+
+/** A routing front-matter block, the shape authoring-standard.md specifies. */
+function fm(id: string, description: string, when: string[]): string {
+  return `---\nid: ${id}\ndescription: "${description}"\nwhen: [${when.join(", ")}]\n---\n\n`;
+}

--- a/tests/knowledge-index-emit.test.ts
+++ b/tests/knowledge-index-emit.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The routing-index pair (Art II): knowledge-index-emit.ts (emitter) and
+ * knowledge-frontmatter-check.ts (linter). Pure and FS-free on both halves, so
+ * every case here is content in / findings out — no tmpdir, no build artifact.
+ *
+ * The linter cases are written the way the repo's own scar asks for: each one
+ * BREAKS something deliberately and asserts the check goes red. A check that has
+ * only ever been observed green has not been shown to run.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildIndex, emitIndex, parseFrontMatter } from "../src/core/knowledge-index-emit.js";
+import { frontMatterChecks, topLevelMarkdown } from "../src/core/knowledge-frontmatter-check.js";
+
+const GOOD = `---
+id: motion-craft
+description: "The animation decision ladder."
+when: [motion, animation, easing]
+---
+
+# Motion Craft
+`;
+
+const OTHER = `---
+id: color-science
+description: "OKLCH reasoning and contrast targets."
+when: [color, contrast]
+---
+
+# Color Science
+`;
+
+/** The two-file core every linter case starts from, plus a README that is exempt. */
+function core(extra: Record<string, string> = {}): Record<string, string> {
+  return { "motion-craft.md": GOOD, "color-science.md": OTHER, "README.md": "# index\n", ...extra };
+}
+
+/** The index bytes a given content map is expected to produce. */
+function expected(md: Record<string, string>): string {
+  return emitIndex(buildIndex(topLevelMarkdown(md)));
+}
+
+const ids = (f: { checkId: string }[]): string[] => f.map((x) => x.checkId).sort();
+
+describe("parseFrontMatter", () => {
+  it("reads id, description, and when, stripping quotes", () => {
+    const r = parseFrontMatter(GOOD);
+    expect(r).toEqual({ ok: true, id: "motion-craft", description: "The animation decision ladder.", when: ["motion", "animation", "easing"] });
+  });
+
+  it("returns null — not an error — when there is no block at all", () => {
+    // null and {ok:false} mean different things to the linter: absent vs malformed.
+    expect(parseFrontMatter("# Motion Craft\n")).toBeNull();
+  });
+
+  it.each([
+    ["never closed", "---\nid: x\n"],
+    ["missing id", '---\ndescription: "d"\nwhen: [a]\n---\n'],
+    ["missing description", "---\nid: x\nwhen: [a]\n---\n"],
+    ["empty when", '---\nid: x\ndescription: "d"\nwhen: []\n---\n'],
+    ["when is not a list", '---\nid: x\ndescription: "d"\nwhen: motion\n---\n'],
+    ["unknown key", '---\nid: x\ndescription: "d"\nwhen: [a]\ntier: knowledge\n---\n'],
+    ["line is not key: value", '---\nid: x\ndescription: "d"\nwhen: [a]\njust-a-word\n---\n'],
+  ])("rejects front-matter that is %s", (_label, content) => {
+    const r = parseFrontMatter(content);
+    expect(r?.ok).toBe(false);
+  });
+});
+
+describe("buildIndex / emitIndex", () => {
+  it("sorts entries by id and keeps each file's authored tag order", () => {
+    const idx = buildIndex(topLevelMarkdown(core()));
+    expect(idx.entries.map((e) => e.id)).toEqual(["color-science", "motion-craft"]);
+    expect(idx.entries[1]?.when).toEqual(["motion", "animation", "easing"]);
+  });
+
+  it("records the knowledge-relative path so a consumer can open the file", () => {
+    const idx = buildIndex(topLevelMarkdown(core()));
+    expect(idx.entries[0]?.path).toBe("knowledge/color-science.md");
+  });
+
+  it("is deterministic — same input, same bytes (Art I.2)", () => {
+    expect(emitIndex(buildIndex(topLevelMarkdown(core())))).toBe(emitIndex(buildIndex(topLevelMarkdown(core()))));
+  });
+
+  it("skips an untagged file rather than inventing an entry for it", () => {
+    const md = core({ "page-structures.md": "# Page Structures\n" });
+    const idx = buildIndex(topLevelMarkdown(md));
+    expect(idx.entries.map((e) => e.id)).not.toContain("page-structures");
+  });
+
+  it("ignores subdirectory files — personas/** route through persona-index", () => {
+    const md = core({ "personas/editorial.md": GOOD });
+    expect(buildIndex(topLevelMarkdown(md)).entries).toHaveLength(2);
+  });
+});
+
+describe("frontMatterChecks — green only when nothing is broken", () => {
+  it("passes a core whose committed index matches its front-matter", () => {
+    const md = core();
+    expect(frontMatterChecks(md, expected(md))).toEqual([]);
+  });
+
+  it("exempts README.md, which is the map rather than a destination", () => {
+    const md = core();
+    expect(ids(frontMatterChecks(md, expected(md)))).not.toContain("index-frontmatter-missing");
+  });
+});
+
+describe("frontMatterChecks — each check, broken on purpose", () => {
+  it("index-frontmatter-missing: a top-level file with no block", () => {
+    const md = core({ "page-structures.md": "# Page Structures\n" });
+    const f = frontMatterChecks(md, expected(md));
+    expect(ids(f)).toContain("index-frontmatter-missing");
+    expect(f.find((x) => x.checkId === "index-frontmatter-missing")?.message).toContain("page-structures.md");
+  });
+
+  it("index-frontmatter-bad: a block that does not parse", () => {
+    const md = core({ "flow-craft.md": '---\nid: flow-craft\ndescription: "d"\nwhen: []\n---\n' });
+    expect(ids(frontMatterChecks(md, expected(md)))).toContain("index-frontmatter-bad");
+  });
+
+  it("index-frontmatter-bad: id that disagrees with the filename", () => {
+    const md = core({ "color-science.md": OTHER.replace("id: color-science", "id: colour-science") });
+    const f = frontMatterChecks(md, expected(md));
+    expect(f.find((x) => x.checkId === "index-frontmatter-bad")?.message).toContain("must match the filename");
+  });
+
+  it("index-drift: committed index is stale", () => {
+    const md = core();
+    const stale = expected(md).replace("The animation decision ladder.", "Something else entirely");
+    expect(ids(frontMatterChecks(md, stale))).toContain("index-drift");
+  });
+
+  it("index-drift: committed index is absent", () => {
+    const f = frontMatterChecks(core(), null);
+    expect(f.find((x) => x.checkId === "index-drift")?.message).toContain("is missing");
+  });
+
+  it("every finding is error severity — a stale map is not advisory", () => {
+    const md = core({ "page-structures.md": "# Page Structures\n" });
+    for (const finding of frontMatterChecks(md, null)) expect(finding.severity).toBe("error");
+  });
+});

--- a/tests/knowledge-lint.test.ts
+++ b/tests/knowledge-lint.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from "vitest";
 
 import { lintKnowledge } from "../src/core/knowledge-lint.js";
 import type { KnowledgeLintInput } from "../src/core/knowledge-lint.js";
+import { buildIndex, emitIndex } from "../src/core/knowledge-index-emit.js";
+import { topLevelMarkdown } from "../src/core/knowledge-frontmatter-check.js";
 
 /** A mutable view of the input so tests can tweak fixtures before linting. */
 type MutableInput = Omit<KnowledgeLintInput, "files" | "mdContents" | "repoFiles"> & {
@@ -48,8 +50,8 @@ function consistent(overrides: Partial<MutableInput> = {}): MutableInput {
   ]);
   const mdContents: Record<string, string> = {
     "README.md": readme,
-    "taste-rubric.md": "# Taste\n",
-    "persona-index.md": personaIndex,
+    "taste-rubric.md": fm("taste-rubric", "The taste model.", ["taste"]) + "# Taste\n",
+    "persona-index.md": fm("persona-index", "Persona lookup.", ["persona"]) + personaIndex,
     "personas/family-a.md": familyA,
     "personas/family-b.md": familyB,
   };
@@ -62,7 +64,7 @@ function consistent(overrides: Partial<MutableInput> = {}): MutableInput {
     "personas/personas.json",
     "benchmarks/stripe--202607.dna.json",
   ];
-  return {
+  const base = {
     files,
     mdContents,
     personasJson,
@@ -70,6 +72,14 @@ function consistent(overrides: Partial<MutableInput> = {}): MutableInput {
     asOf: "202607",
     ...overrides,
   };
+  // The committed index must match whatever mdContents the caller ended up with,
+  // or every case would also trip index-drift and stop testing its own check.
+  return { ...base, committedIndex: emitIndex(buildIndex(topLevelMarkdown(base.mdContents))) };
+}
+
+/** A routing front-matter block, the shape authoring-standard.md specifies. */
+function fm(id: string, description: string, when: string[]): string {
+  return `---\nid: ${id}\ndescription: "${description}"\nwhen: [${when.join(", ")}]\n---\n\n`;
 }
 
 const ids = (input: KnowledgeLintInput): string[] => lintKnowledge(input).map((f) => f.checkId);
@@ -83,7 +93,7 @@ describe("knowledge-lint — passes on a consistent core", () => {
 describe("knowledge-lint — index checks", () => {
   it("index-missing-row: a knowledge md with no table row", () => {
     const base = consistent();
-    base.mdContents["orphan.md"] = "# Orphan\n";
+    base.mdContents["orphan.md"] = fm("orphan", "An orphan.", ["orphan"]) + "# Orphan\n";
     base.files.push("orphan.md");
     expect(ids(base)).toContain("index-missing-row");
   });


### PR DESCRIPTION
## The problem, measured

`knowledge/README.md`'s `## The files` table is the only map the knowledge core has. Its cells run past a thousand characters each, so routing a single task means loading the entire table — frequently more tokens than the file it eventually points to. There is no machine-readable index at all.

## What this ships

Every top-level `knowledge/*.md` now opens with three keys:

```yaml
---
id: motion-craft
description: "The animation decision ladder T1 CSS to T6 WebGL, and the motion floors."
when: [motion, animation, transition, reduced-motion, motion-tier, easing]
---
```

`when` is the routing signal — **the words a task uses, not the words the file's own headings use**. `ui knowledge index --emit` compiles the blocks into `knowledge/index.json`: 32 entries, 11 KB. An agent reads that, picks a file, opens one file.

## The Art II pair

A convention that exists only as prose drifts, so the emitter and the check ship together:

| Half | What |
|---|---|
| **emitter** | `ui knowledge index [--emit]` — pure, FS-free, deterministic core (`knowledge-index-emit.ts`); no clock, no fs, no network |
| **linter** | `index-frontmatter-missing` · `index-frontmatter-bad` (unparseable, or `id` ≠ filename) · `index-drift` (committed index ≠ the files it came from) |

**Every check was verified by breaking it on purpose** — removing a block, renaming an `id`, emptying `when`, staling the index, deleting the index — watching it go red, then restoring. A check only ever observed green has not been shown to run.

## Three keys, not seven

`tier`, `status`, `scope`, and `requires` were each considered and cut. Every one of them needed its own linter to stay honest, and none of them changed *which file a task should open*. The rule is written into `authoring-standard.md`: add a fourth key only when a routing decision cannot be made without it.

## Scope: top level only

`personas/**` route through `persona-index.md`, `figma-craft/**` through its own entry file, and `benchmarks/**` are data rather than prose. Tagging them individually would grow the index without giving a task a new place to land.

## Also updated

- `authoring-standard.md` — the front-matter rule, why three keys, and the edit → `--emit` → commit loop.
- `knowledge/README.md` — points readers at `index.json` first; the table stays for a human reading top to bottom.
- Two existing fixtures (`knowledge-lint`, `cmd-knowledge`) now build cores that carry front-matter and re-emit their index, so each case still tests its own check rather than tripping drift.

## Gates

`typecheck` · `lint` · `build` pass · `ui knowledge check` **0 findings** · `npm pack` 116 → **117 files** (`knowledge/index.json`, 11.1 kB — it ships, which is the point) · 22 new tests, **2743 passed**.

Suite shows the same 5 red files as clean `origin/main`: four pre-existing (#122, fixed for two of them in #121) and `spec-022-lifecycle`, which only times out under full-suite parallel load and passes 92/92 in isolation. **No new failures.**