### PR TITLE
feat(taste-lint): give the GSAP direction the linter it never had

### DIFF
--- a/knowledge/gsap-motion-direction.md
+++ b/knowledge/gsap-motion-direction.md
@@ -151,7 +151,30 @@ event listeners alongside animation cleanup.
 - Delivery evidence includes normal-motion and reduced-motion captures, console cleanliness,
   cleanup verification, INP, CLS, and a frame-rate trace for the signature interaction.
 
-## 9. Benchmark boundary
+## 9. The machine floor — what `ui taste-lint` decides for you
+
+Six rules above are decidable from static source, so they are checks rather than advice.
+They run inside `ui taste-lint <file.html>` on the Motion axis, at error severity, and stay
+silent unless GSAP is actually present in the document.
+
+| checkId | Fails when | Rule it enforces |
+|---|---|---|
+| `gsap-dev-markers-shipped` | `markers: true` or `GSDevTools` survives into a delivered file | §5 "use markers during construction only" |
+| `gsap-scrub-and-toggle` | one `scrollTrigger` object sets both `scrub` and `toggleActions` | §5 "never both" |
+| `gsap-plugin-unregistered` | a plugin is used with no `gsap.registerPlugin()` for it | §7 plugin restraint |
+| `gsap-transforms-pinned-el` | the pinned selector is itself the target of a transform tween | §5 "pin the wrapper, animate a child" |
+| `gsap-no-reduced-motion` | GSAP animates and nothing in the document branches on `prefers-reduced-motion` | §8 accessibility floor |
+| `gsap-permanent-will-change` | `will-change` sits in a static CSS rule instead of being set and released around the animation | §8 performance |
+
+**What this floor CANNOT see.** `taste-lint` reads one HTML file. A production scene keeps
+its choreography in an external `hero.js`, and **none of these checks reach it** — measured:
+run against this repo's own GSAP pages, all six stay silent because every `gsap.*` call lives
+in a separate script. Treat a clean run as "nothing wrong in the markup", never as "the
+choreography is sound". The judgment this file actually asks for — does the scene earn its
+pin, does the motion carry meaning, does it stay comprehensible at rest — is not in scope for
+any static check and remains the reviewer's.
+
+## 10. Benchmark boundary
 
 For the DESIGN:OS promotion and Architecture web benchmarks, require one story-bearing GSAP
 signature interaction and restrained supporting choreography. For the Nutrition native-mobile

--- a/src/core/taste-checks-gsap.ts
+++ b/src/core/taste-checks-gsap.ts
@@ -1,0 +1,232 @@
+/**
+ * Motion axis, GSAP subset — the machine-checkable half of
+ * `knowledge/gsap-motion-direction.md`.
+ *
+ * That file shipped as prose with no linter, which the repo's own doctrine calls
+ * out: a standard that exists only as prose drifts. These are the rules from it
+ * that a static reader can decide without rendering anything. Everything else in
+ * the file — is the choreography *meaningful*, does the scene earn a pin — stays
+ * with the model, exactly as the taste linter's other axes do.
+ *
+ * Pure string/regex heuristics over the raw HTML, like every other taste check:
+ * no DOM parser, no browser. Precision over recall — a false positive that fails
+ * a good build costs more than a missed marginal one, so each check requires GSAP
+ * to actually be present before it says anything.
+ *
+ *   gsap-dev-markers-shipped   error   markers/GSDevTools left in a delivered file
+ *   gsap-scrub-and-toggle      error   scrub + toggleActions on one ScrollTrigger
+ *   gsap-plugin-unregistered   error   a plugin used with no registerPlugin call
+ *   gsap-transforms-pinned-el  error   the pinned element is itself transformed
+ *   gsap-no-reduced-motion     error   GSAP present, no reduced-motion branch
+ *   gsap-permanent-will-change error   will-change parked in a static rule
+ */
+import type { TasteFinding } from "./taste-lint.js";
+import { lineOf } from "./taste-checks-shared.js";
+
+const AXIS = "Motion";
+
+/** GSAP is in play at all — every check below is silent without this. */
+export function usesGsap(rawHtml: string): boolean {
+  const html = blankAttributes(rawHtml);
+  return /\bgsap\s*\.\s*(to|from|fromTo|timeline|set|matchMedia|registerPlugin|context)\b/.test(html)
+    || /\bScrollTrigger\s*\.\s*(create|refresh|matchMedia|batch)\b/.test(html);
+}
+
+/** Strip comments so a rule quoted in prose does not read as live code. */
+function code(html: string): string {
+  return html.replace(/<!--[\s\S]*?-->/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/**
+ * Blank out tag ATTRIBUTES, keeping every offset so `lineOf` still points at the
+ * right line. A real page loads plugins by file — `<script src="ScrollTrigger.min.js">`
+ * — and a bare name scan reads that filename as a use of the plugin. Caught on the
+ * first real-data run (Art III): the first draft flagged `gsap-plugin-unregistered`
+ * on a page whose only mention of ScrollTrigger was its script tag.
+ */
+function blankAttributes(html: string): string {
+  return html.replace(/<([a-zA-Z][a-zA-Z0-9-]*)([^>]*)>/g, (_all, tag: string, attrs: string) =>
+    `<${tag}${" ".repeat(attrs.length)}>`);
+}
+
+/**
+ * gsap-dev-markers-shipped — "Remove development markers and GSDevTools before
+ * delivery" / "Use markers during construction only" (§ScrollTrigger).
+ *
+ * `markers: false` is fine: it is the switch in its off position, not a marker.
+ */
+export function checkGsapDevMarkers(html: string): TasteFinding[] {
+  const src = code(html);
+  if (!usesGsap(src)) return [];
+  const findings: TasteFinding[] = [];
+
+  const markers = /\bmarkers\s*:\s*(?!false)(true|\{)/.exec(src);
+  if (markers !== null) {
+    findings.push({
+      checkId: "gsap-dev-markers-shipped", axis: AXIS, severity: "error",
+      line: lineOf(src, markers.index),
+      message: "ScrollTrigger `markers` is on — construction-only debug UI, remove it before delivery (gsap-motion-direction.md, ScrollTrigger)",
+    });
+  }
+  const devtools = /\bGSDevTools\b/.exec(src);
+  if (devtools !== null) {
+    findings.push({
+      checkId: "gsap-dev-markers-shipped", axis: AXIS, severity: "error",
+      line: lineOf(src, devtools.index),
+      message: "GSDevTools is still wired in — a development tool, remove it before delivery (gsap-motion-direction.md, ScrollTrigger)",
+    });
+  }
+  return findings;
+}
+
+/**
+ * gsap-scrub-and-toggle — "Choose `scrub` for continuous progress or
+ * `toggleActions` for discrete behavior, never both."
+ *
+ * Scoped to a single `scrollTrigger: { … }` object so two unrelated triggers in
+ * one file, one scrubbed and one toggled, stay legal.
+ */
+export function checkGsapScrubAndToggle(html: string): TasteFinding[] {
+  const src = code(html);
+  if (!usesGsap(src)) return [];
+  const findings: TasteFinding[] = [];
+  const block = /scrollTrigger\s*:\s*\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = block.exec(src)) !== null) {
+    const body = m[1] ?? "";
+    if (/\bscrub\s*:/.test(body) && /\btoggleActions\s*:/.test(body)) {
+      findings.push({
+        checkId: "gsap-scrub-and-toggle", axis: AXIS, severity: "error",
+        line: lineOf(src, m.index),
+        message: "one ScrollTrigger sets both `scrub` and `toggleActions` — continuous progress or discrete behavior, never both (gsap-motion-direction.md, ScrollTrigger)",
+      });
+    }
+  }
+  return findings;
+}
+
+/** Plugins that must be registered before use. */
+const PLUGINS = ["ScrollTrigger", "ScrollSmoother", "SplitText", "Flip", "Draggable", "MotionPathPlugin", "TextPlugin", "Observer"];
+
+/**
+ * gsap-plugin-unregistered — a plugin is referenced but never passed to
+ * `gsap.registerPlugin`. Silent in production until a bundler tree-shakes it,
+ * which is exactly when it is hardest to diagnose.
+ */
+export function checkGsapPluginUnregistered(html: string): TasteFinding[] {
+  const src = blankAttributes(code(html));
+  if (!usesGsap(src)) return [];
+  const registered = new Set<string>();
+  const reg = /gsap\s*\.\s*registerPlugin\s*\(([^)]*)\)/g;
+  let r: RegExpExecArray | null;
+  while ((r = reg.exec(src)) !== null) {
+    for (const name of (r[1] ?? "").split(",")) registered.add(name.trim());
+  }
+  const findings: TasteFinding[] = [];
+  for (const plugin of PLUGINS) {
+    if (registered.has(plugin)) continue;
+    const use = new RegExp(`\\b${plugin}\\s*\\.\\s*[a-zA-Z]`).exec(src)
+      ?? new RegExp(`scrollTrigger\\s*:[\\s\\S]{0,200}?\\b${plugin}\\b`).exec(src);
+    if (use !== null) {
+      findings.push({
+        checkId: "gsap-plugin-unregistered", axis: AXIS, severity: "error",
+        line: lineOf(src, use.index),
+        message: `${plugin} is used but never passed to gsap.registerPlugin() — it works until a bundler tree-shakes it (gsap-motion-direction.md, plugin restraint)`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * gsap-transforms-pinned-el — "Pin the scene wrapper and animate a child. Do not
+ * transform the pinned element."
+ *
+ * Only fires when the SAME selector is both the pin target and a tween target,
+ * which is the actual failure; a pinned wrapper whose children move is correct.
+ */
+export function checkGsapTransformsPinnedElement(html: string): TasteFinding[] {
+  const src = code(html);
+  if (!usesGsap(src)) return [];
+  const pins = new Set<string>();
+  const pinRe = /\bpin\s*:\s*["'`]([^"'`]+)["'`]/g;
+  let p: RegExpExecArray | null;
+  while ((p = pinRe.exec(src)) !== null) pins.add((p[1] ?? "").trim());
+  if (pins.size === 0) return [];
+
+  const findings: TasteFinding[] = [];
+  const tween = /gsap\s*\.\s*(?:to|from|fromTo|set)\s*\(\s*["'`]([^"'`]+)["'`]\s*,([\s\S]{0,300}?)\)/g;
+  let t: RegExpExecArray | null;
+  while ((t = tween.exec(src)) !== null) {
+    const target = (t[1] ?? "").trim();
+    const vars = t[2] ?? "";
+    if (!pins.has(target)) continue;
+    if (!/\b(x|y|xPercent|yPercent|scale|scaleX|scaleY|rotation|rotate|skew|transform)\s*:/.test(vars)) continue;
+    findings.push({
+      checkId: "gsap-transforms-pinned-el", axis: AXIS, severity: "error",
+      line: lineOf(src, t.index),
+      message: `'${target}' is pinned and also transformed — pin the scene wrapper and animate a child instead (gsap-motion-direction.md, ScrollTrigger)`,
+    });
+  }
+  return findings;
+}
+
+/**
+ * gsap-no-reduced-motion — GSAP is driving motion with no reduced-motion branch
+ * anywhere. The file's floor: "Use `gsap.matchMedia()` for responsive
+ * choreography and `prefers-reduced-motion`."
+ *
+ * A CSS `@media (prefers-reduced-motion)` block counts: the honest outcome is
+ * that a reduced-motion user gets a settled state, not that it was achieved
+ * through a particular API.
+ */
+export function checkGsapNoReducedMotion(html: string): TasteFinding[] {
+  const src = code(html);
+  if (!usesGsap(src)) return [];
+  if (/prefers-reduced-motion/.test(src)) return [];
+  const at = /\bgsap\s*\.\s*(?:to|from|fromTo|timeline)\b/.exec(src);
+  return [{
+    checkId: "gsap-no-reduced-motion", axis: AXIS, severity: "error",
+    line: at === null ? 1 : lineOf(src, at.index),
+    message: "GSAP animates with no prefers-reduced-motion branch — every tier owes a settled, non-animated state (gsap-motion-direction.md, accessibility floor)",
+  }];
+}
+
+/**
+ * gsap-permanent-will-change — "Apply `will-change` only while a known element
+ * animates." A `will-change` sitting in a static CSS rule keeps a compositor
+ * layer alive for the life of the page.
+ *
+ * `will-change: auto` is the release value, so it is never a finding.
+ */
+export function checkGsapPermanentWillChange(html: string): TasteFinding[] {
+  const src = code(html);
+  if (!usesGsap(src)) return [];
+  const findings: TasteFinding[] = [];
+  const styleBlocks = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+  let s: RegExpExecArray | null;
+  while ((s = styleBlocks.exec(src)) !== null) {
+    const css = s[1] ?? "";
+    const hit = /will-change\s*:\s*(?!auto)([a-z-]+)/.exec(css);
+    if (hit !== null) {
+      findings.push({
+        checkId: "gsap-permanent-will-change", axis: AXIS, severity: "error",
+        line: lineOf(src, s.index + (s[0] ?? "").indexOf(hit[0])),
+        message: "`will-change` is parked in a static rule — set it as the animation starts and release it after, or the compositor layer never goes away (gsap-motion-direction.md, performance)",
+      });
+    }
+  }
+  return findings;
+}
+
+/** Every GSAP check, in checkId order. */
+export function gsapChecks(html: string): TasteFinding[] {
+  return [
+    ...checkGsapDevMarkers(html),
+    ...checkGsapNoReducedMotion(html),
+    ...checkGsapPermanentWillChange(html),
+    ...checkGsapPluginUnregistered(html),
+    ...checkGsapScrubAndToggle(html),
+    ...checkGsapTransformsPinnedElement(html),
+  ];
+}

--- a/src/core/taste-lint.ts
+++ b/src/core/taste-lint.ts
@@ -60,6 +60,7 @@ import { checkFontScaleSprawl } from "./taste-checks-font-scale.js";
 import { checkModeInvisibleSurface } from "./taste-checks-invisible-surface.js";
 import { checkContainerNestingDepth } from "./taste-checks-nesting.js";
 import { checkRadiusSprawl } from "./taste-checks-radius.js";
+import { gsapChecks } from "./taste-checks-gsap.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -156,6 +157,10 @@ export function lintTaste(html: string, opts: TasteLintOptions = {}): TasteLintR
     // Craft-lint graduation (spec CRAFT-LINT). Both new checks default warning.
     ...checkContainerNestingDepth(stripped),
     ...checkRadiusSprawl(stripped),
+    // Motion axis, GSAP subset — the machine-checkable half of
+    // knowledge/gsap-motion-direction.md, which shipped as prose with no linter.
+    // Every check is silent unless GSAP is actually present in the document.
+    ...gsapChecks(stripped),
   ];
 
   // Sort by rubric axis order, then by line (undefined lines last).

--- a/tests/taste-checks-gsap.test.ts
+++ b/tests/taste-checks-gsap.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Motion axis, GSAP subset. Every case here breaks one rule from
+ * knowledge/gsap-motion-direction.md on purpose and asserts the check fires,
+ * then pairs it with the correct form and asserts silence — a check that only
+ * ever goes green has not been shown to run, and one that never goes green is
+ * a tax rather than a gate.
+ *
+ * Pure content in / findings out; no tmpdir, no build artifact.
+ */
+import { describe, expect, it } from "vitest";
+
+import { gsapChecks, usesGsap } from "../src/core/taste-checks-gsap.js";
+
+const ids = (html: string): string[] => gsapChecks(html).map((f) => f.checkId).sort();
+
+/** Wrap a script body in the minimum document the checks read. */
+function doc(script: string, style = ""): string {
+  return `<!doctype html><html><head>${style ? `<style>${style}</style>` : ""}</head><body>
+<script>${script}</script></body></html>`;
+}
+
+/** A reduced-motion branch, so cases can isolate the rule they are testing. */
+const RM = `if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) { return; }`;
+
+describe("usesGsap — the gate every check sits behind", () => {
+  it("is false for a document with no GSAP, so none of these checks speak", () => {
+    const html = doc(`document.querySelector(".x").classList.add("on");`, `.x { will-change: transform; }`);
+    expect(usesGsap(html)).toBe(false);
+    expect(gsapChecks(html)).toEqual([]);
+  });
+
+  it("is true once a tween or a ScrollTrigger appears", () => {
+    expect(usesGsap(doc(`gsap.to(".x", { opacity: 1 });`))).toBe(true);
+    expect(usesGsap(doc(`ScrollTrigger.create({ trigger: ".x" });`))).toBe(true);
+  });
+});
+
+describe("gsap-dev-markers-shipped", () => {
+  it("fires on markers: true", () => {
+    expect(ids(doc(`${RM} gsap.to(".x", { scrollTrigger: { trigger: ".x", markers: true } });`)))
+      .toContain("gsap-dev-markers-shipped");
+  });
+
+  it("fires on GSDevTools", () => {
+    expect(ids(doc(`${RM} GSDevTools.create(); gsap.to(".x", { y: 10 });`)))
+      .toContain("gsap-dev-markers-shipped");
+  });
+
+  it("stays silent on markers: false — the switch in its off position", () => {
+    expect(ids(doc(`${RM} gsap.to(".x", { scrollTrigger: { trigger: ".x", markers: false } });`)))
+      .not.toContain("gsap-dev-markers-shipped");
+  });
+});
+
+describe("gsap-scrub-and-toggle", () => {
+  it("fires when one trigger sets both", () => {
+    expect(ids(doc(`${RM} gsap.to(".x", { scrollTrigger: { trigger: ".x", scrub: 1, toggleActions: "play none none reverse" } });`)))
+      .toContain("gsap-scrub-and-toggle");
+  });
+
+  it("allows two separate triggers, one scrubbed and one toggled", () => {
+    const html = doc(`${RM}
+      gsap.to(".a", { scrollTrigger: { trigger: ".a", scrub: 1 } });
+      gsap.to(".b", { scrollTrigger: { trigger: ".b", toggleActions: "play none none reverse" } });`);
+    expect(ids(html)).not.toContain("gsap-scrub-and-toggle");
+  });
+});
+
+describe("gsap-plugin-unregistered", () => {
+  it("fires when ScrollTrigger is used with no registerPlugin", () => {
+    expect(ids(doc(`${RM} ScrollTrigger.create({ trigger: ".x" });`)))
+      .toContain("gsap-plugin-unregistered");
+  });
+
+  it("stays silent once the plugin is registered", () => {
+    expect(ids(doc(`${RM} gsap.registerPlugin(ScrollTrigger); ScrollTrigger.create({ trigger: ".x" });`)))
+      .not.toContain("gsap-plugin-unregistered");
+  });
+
+  it("reads a multi-plugin registration", () => {
+    expect(ids(doc(`${RM} gsap.registerPlugin(ScrollTrigger, Flip); Flip.from(s); ScrollTrigger.create({ trigger: ".x" });`)))
+      .not.toContain("gsap-plugin-unregistered");
+  });
+});
+
+describe("gsap-transforms-pinned-el", () => {
+  it("fires when the pinned selector is itself transformed", () => {
+    expect(ids(doc(`${RM} gsap.registerPlugin(ScrollTrigger);
+      gsap.to(".scene", { yPercent: -50, scrollTrigger: { trigger: ".scene", pin: ".scene" } });`)))
+      .toContain("gsap-transforms-pinned-el");
+  });
+
+  it("allows pinning a wrapper and animating a child — the prescribed shape", () => {
+    expect(ids(doc(`${RM} gsap.registerPlugin(ScrollTrigger);
+      gsap.to(".scene__inner", { yPercent: -50, scrollTrigger: { trigger: ".scene", pin: ".scene" } });`)))
+      .not.toContain("gsap-transforms-pinned-el");
+  });
+
+  it("ignores a non-transform tween on the pinned element", () => {
+    expect(ids(doc(`${RM} gsap.registerPlugin(ScrollTrigger);
+      gsap.to(".scene", { opacity: 0.5, scrollTrigger: { trigger: ".scene", pin: ".scene" } });`)))
+      .not.toContain("gsap-transforms-pinned-el");
+  });
+});
+
+describe("gsap-no-reduced-motion", () => {
+  it("fires when GSAP animates with no reduced-motion branch anywhere", () => {
+    expect(ids(doc(`gsap.to(".x", { y: 40 });`))).toContain("gsap-no-reduced-motion");
+  });
+
+  it("accepts gsap.matchMedia with the reduce query", () => {
+    expect(ids(doc(`gsap.matchMedia().add("(prefers-reduced-motion: reduce)", () => {});
+      gsap.to(".x", { y: 40 });`))).not.toContain("gsap-no-reduced-motion");
+  });
+
+  it("accepts a CSS media query — the outcome is what is owed, not the API", () => {
+    expect(ids(doc(`gsap.to(".x", { y: 40 });`, `@media (prefers-reduced-motion: reduce) { * { animation: none; } }`)))
+      .not.toContain("gsap-no-reduced-motion");
+  });
+});
+
+describe("gsap-permanent-will-change", () => {
+  it("fires on will-change parked in a static rule", () => {
+    expect(ids(doc(`${RM} gsap.to(".x", { y: 40 });`, `.x { will-change: transform; }`)))
+      .toContain("gsap-permanent-will-change");
+  });
+
+  it("accepts will-change: auto, which is the release value", () => {
+    expect(ids(doc(`${RM} gsap.to(".x", { y: 40 });`, `.x { will-change: auto; }`)))
+      .not.toContain("gsap-permanent-will-change");
+  });
+
+  it("accepts it being set from script as the animation starts", () => {
+    expect(ids(doc(`${RM} gsap.to(".x", { y: 40, onStart() { el.style.willChange = "transform"; },
+      onComplete() { el.style.willChange = "auto"; } });`))).not.toContain("gsap-permanent-will-change");
+  });
+});
+
+describe("a correct GSAP scene trips nothing", () => {
+  it("registers its plugin, branches on reduced motion, pins a wrapper, animates a child", () => {
+    const html = doc(`
+      gsap.registerPlugin(ScrollTrigger);
+      gsap.matchMedia().add("(prefers-reduced-motion: no-preference)", () => {
+        gsap.to(".scene__inner", {
+          yPercent: -50,
+          scrollTrigger: { trigger: ".scene", pin: ".scene", scrub: 1, markers: false },
+        });
+      });`);
+    expect(gsapChecks(html)).toEqual([]);
+  });
+
+  it("every finding is Motion axis and error severity", () => {
+    const bad = doc(`GSDevTools.create(); ScrollTrigger.create({ trigger: ".x" }); gsap.to(".x", { y: 1 });`,
+      `.x { will-change: transform; }`);
+    const findings = gsapChecks(bad);
+    expect(findings.length).toBeGreaterThan(0);
+    for (const f of findings) {
+      expect(f.axis).toBe("Motion");
+      expect(f.severity).toBe("error");
+    }
+  });
+});


### PR DESCRIPTION
`knowledge/gsap-motion-direction.md` shipped as prose with no check. `CLAUDE.md` names this exact failure: *"A standard needs an emitter AND a linter. Prose-only standards drift."*

Six of its rules are decidable from static source, so they become checks on the Motion axis, all error severity:

| checkId | Fails when | Rule |
|---|---|---|
| `gsap-dev-markers-shipped` | `markers: true` or `GSDevTools` survives delivery | §5 markers are construction-only |
| `gsap-scrub-and-toggle` | one `scrollTrigger` sets both | §5 "never both" |
| `gsap-plugin-unregistered` | a plugin used with no `registerPlugin` | §7 plugin restraint |
| `gsap-transforms-pinned-el` | the pinned selector is itself transformed | §5 pin the wrapper, animate a child |
| `gsap-no-reduced-motion` | GSAP animates, nothing branches on reduce | §8 accessibility floor |
| `gsap-permanent-will-change` | `will-change` parked in a static rule | §8 performance |

**No new emitter, no new command.** The direction's emitter half already exists as the skill template; the debt was the missing check. These join the existing lint battery rather than growing a parallel one.

## Red-first, and green-first

Each check is tested by breaking its rule and asserting it fires, **and** paired with the correct form asserted silent. A check that never goes red has not been shown to run; a check that never goes green is a tax. 21 tests.

## What the real-data run bought

Running against this repo's own GSAP pages (Art III) immediately caught a false positive: `gsap-plugin-unregistered` fired on a `script` tag whose `src` merely names the plugin file, reading a filename as a use of the plugin. Tag attributes are now blanked — offsets preserved so line numbers stay right — before the scan. A probe with an injected violation still goes red, so the fix tightened precision without disabling the check.

## The boundary, written down

That same run produced the honest limit, now in the knowledge file:

> `taste-lint` reads one HTML file. A production scene keeps its choreography in an external `hero.js`, and **none of these checks reach it** — measured: all six stay silent on this repo's GSAP pages because every `gsap.*` call lives in a separate script. Treat a clean run as "nothing wrong in the markup", never as "the choreography is sound".

The judgment the file actually asks for — does the scene earn its pin, does the motion carry meaning — is not in scope for any static check and stays with the reviewer.

## Gates

`typecheck` · `lint` · `build` pass · `ui knowledge check` **0 findings** · 21 new tests · **2742 passed**. The same 5 files fail as on clean `origin/main` (#122, two fixed in #121; `spec-022-lifecycle` only times out under full-suite parallel load). No new failures.
