### PR TITLE
feat(deck): redesign all 28 slides into Radiant Big Number editorial style

### DIFF
--- a/docs/deck.css
+++ b/docs/deck.css
@@ -1156,3 +1156,435 @@
     transition: none !important;
   }
 }
+
+
+
+/* =========================================================
+   RADIANT EDITORIAL THEME (BIG NUMBER • LESS CONTENT)
+   High-Contrast Asymmetric Split Layout
+   Obsidian Dark Backdrop + Luminous Gradient Master Card + Tactile Metric Orbs
+   ========================================================= */
+
+:root {
+  --bg-obsidian: #040507;
+  --bg-obsidian-card: #0c0d12;
+  --text-obsidian-primary: #f5f6f8;
+  --text-obsidian-muted: #8e929b;
+  
+  /* Luminous Radiant Card Palette */
+  --luminous-grad: linear-gradient(135deg, #e4fed2 0%, #f7fed8 40%, #9ef5b4 100%);
+  --luminous-text-primary: #07080a;
+  --luminous-text-muted: #2d323b;
+  --luminous-track: rgba(0, 0, 0, 0.12);
+  --luminous-bar: #07080a;
+
+  /* Tactile Orbs Palette */
+  --orb-lime-bg: #e2fed0;
+  --orb-lime-text: #07080a;
+  --orb-dark-bg: radial-gradient(circle at 30% 30%, #22252e 0%, #0d0e12 100%);
+  --orb-dark-text: #f3f4f6;
+  --orb-dark-border: rgba(255, 255, 255, 0.1);
+  --orb-dark-shadow: 0 24px 60px rgba(0, 0, 0, 0.7);
+}
+
+.slide-stage {
+  background-color: var(--bg-obsidian) !important;
+  border-color: #1a1c24 !important;
+}
+
+.slide-item {
+  background-color: var(--bg-obsidian) !important;
+  color: var(--text-obsidian-primary);
+  padding: 48px 80px 40px !important;
+}
+
+.chrome-accent-strip {
+  background: var(--orb-lime-bg) !important;
+}
+
+.chrome-header {
+  top: 24px !important;
+  left: 80px !important;
+  right: 80px !important;
+  color: var(--text-obsidian-muted) !important;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+}
+
+.chrome-brand-badge {
+  background-color: var(--orb-lime-bg) !important;
+  color: var(--luminous-text-primary) !important;
+}
+
+.chrome-footer {
+  bottom: 20px !important;
+  left: 80px !important;
+  right: 80px !important;
+  color: var(--text-obsidian-muted) !important;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+/* Radiant Asymmetric Split Stage Layout */
+.radiant-stage-grid {
+  display: grid;
+  grid-template-columns: 46% 54%;
+  gap: 48px;
+  width: 100%;
+  height: calc(1080px - 140px);
+  margin-top: 10px;
+  align-items: center;
+}
+
+/* Left Column: Tactile Metric Orbs Cluster */
+.radiant-left-cluster {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.orb-badge-icon {
+  position: absolute;
+  top: 12%;
+  left: 12%;
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  background: var(--orb-lime-bg);
+  color: var(--orb-lime-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: 800;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+/* Primary Luminous Lime Orb */
+.orb-primary-lime {
+  position: absolute;
+  left: 6%;
+  bottom: 14%;
+  width: 330px;
+  height: 330px;
+  border-radius: 50%;
+  background: var(--orb-lime-bg);
+  color: var(--orb-lime-text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  text-align: center;
+  box-shadow: 0 20px 60px rgba(158, 245, 180, 0.25);
+  z-index: 3;
+  transition: transform 0.2s ease;
+}
+
+.orb-arrow {
+  font-size: 28px;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.orb-stat-huge {
+  font-size: 72px;
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+.orb-label-main {
+  font-size: 19px;
+  font-weight: 600;
+  margin-top: 10px;
+  letter-spacing: -0.01em;
+  opacity: 0.9;
+}
+
+/* Secondary Dark Glass Orb */
+.orb-secondary-dark {
+  position: absolute;
+  top: 16%;
+  right: 18%;
+  width: 270px;
+  height: 270px;
+  border-radius: 50%;
+  background: var(--orb-dark-bg);
+  color: var(--orb-dark-text);
+  border: 1px solid var(--orb-dark-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
+  box-shadow: var(--orb-dark-shadow);
+  z-index: 2;
+}
+
+.orb-stat-secondary {
+  font-size: 58px;
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+}
+
+.orb-label-secondary {
+  font-size: 17px;
+  font-weight: 500;
+  color: var(--text-obsidian-muted);
+  margin-top: 8px;
+}
+
+/* Tertiary Dark Glass Orb */
+.orb-tertiary-dark {
+  position: absolute;
+  right: 6%;
+  bottom: 12%;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: var(--orb-dark-bg);
+  color: var(--orb-dark-text);
+  border: 1px solid var(--orb-dark-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  text-align: center;
+  box-shadow: var(--orb-dark-shadow);
+  z-index: 1;
+}
+
+.orb-stat-tertiary {
+  font-size: 48px;
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+}
+
+.orb-label-tertiary {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-obsidian-muted);
+  margin-top: 6px;
+}
+
+/* Right Column: Luminous Master Card */
+.radiant-master-card {
+  width: 100%;
+  height: 100%;
+  max-height: 760px;
+  background: var(--luminous-grad);
+  border-radius: 36px;
+  padding: 56px 64px;
+  color: var(--luminous-text-primary);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6), 0 2px 10px rgba(0, 0, 0, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+.radiant-card-top {
+  display: flex;
+  flex-direction: column;
+}
+
+.radiant-dots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.radiant-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #07080a;
+  opacity: 0.85;
+}
+
+.radiant-display-title {
+  font-size: 60px;
+  font-weight: 800;
+  line-height: 1.04;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+  color: var(--luminous-text-primary);
+  margin-bottom: 22px;
+}
+
+.radiant-body-text {
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--luminous-text-muted);
+  max-width: 580px;
+  font-weight: 500;
+}
+
+.radiant-card-bottom {
+  margin-top: auto;
+  padding-top: 32px;
+}
+
+.radiant-hero-number {
+  font-size: 96px;
+  font-weight: 800;
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  color: var(--luminous-text-primary);
+}
+
+.radiant-hero-label {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--luminous-text-primary);
+  margin-top: 6px;
+}
+
+.radiant-progress-track {
+  width: 100%;
+  max-width: 220px;
+  height: 8px;
+  background: var(--luminous-track);
+  border-radius: 999px;
+  margin-top: 20px;
+  overflow: hidden;
+}
+
+.radiant-progress-fill {
+  height: 100%;
+  background: var(--luminous-bar);
+  border-radius: 999px;
+}
+
+/* Mobile & Tablet Responsive Breakdown */
+
+@media (max-width: 1023px) {
+  .radiant-stage-grid {
+    display: flex !important;
+    flex-direction: column !important;
+    height: auto !important;
+    gap: 24px !important;
+    margin-top: 40px !important;
+  }
+
+  .radiant-master-card {
+    order: 1 !important;
+    max-height: none !important;
+    padding: 32px 24px !important;
+    border-radius: 24px !important;
+  }
+
+  .radiant-display-title {
+    font-size: 34px !important;
+    line-height: 1.05 !important;
+    margin-bottom: 16px !important;
+  }
+
+  .radiant-body-text {
+    font-size: 15px !important;
+    line-height: 1.5 !important;
+  }
+
+  .radiant-card-bottom {
+    padding-top: 24px !important;
+  }
+
+  .radiant-hero-number {
+    font-size: 56px !important;
+  }
+
+  .radiant-hero-label {
+    font-size: 18px !important;
+  }
+
+  .radiant-left-cluster {
+    order: 2 !important;
+    position: relative !important;
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 12px !important;
+    height: auto !important;
+    width: 100% !important;
+    margin-top: 12px !important;
+  }
+
+  .orb-badge-icon {
+    position: relative !important;
+    top: auto !important;
+    left: auto !important;
+    grid-column: span 2;
+    width: 44px !important;
+    height: 44px !important;
+    font-size: 18px !important;
+    border-radius: 12px !important;
+    margin: 0 auto 8px auto !important;
+  }
+
+  .orb-primary-lime {
+    position: relative !important;
+    left: auto !important;
+    bottom: auto !important;
+    grid-column: span 2;
+    width: 100% !important;
+    height: auto !important;
+    border-radius: 20px !important;
+    padding: 24px !important;
+  }
+
+  .orb-stat-huge {
+    font-size: 48px !important;
+  }
+
+  .orb-label-main {
+    font-size: 15px !important;
+  }
+
+  .orb-secondary-dark {
+    position: relative !important;
+    top: auto !important;
+    right: auto !important;
+    width: 100% !important;
+    height: auto !important;
+    border-radius: 18px !important;
+    padding: 20px 14px !important;
+  }
+
+  .orb-stat-secondary {
+    font-size: 32px !important;
+  }
+
+  .orb-label-secondary {
+    font-size: 13px !important;
+  }
+
+  .orb-tertiary-dark {
+    position: relative !important;
+    right: auto !important;
+    bottom: auto !important;
+    width: 100% !important;
+    height: auto !important;
+    border-radius: 18px !important;
+    padding: 20px 14px !important;
+  }
+
+  .orb-stat-tertiary {
+    font-size: 32px !important;
+  }
+
+  .orb-label-tertiary {
+    font-size: 13px !important;
+  }
+}

--- a/docs/deck.js
+++ b/docs/deck.js
@@ -148,8 +148,8 @@
     if (!overviewGrid) return;
     overviewGrid.innerHTML = '';
     slides.forEach((slide, index) => {
-      const titleEl = slide.querySelector('.slide-title-display, .slide-title-h1');
-      const titleText = titleEl ? titleEl.textContent : 'Slide ' + (index + 1);
+      const titleEl = slide.querySelector('.radiant-display-title, .slide-title-display, .slide-title-h1');
+      const titleText = titleEl ? (titleEl.innerHTML.replace(/<br\s*\/?>/gi, ' ').replace(/<[^>]+>/g, '').trim()) : 'Slide ' + (index + 1);
       const card = document.createElement('div');
       card.className = 'overview-card' + (index === currentIndex ? ' active' : '');
       card.innerHTML = '<div style="font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 8px;">SLIDE ' + String(index + 1).padStart(2, '0') + '</div><div style="font-weight: 700; font-size: 14px; color: var(--text-primary); line-height: 1.3;">' + titleText + '</div>';
@@ -226,13 +226,21 @@
         const slideData = DECK_I18N.slides[slideNum] && (DECK_I18N.slides[slideNum][lang] || DECK_I18N.slides[slideNum].en);
         if (slideData) {
           const eyebrowEl = slide.querySelector('.slide-eyebrow');
-          const titleEl = slide.querySelector('.slide-title-display, .slide-title-h1');
+          const titleEl = slide.querySelector('.radiant-display-title, .slide-title-display, .slide-title-h1');
           const subtitleEl = slide.querySelector('.slide-subtitle');
           const notesEl = slide.querySelector('[data-speaker-notes]');
 
-          if (eyebrowEl && slideData.eyebrow) eyebrowEl.innerHTML = slideData.eyebrow;
+          const radTitle = slide.querySelector('.radiant-display-title');
+          const radBody = slide.querySelector('.radiant-body-text');
+          const radHeroNum = slide.querySelector('.radiant-hero-number');
+          const radHeroLabel = slide.querySelector('.radiant-hero-label');
+          if (radTitle && slideData.title) radTitle.innerHTML = slideData.title;
+          if (radBody && (slideData.body || slideData.subtitle)) radBody.innerHTML = slideData.body || slideData.subtitle;
+          if (radHeroNum && slideData.heroNum) radHeroNum.textContent = slideData.heroNum;
+          if (radHeroLabel && slideData.heroLabel) radHeroLabel.textContent = slideData.heroLabel;
+
           if (titleEl && slideData.title) titleEl.innerHTML = slideData.title;
-          if (subtitleEl && slideData.subtitle) subtitleEl.innerHTML = slideData.subtitle;
+          if (subtitleEl && (slideData.subtitle || slideData.body)) subtitleEl.innerHTML = slideData.subtitle || slideData.body;
           if (notesEl && slideData.notes) notesEl.setAttribute('data-speaker-notes', slideData.notes);
         }
       });

--- a/docs/design-os-guide-slides.html
+++ b/docs/design-os-guide-slides.html
@@ -53,2105 +53,1796 @@
   <main class="deck-viewport">
     <div class="slide-stage" id="slideStage">
 
-
 <article class="slide-item active" id="slide-1" data-index="1">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
           <div class="chrome-brand">
             <span class="chrome-brand-badge">DESIGN:OS</span>
-            <span>Masterclass Architecture Deck</span>
+            <span>Masterclass Operating Guide • V1.0</span>
           </div>
-          <div>The Complete 28-Slide Operating Guide • v1.0.0</div>
+          <div>01 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone" style="justify-content: center;">
-          <span class="slide-eyebrow gsap-reveal">Multi-Runtime Design CLI • Production Operating Manual</span>
-          <h1 class="slide-title-display gsap-reveal">
-            Mastering DESIGN:OS<br>From AI Reasoning to Scroll-Cinema &amp; Figma.
-          </h1>
-          <p class="slide-subtitle gsap-reveal" style="font-size: var(--font-size-xl);">
-            7 Strategic Acts: AI vs Kernel Division, 6 Onboarding Roads, Live Figma Bridge 9410, Recall Vector Memory, OKLCH Color Science, 3D GFlow &amp; 2K Scroll-Cinema, and Qualified Delivery Floor.
-          </p>
-          <div style="display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px;" class="gsap-reveal">
-            <span class="matrix-badge">28 Master Slides</span>
-            <span class="matrix-badge">Figma Desktop Hand</span>
-            <span class="matrix-badge">GFlow &amp; Scroll-Cinema</span>
-            <span class="matrix-badge">OKLCH &amp; P3 Gamut</span>
-            <span class="matrix-badge">12 UX Laws</span>
-            <span class="matrix-badge">Fable Thinking</span>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">✦</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">100%</div>
+              <div class="orb-label-main">Deterministic Floor</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">7 Acts</div>
+              <div class="orb-label-secondary">Strategic Chapters</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">28</div>
+              <div class="orb-label-tertiary">Master Slides</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">MASTERING<br>DESIGN:OS</h1>
+              <p class="radiant-body-text">The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0 %</div>
+              <div class="radiant-hero-label">LLM Luck Required</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
+            </div>
           </div>
         </section>
 
         <footer class="chrome-footer">
-          <div>Press [Left / Right Arrow] or [Space] to navigate • [S] Speaker Notes • [O] Overview • [L] Language • [T] Theme</div>
-          <div id="slideCounterDisplay">01 / 28</div>
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>01 / 28</div>
         </footer>
-        <div data-speaker-notes="Chào mừng đến với DESIGN:OS Masterclass mở rộng 28 slide. Đây là bộ cẩm nang hoàn chỉnh nhất, bao quát từ lõi toán học, cầu nối Figma, bộ nhớ vector đến điện ảnh cuộn trang 3D và 5 câu chuyện ngụ ngôn triết lý thiết kế."></div>
+        <div data-speaker-notes="Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."></div>
       </article>
 
 <article class="slide-item" id="slide-2" data-index="2">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Triết Lý Cốt Lõi</span></div>
-          <div>Hồi 1 • 01 • Core Foundations</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Core Philosophy</span>
+          </div>
+          <div>02 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Triết Lý Cốt Lõi</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 3 Supreme Truths of DESIGN:OS</h2>
-            <p class="slide-subtitle gsap-reveal">Eliminating reliance on LLM luck. Enforcing quality through color science and deterministic machine floors.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">360°</div>
+              <div class="orb-label-main">OKLCH Uniformity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0.02</div>
+              <div class="orb-label-secondary">ΔEOK Precision</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">14</div>
+              <div class="orb-label-tertiary">Quality Linters</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableTriadTitle fableTriadDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="nodePillar2"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableTriadTitle">The 3 Supreme Truths Architecture Triad</title>
-            <desc id="fableTriadDesc">Equilateral harmonic architecture diagram representing the three unbreakable foundational pillars: OKLCH Color Math, Sovereign Division of Labor, and the 14-Plank Machine Quality Floor.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">3 SUPREME<br>TRUTHS</h1>
+              <p class="radiant-body-text">Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.</p>
+            </div>
 
-            <defs>
-              <linearGradient id="triadBeam" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-primary)" stop-opacity="0.3"/>
-                <stop offset="50%" stop-color="var(--text-primary)" stop-opacity="0.9"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="0.3"/>
-              </linearGradient>
-            </defs>
-
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE HARMONIC FIELD • THREE INVIOLABLE TRUTHS</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="url(#triadBeam)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="url(#triadBeam)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <rect x="450" y="212" width="60" height="20" rx="10" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="480" y="226" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">FEEDS</text>
-
-            <rect x="930" y="212" width="60" height="20" rx="10" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="960" y="226" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">ENFORCES</text>
-
-            <!-- PILLAR 1: OKLCH COLOR SCIENCE (Prismatic Chamber) -->
-            <g id="nodePillar1" class="interactive-node" tabindex="0" role="button" aria-label="Truth 1: OKLCH Color Science" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TRUTH 01 • COLOR SCIENCE</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="104" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <polygon points="104,152 116,172 92,172" fill="var(--text-primary)"/>
-
-              <text x="136" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">OKLCH Color Math</text>
-              <text x="136" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Perceptual Uniformity Scale</text>
-
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu hoàn toàn HSL &amp; Hex ngẫu nhiên</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ sáng cảm nhận L đồng đều mọi góc Hue</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đạt chuẩn tương phản quang học WCAG AA</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khai thác 100% không gian màu Display P3</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">METRIC: ΔEOK &lt; 0.02 (Pure Precision)</text>
-            </g>
-
-            <!-- PILLAR 2: DIVISION OF LABOR (Dual Core Monolith - FOCAL) -->
-            <g id="nodePillar2" class="interactive-node" tabindex="0" role="button" aria-label="Truth 2: Division of Labor" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">TRUTH 02 • BRAIN &amp; BODY [FOCAL]</text>
-
-              <circle cx="564" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="564" cy="165" r="7" fill="var(--text-primary)"/>
-
-              <text x="596" y="162" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Division of Labor</text>
-              <text x="596" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Reasoning Brain vs UI Kernel</text>
-
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Host AI: Suy luận Persona, IA &amp; Component Tree</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• UI Kernel: Đóng gói DTCG Tokens &amp; Toán học màu</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tách bạch tuyệt đối giữa Ý Niệm và Thực Thi</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Không ảo giác token, không phụ thuộc may rủi</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">CONTRACT: Zero Stochastic Code</text>
-            </g>
-
-            <!-- PILLAR 3: MACHINE QUALITY FLOOR (14-Plank Grid) -->
-            <g id="nodePillar3" class="interactive-node" tabindex="0" role="button" aria-label="Truth 3: Deterministic Machine Floor" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TRUTH 03 • QUALITY FLOOR</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="1044" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <rect x="1038" y="159" width="12" height="12" fill="var(--text-primary)"/>
-
-              <text x="1076" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Deterministic Floor</text>
-              <text x="1076" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">14 Hard Machine Linters</text>
-
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui validate-layout: Bắt tràn màn hình &amp; soup &gt; 2</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui taste-lint: Sàn thẩm mỹ 6 trục (Taste Floor)</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui a11y-lint: Kiểm thử tĩnh chuẩn tiếp cận Tier-1</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Lỗi bất kỳ = Chặn merge Pull Request (Exit 1)</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">GATE: 14 Linters 100% Pass</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-2">
-              <span class="readout-badge">FOUNDATIONS TRIAD: ACTIVE</span>
-              <span class="readout-text" id="readout-text-slide-2">Click any Pillar node or trigger button to inspect architectural contract parameters.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">14</div>
+              <div class="radiant-hero-label">Machine Floor Linters</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Operating Manual • Core Philosophy</div><div>02 / 28</div></footer>
-        <div data-speaker-notes="3 chân lý tối thượng là kim chỉ nam: biến sự hỗn loạn của LLM thành kết quả tất định."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>02 / 28</div>
+        </footer>
+        <div data-speaker-notes="The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."></div>
       </article>
 
 <article class="slide-item" id="slide-3" data-index="3">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Kiến Trúc Phân Quyền</span></div>
-          <div>Hồi 1 • 02 • Architecture Split</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Architecture Split</span>
+          </div>
+          <div>03 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Kiến Trúc Phân Quyền</span>
-            <h2 class="slide-title-h1 gsap-reveal">Division of Labor: AI Reasoning vs UI Kernel</h2>
-            <p class="slide-subtitle gsap-reveal">Host AI Agent handles creative reasoning, while the deterministic UI Kernel executes color mathematics and strict compliance verification.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚙</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">2 Minds</div>
+              <div class="orb-label-main">Human & Host Agent</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Kernel</div>
+              <div class="orb-label-secondary">Deterministic Engine</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Leaks</div>
+              <div class="orb-label-tertiary">Stochastic Free</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableArchTitle fableArchDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="kernelChamber"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableArchTitle">The Division of Labor: From Human Beacon to Neural Prism and Monolithic Kernel Gate</title>
-            <desc id="fableArchDesc">Aerodynamic structural diagram illustrating the living transformation of human intent through neural reasoning into deterministic, mathematically verified UI code.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DIVISION<br>OF LABOR</h1>
+              <p class="radiant-body-text">The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.</p>
+            </div>
 
-            <defs>
-              <!-- Luminous Waveguide Gradients -->
-              <linearGradient id="beamGradient1" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-muted)" stop-opacity="0.2"/>
-                <stop offset="50%" stop-color="var(--text-primary)" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="1"/>
-              </linearGradient>
-              <linearGradient id="beamGradient2" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-primary)" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="1"/>
-              </linearGradient>
-              <filter id="glowFable" x="-20%" y="-20%" width="140%" height="140%">
-                <feGaussianBlur stdDeviation="6" result="blur" />
-                <feComposite in="SourceGraphic" in2="blur" operator="over" />
-              </filter>
-            </defs>
-
-            <!-- Background Atmospheric Energy Field -->
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--text-inverse)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE LIVING STREAM • BRAIN &amp; BODY DUALITY PIPELINE</text>
-
-            <!-- 1. Waveguide Conduit 1 (Human -> AI) -->
-            <path id="waveguide1" d="M 360 250 C 420 250, 440 250, 500 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 360 250 C 420 250, 440 250, 500 250" fill="none" stroke="url(#beamGradient1)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <!-- 2. Waveguide Conduit 2 (AI -> Kernel) -->
-            <path id="waveguide2" d="M 900 250 C 960 250, 980 250, 1040 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 900 250 C 960 250, 980 250, 1040 250" fill="none" stroke="url(#beamGradient2)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <!-- Photonic Packets (Data flow pulse) -->
-
-            <!-- Conduit Flow Status Badges -->
-            <rect x="395" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="430" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PROMPT</text>
-
-            <rect x="935" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="970" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">AST / DTCG</text>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 1: THE HUMAN BEACON (Intent Transmitter)        -->
-            <!-- ======================================================== -->
-            <g id="nodeUser" class="interactive-node" tabindex="0" role="button" aria-label="Organism 1: Human Intent Beacon" style="cursor: pointer;">
-              <!-- Outer Resonance Rings -->
-              <circle cx="200" cy="250" r="145" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-              <circle cx="200" cy="250" r="130" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              
-              <!-- Core Capsule -->
-              <rect x="80" y="150" width="240" height="200" rx="16" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              
-              <!-- Glowing Beacon Emitter -->
-              <circle cx="200" cy="180" r="22" fill="var(--text-inverse)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="200" cy="180" r="8" fill="var(--text-primary)"/>
-
-              <text x="200" y="228" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.1em" text-anchor="middle">ORGAN 01 • TRANSMITTER</text>
-              <text x="200" y="255" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Human Intent</text>
-              <text x="200" y="278" font-family="var(--font-mono)" font-size="12" fill="var(--text-secondary)" text-anchor="middle">Natural Language Brief</text>
-
-              <!-- Parametric Readout -->
-              <rect x="96" y="298" width="208" height="34" rx="8" fill="var(--bg-surface)" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="200" y="320" font-family="var(--font-mono)" font-size="11" font-weight="600" fill="var(--text-primary)" text-anchor="middle">INPUT: Brand • Mood • Target</text>
-            </g>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 2: THE NEURAL PRISM (Creative Reasoning Brain)  -->
-            <!-- ======================================================== -->
-            <g id="nodeAgent" class="interactive-node" tabindex="0" role="button" aria-label="Organism 2: Neural Synthesis Prism" style="cursor: pointer;">
-              <!-- Outer Prism Geometry (Hexagonal Resonator) -->
-              <polygon points="700,70 880,160 880,340 700,430 520,340 520,160" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              
-              <!-- Inner Refraction Core -->
-              <polygon points="700,100 850,175 850,325 700,400 550,325 550,175" fill="var(--bg-surface-raised)" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <!-- Central Synthesis Engine -->
-              <circle cx="700" cy="200" r="36" fill="var(--text-inverse)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <text x="700" y="195" font-family="'Inter'" font-size="22" font-weight="900" fill="var(--text-primary)" text-anchor="middle">AI</text>
-              <text x="700" y="215" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-muted)" text-anchor="middle">BRAIN</text>
-
-              <text x="700" y="260" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.1em" text-anchor="middle">ORGAN 02 • NEURAL PRISM</text>
-              <text x="700" y="285" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Host AI Agent</text>
-              <text x="700" y="308" font-family="var(--font-mono)" font-size="12" fill="var(--text-secondary)" text-anchor="middle">Creative Synthesis &amp; Persona</text>
-
-              <!-- Refraction Beams (Persona spectrum) -->
-              <line x1="600" y1="330" x2="800" y2="330" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="700" y="352" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Resolves Persona Family</text>
-              <text x="700" y="374" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Crafts Semantic DOM Tree</text>
-
-              <rect x="570" y="390" width="260" height="28" rx="6" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="700" y="408" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-primary)" text-anchor="middle">ROLE: Creative Reasoning</text>
-            </g>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 3: THE MONOLITHIC KERNEL GATE (Deterministic)   -->
-            <!-- ======================================================== -->
-            <g id="nodeKernel" class="interactive-node" tabindex="0" role="button" aria-label="Organism 3: Monolithic Kernel Gate" style="cursor: pointer;">
-              <!-- Outer Monolith Boundary (Heavy Structural Armor) -->
-              <rect x="1040" y="70" width="350" height="360" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              
-              <!-- Top Gate Header -->
-              <rect x="1040" y="70" width="350" height="50" rx="16" fill="var(--text-primary)"/>
-              <text x="1215" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">ORGAN 03 • MONOLITHIC GATE [FOCAL]</text>
-
-              <!-- Core Identity -->
-              <text x="1215" y="155" font-family="var(--font-sans)" font-size="22" font-weight="800" fill="var(--text-primary)" text-anchor="middle">UI Kernel Engine</text>
-              <text x="1215" y="178" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)" text-anchor="middle">Deterministic Color &amp; 14 Linters Floor</text>
-              <line x1="1070" y1="195" x2="1360" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <!-- 3 Gate Valves (The 3 Hard Machine Checks) -->
-              <g transform="translate(1065, 210)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">1. OKLCH / P3 Color Math</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">ΔEOK PASS</text>
-              </g>
-
-              <g transform="translate(1065, 256)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">2. DTCG Token Compiler</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">100% BOUND</text>
-              </g>
-
-              <g transform="translate(1065, 302)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">3. 14 Deterministic Linters</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">EXIT 0</text>
-              </g>
-
-              <!-- Qualified Delivery Seal -->
-              <rect x="1065" y="355" width="300" height="50" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1215" y="385" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.06em" text-anchor="middle">✓ ZERO-STOCHASTIC RELEASE</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-3">
-              <span class="readout-badge">PIPELINE: ACTIVE</span>
-              <span class="readout-text" id="readout-text-slide-3">Click any node or press 'Simulate Data Flow' to watch the prompt-to-kernel deterministic validation run.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Deterministic Compile</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Architecture • System Division of Labor</div><div>03 / 28</div></footer>
-        <div data-speaker-notes="AI Agent suy luận, UI Kernel kiểm định. Hai bán cầu kết hợp thành vòng lặp tự sửa lỗi hoàn hảo."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>03 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."></div>
       </article>
 
 <article class="slide-item" id="slide-4" data-index="4">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Optional Hands</span></div>
-          <div>Hồi 1 • 03 • Specialized Modules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Hands Ecosystem</span>
+          </div>
+          <div>04 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Module Mở Rộng</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 6 Specialized Optional Hands Ecosystem</h2>
-            <p class="slide-subtitle gsap-reveal">Specialized modular hands extend multi-dimensional design capabilities, gracefully degrading when unconfigured.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">✋</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Hands</div>
+              <div class="orb-label-main">Specialized Engines</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 CLI</div>
+              <div class="orb-label-secondary">Unified Toolchain</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 ms</div>
+              <div class="orb-label-tertiary">Runtime Bloat</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. FIGMA 1:1 MIRROR</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">figma-agent</div>
-              <p class="stat-desc">Connects to Figma Desktop via port 9410. Synthesizes precise auto-layout, swaps component instances, and syncs tokens bi-directionally.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">OPTIONAL<br>HANDS</h1>
+              <p class="radiant-body-text">Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. SEMANTIC MEMORY</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">recall (mind)</div>
-              <p class="stat-desc">Local vector memory powered by ONNX embeddings. Recalls historical lessons at task start and distills insights upon completion.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. 3D &amp; SCROLL CINEMA</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">gflow &amp; scrub</div>
-              <p class="stat-desc">Điều khiển camera 3D và cuộn video không vết cắt (Seam Physics) thông qua Google Flow (Veo/Imagen).</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">4. VISUAL REGRESSION</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">page-shot &amp; vr</div>
-              <p class="stat-desc">Chụp render thực tế và so sánh pixel-level diff cho từng component (vr-matrix), ngăn chặn layout shift ngoài ý muốn.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">5. RENDERED A11Y</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">a11y-audit</div>
-              <p class="stat-desc">Thực thi axe-core trên Chrome headless để kiểm tra độ tương phản thực tế và cây ngữ nghĩa ARIA ở trạng thái render thật.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">6. CANVAS &amp; SHADERS</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">canvas-ui (T6)</div>
-              <p class="stat-desc">Mô phỏng chất liệu Liquid Glass, hạt 3D và WebGL shaders với hợp đồng dọn dẹp bộ nhớ (Teardown Contract).</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6</div>
+              <div class="radiant-hero-label">Multi-Runtime Engines</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Toolchain • Optional Hands Ecosystem</div><div>04 / 28</div></footer>
-        <div data-speaker-notes="6 cánh tay này biến DESIGN:OS thành hệ điều hành thiết kế toàn năng từ giao diện web phẳng đến không gian 3D và canvas Figma."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>04 / 28</div>
+        </footer>
+        <div data-speaker-notes="The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."></div>
       </article>
 
 <article class="slide-item" id="slide-5" data-index="5">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Bản Sắc Thiết Kế</span></div>
-          <div>Hồi 1 • 04 • Design Soul Architecture</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Design Soul</span>
+          </div>
+          <div>05 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bản Sắc Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">3-Tier Design Soul Hierarchy (Never / Always / Voice)</h2>
-            <p class="slide-subtitle gsap-reveal">Establishing aesthetic stances and consistent design vocabulary from Studio level down to specific projects.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏛</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">WT 75</div>
+              <div class="orb-label-main">Project Overrides</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">WT 50</div>
+              <div class="orb-label-secondary">Studio Shared</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">WT 0</div>
+              <div class="orb-label-tertiary">Factory Invariant</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableSoulTitle fableSoulDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ttb"
-            data-focal-id="soulProject"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableSoulTitle">Design Soul: The 3 Tiers of Sovereignty &amp; Precedence Cascade</title>
-            <desc id="fableSoulDesc">Hierarchical cascade diagram showing the three tiers of design truth: Factory Invariants, Studio Standards, and Project Soul.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">CASCADE OF<br>SOVEREIGNTY</h1>
+              <p class="radiant-body-text">Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE SOVEREIGNTY CASCADE • THREE TIERS OF DESIGN TRUTH</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- TIER 0: FACTORY INVARIANTS -->
-            <g id="soulFactory" class="interactive-node" tabindex="0" role="button" aria-label="Tier 0: Factory Invariants" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TIER 0 • FACTORY (WEIGHT 0)</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="104" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <rect x="96" y="157" width="16" height="16" fill="var(--text-primary)"/>
-
-              <text x="136" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Factory Invariants</text>
-              <text x="136" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Immutable Architectural Laws</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu Purple-on-Dark &amp; Glow Borders</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cấm container lồng nhau quá 2 cấp (Soup)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chuẩn tiếp cận WCAG 2.2 AA bắt buộc</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Luật cứng: Không thể bị ghi đè (Immutable)</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SOVEREIGNTY: Absolute Floor</text>
-            </g>
-
-            <!-- TIER 1: STUDIO STANDARDS -->
-            <g id="soulStudio" class="interactive-node" tabindex="0" role="button" aria-label="Tier 1: Studio Standards" style="cursor: pointer;">
-              <rect x="520" y="80" width="400" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="520" y="80" width="400" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="544" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TIER 1 • STUDIO (WEIGHT 50)</text>
-              <circle cx="890" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="564" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <polygon points="564,152 576,172 552,172" fill="var(--text-primary)"/>
-
-              <text x="596" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Studio Standards</text>
-              <text x="596" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Workspace Shared Conventions</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chuẩn nhịp 8px Spacing Grid toàn team</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Thư viện Icon mặc định: Phosphor Icons</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Font typography mặc định theo phân khúc</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Định hình phong cách chung cả tổ chức</text>
-
-              <rect x="544" y="350" width="352" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="720" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">WORKSPACE: Shared Stance</text>
-            </g>
-
-            <!-- TIER 2: PROJECT SOUL -->
-            <g id="soulProject" class="interactive-node" tabindex="0" role="button" aria-label="Tier 2: Project Soul" style="cursor: pointer;">
-              <rect x="1000" y="70" width="380" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1000" y="70" width="380" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="1190" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">TIER 2 • PROJECT SOUL [FOCAL]</text>
-
-              <circle cx="1044" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="1044" cy="165" r="8" fill="var(--text-primary)"/>
-
-              <text x="1076" y="162" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Project Soul</text>
-              <text x="1076" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Bespoke Brand Persona</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Persona gia đình: Aurora Minimal / Brutalist</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bảng màu thương hiệu OKLCH độc bản</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ cao thang chuyển động (Motion Cap T5)</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Ghi đè Studio Stance khi Brief yêu cầu</text>
-
-              <rect x="1024" y="350" width="332" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1190" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">PRECEDENCE: Project Brief Wins</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-5">
-              <span class="readout-badge">PRECEDENCE: HIERARCHICAL</span>
-              <span class="readout-text" id="readout-text-slide-5">Click tiers to test rule resolution: Explicit User Brief (100) > Project Soul (75) > Studio Standards (50) > Factory Invariants (0).</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3 Tiers</div>
+              <div class="radiant-hero-label">Precedence Hierarchy</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 75%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Architecture • Soul Precedence</div><div>05 / 28</div></footer>
-        <div data-speaker-notes="Soul thiết lập lập trường thẩm mỹ. Explicit Brief từ user luôn có quyền ghi đè cao nhất."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>05 / 28</div>
+        </footer>
+        <div data-speaker-notes="Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."></div>
       </article>
 
 <article class="slide-item" id="slide-6" data-index="6">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Onboarding Router</span></div>
-          <div>Hồi 2 • 05 • The 6 Entry Roads</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Onboarding</span>
+          </div>
+          <div>06 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Onboarding</span>
-            <h2 class="slide-title-h1 gsap-reveal">6 Entry Roads for Project Onboarding (E1–E6)</h2>
-            <p class="slide-subtitle gsap-reveal">Chạy <code>ui scan --json</code> để tự động nhận diện tình trạng dự án và chọn đúng lộ trình khởi tạo.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🛣</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Roads</div>
+              <div class="orb-label-main">E1 to E6 Pathways</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Scan</div>
+              <div class="orb-label-secondary">Auto Diagnostics</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Guess</div>
+              <div class="orb-label-tertiary">Instant Setup</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E1 • GREENFIELD</span>
-              <div class="stat-label" style="margin-top: 10px;">Dự án mới hoàn toàn</div>
-              <p class="stat-desc">Khởi tạo Design System từ 1 trong 26 Personas có sẵn.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui ds init app --persona aurora-minimal</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">6 ENTRY<br>ROADS</h1>
+              <p class="radiant-body-text">Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E2 • BROWNFIELD</span>
-              <div class="stat-label" style="margin-top: 10px;">Codebase có sẵn</div>
-              <p class="stat-desc">Quét mã nguồn hiện tại và biên dịch thành Design System.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui scan --cwd . → /ui:learn</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E3 • LIVE URL</span>
-              <div class="stat-label" style="margin-top: 10px;">Bóc tách từ URL</div>
-              <p class="stat-desc">Trích xuất màu sắc, typography từ website bạn thích.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>/ui:from-url https://linear.app</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E4 • FIGMA LIBRARY</span>
-              <div class="stat-label" style="margin-top: 10px;">Thư viện Figma</div>
-              <p class="stat-desc">Quét Figma file và chuyển thành bundle tokens + registry.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>design-os figma scan → ui ingest-figma-ds</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E5 • DTCG TOKENS</span>
-              <div class="stat-label" style="margin-top: 10px;">Token shadcn / DTCG</div>
-              <p class="stat-desc">Nạp file token JSON có sẵn vào kho Design System.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui ds import tokens.json --name my-app</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E6 • MOODBOARD</span>
-              <div class="stat-label" style="margin-top: 10px;">Ảnh mẫu &amp; Shots</div>
-              <p class="stat-desc">Nạp ảnh chụp màn hình để trích xuất hạt giống Persona.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>design-os reference add ./shot.png</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">E1-E6</div>
+              <div class="radiant-hero-label">Deterministic Gateways</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 60%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Onboarding • Entry Roads E1-E6</div><div>06 / 28</div></footer>
-        <div data-speaker-notes="6 cổng vào này đảm bảo DESIGN:OS hòa nhập vào bất kỳ quy trình làm việc nào của team dù là vẽ Figma trước hay code trước."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>06 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."></div>
       </article>
 
 <article class="slide-item" id="slide-7" data-index="7">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Onboarding Checklist</span></div>
-          <div>Hồi 2 • 06 • Setup &amp; Stop-Gates</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Setup Protocol</span>
+          </div>
+          <div>07 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Onboarding</span>
-            <h2 class="slide-title-h1 gsap-reveal">5-Step Setup Protocol &amp; Mandatory STOP-Gates</h2>
-            <p class="slide-subtitle gsap-reveal">Tuân thủ thứ tự thiết lập để không bao giờ gặp lỗi lệch mã băm hoặc sai danh tính Agent.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🔒</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <div class="stat-label">5 Bước Khởi Tạo Chuẩn Xác</div>
-              <ol style="padding-left: 24px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 16px;">
-                <li><strong>Bước 0:</strong> Chạy <code>ui onboard</code> xem checklist và <code>ui scan</code>.</li>
-                <li><strong>Bước 1:</strong> Chọn cổng (E1–E6) để seal kho <code>design/</code>.</li>
-                <li><strong>Bước 2:</strong> Chạy cả 2 lệnh Doctor: <code>ui doctor</code> và <code>design-os doctor --versions</code>.</li>
-                <li><strong>Bước 3:</strong> Điền Never/Always/Voice vào <code>design/soul.md</code> rồi chạy <code>ui ds soul check</code>.</li>
-                <li><strong>Bước 4:</strong> Khởi tạo đội ngũ Agent: <code>ui agents init</code>.</li>
-              </ol>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">5 Steps</div>
+              <div class="orb-label-main">Ordered Setup</div>
             </div>
 
-            <div style="display: flex; flex-direction: column; gap: 24px;">
-              <div class="slide-card gsap-card" style="border-top-color: var(--text-primary);">
-                <span class="matrix-badge">⚠️ STOP-GATE 1: NAMING HYGIENE</span>
-                <div class="stat-label" style="margin-top: 8px;">Luôn truyền --name khi import token</div>
-                <p class="stat-desc">Nếu bỏ qua <code>--name &lt;slug&gt;</code>, hệ thống mặc định đặt tên là <code>imported-ds</code> và sau này toàn bộ AI Agent sẽ bị đặt tên là <code>designer-imported-ds</code>.</p>
-              </div>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Protocol Bound</div>
+            </div>
 
-              <div class="slide-card gsap-card" style="border-top-color: var(--text-primary);">
-                <span class="matrix-badge">🛑 STOP-GATE 2: GIT PREREQUISITE</span>
-                <div class="stat-label" style="margin-top: 8px;">Bắt buộc phải là Git Repository</div>
-                <p class="stat-desc">Dự án phải có <code>.git</code> (chạy <code>git init</code>). Nếu không có git, các lỗi lệch hash registry sau này sẽ không thể diff và truy vết.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Drift</div>
+              <div class="orb-label-tertiary">Token Hash Sync</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">SETUP<br>PROTOCOL</h1>
+              <p class="radiant-body-text">Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">5 / 5</div>
+              <div class="radiant-hero-label">STOP-Gates Cleared</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Onboarding • Verification &amp; Stop-Gates</div><div>07 / 28</div></footer>
-        <div data-speaker-notes="Hai bác sĩ kiểm tra 2 việc khác nhau: ui doctor kiểm tra kernel, còn design-os doctor kiểm tra các optional hands."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>07 / 28</div>
+        </footer>
+        <div data-speaker-notes="Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."></div>
       </article>
 
 <article class="slide-item" id="slide-8" data-index="8">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Agent Staff</span></div>
-          <div>Hồi 2 • 07 • Virtual Design Staff</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Virtual Staff</span>
+          </div>
+          <div>08 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đội Ngũ Agent</span>
-            <h2 class="slide-title-h1 gsap-reveal">Virtual Design Staff &amp; Periodic Heartbeat</h2>
-            <p class="slide-subtitle gsap-reveal">Một lệnh <code>ui agents init</code> cấp cho dự án một đội ngũ 3 chuyên gia AI với ranh giới trách nhiệm nghiêm ngặt.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">👥</div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">AI DESIGNER</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">designer-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Sinh giao diện, tinh chỉnh code HTML/CSS theo đúng Design Tokens.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ được tự chấm điểm bài làm của chính mình.</p>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Agents</div>
+              <div class="orb-label-main">Specialized Roles</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">AI CURATOR</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">curator-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Thanh tra độc lập, phê bình thẩm mỹ 6+1 trục, đối chiếu spec và đưa ra phán quyết.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ được trực tiếp sửa code.</p>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Heart</div>
+              <div class="orb-label-secondary">Cron Heartbeat</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FIGMA HAND</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">figma-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Thao tác trực tiếp trên canvas Figma qua broker port 9410.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ giả lập thao tác khi plugin Figma đang tắt.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">24 / 7</div>
+              <div class="orb-label-tertiary">Active Governance</div>
             </div>
           </div>
 
-          <div class="slide-card gsap-card" style="margin-top: 24px; padding: 20px 28px; flex-direction: row; align-items: center; justify-content: space-between;">
-            <div>
-              <strong style="font-size: var(--font-size-base);">❤️ Recurring Heartbeat (<code>design-os heartbeat</code>)</strong>
-              <p style="font-size: var(--font-size-sm); color: var(--text-muted); margin-top: 4px;">Tự động quét định kỳ: <code>nightly-a11y</code>, <code>weekly-specimen</code>, <code>preview-pages</code>, <code>figma-hygiene</code>.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VIRTUAL<br>STAFF</h1>
+              <p class="radiant-body-text">A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.</p>
             </div>
-            <span class="matrix-badge">HEALTH CHECK CỤC BỘ</span>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3</div>
+              <div class="radiant-hero-label">Specialized AI Roles</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
+            </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Agents • Specialized Roles</div><div>08 / 28</div></footer>
-        <div data-speaker-notes="Designer không bao giờ tự chấm điểm, Curator không bao giờ tự sửa code. Ranh giới trách nhiệm bảo đảm chất lượng khách quan."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>08 / 28</div>
+        </footer>
+        <div data-speaker-notes="Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."></div>
       </article>
 
 <article class="slide-item" id="slide-9" data-index="9">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Daily Verbs</span></div>
-          <div>Hồi 2 • 08 • Everyday Workflow</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Daily Operations</span>
+          </div>
+          <div>09 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Công Việc Hàng Ngày</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 6 Core Daily Verbs (/ui:* Commands)</h2>
-            <p class="slide-subtitle gsap-reveal">Tương tác bằng ngôn ngữ tự nhiên trong CLI. AI tự chuyển hóa thành kế hoạch và code chuẩn mực.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Verbs</div>
+              <div class="orb-label-main">Natural CLI Verbs</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Self-Healing</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 UI Lag</div>
+              <div class="orb-label-tertiary">Instant Output</div>
+            </div>
           </div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. TẠO GIAO DIỆN MỚI</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:generate</span> landing page for an AI developer tool, brutalist-editorial, dark theme
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
-              <p class="stat-desc" style="margin-top: 10px;">Biến yêu cầu sơ khai thành brief chuẩn, dựng layout gắn token, kiểm tra qua 6 linter.</p>
+              <h1 class="radiant-display-title">6 CORE<br>DAILY VERBS</h1>
+              <p class="radiant-body-text">High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. CHỈNH SỬA VI MÔ</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:iterate</span> make the hero headline larger and the CTA button warmer
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6</div>
+              <div class="radiant-hero-label">Core Operating Verbs</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
               </div>
-              <p class="stat-desc" style="margin-top: 10px;">Chỉnh sửa phẫu thuật từng dòng (line-diff) mà không làm vỡ cấu trúc của Design System.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. DỰNG LÊN FIGMA CANVAS</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:to-figma</span> 3-tier pricing card component with toggle
-              </div>
-              <p class="stat-desc" style="margin-top: 10px;">Vẽ trực tiếp lên Figma với cấu trúc auto-layout, instance component thật và biến màu token.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">4. TRUY VẤN BỘ NHỚ</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:why</span> why did we choose oklch(0.65 0.24 260) for primary CTA?
-              </div>
-              <p class="stat-desc" style="margin-top: 10px;">Truy vết nguồn gốc mọi quyết định thiết kế trong quá khứ từ Design Memory.</p>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • Core Verbs</div><div>09 / 28</div></footer>
-        <div data-speaker-notes="6 động từ thường nhật biến CLI thành bảng điều khiển trực quan cho designer và developer."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>09 / 28</div>
+        </footer>
+        <div data-speaker-notes="Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."></div>
       </article>
 
 <article class="slide-item" id="slide-10" data-index="10">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Figma Agent Hand</span></div>
-          <div>Hồi 3 • 09 • Real-Time Bridge</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Figma Bridge</span>
+          </div>
+          <div>10 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Cầu Nối Hai Chiều</span>
-            <h2 class="slide-title-h1 gsap-reveal">Figma Desktop Bridge: Broker Port 9410</h2>
-            <p class="slide-subtitle gsap-reveal">AI Agents and Designers collaborate on a real-time Figma file with secure conflict locking.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌉</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">9410</div>
+              <div class="orb-label-main">WebSocket Broker</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">127.0.0.1</div>
+              <div class="orb-label-secondary">Local Loopback</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Conflict</div>
+              <div class="orb-label-tertiary">Atomic Mutex</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableFigmaTitle fableFigmaDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="figmaNodeBroker"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableFigmaTitle">The Two-Way Bridge: Code Tokens to Live Figma Desktop Canvas</title>
-            <desc id="fableFigmaDesc">Bi-directional suspension bridge diagram connecting Code AST Tokens and Figma Desktop Canvas via Port 9410 Broker.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">FIGMA LIVE<br>DESKTOP BRIDGE</h1>
+              <p class="radiant-body-text">Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE TWO-WAY BRIDGE • PORT 9410 BI-DIRECTIONAL REAL-TIME SYNCHRONIZATION</text>
-
-            <path d="M 380 250 C 440 250, 460 250, 520 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 380 250 C 440 250, 460 250, 520 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <path d="M 920 250 C 980 250, 1000 250, 1060 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 920 250 C 980 250, 1000 250, 1060 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <rect x="415" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="450" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PUSH DTCG</text>
-
-            <rect x="955" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="990" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PULL AST</text>
-
-            <!-- WEST BANK: CODE -->
-            <g id="figmaNodeCode" class="interactive-node" tabindex="0" role="button" aria-label="West Bank: Code Token Matrix" style="cursor: pointer;">
-              <rect x="60" y="80" width="320" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="320" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">WEST BANK • CODE</text>
-              <circle cx="350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Code Repository</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">design/tokens.json (DTCG)</text>
-              <line x1="84" y1="205" x2="356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chân lý màu: design/tokens.json</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Lệnh biên dịch: ui tokens export</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khung mã AST ngữ nghĩa HTML/CSS</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động sinh Pull Request AST diff</text>
-
-              <rect x="84" y="350" width="272" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="220" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SOURCE: Canonical DTCG</text>
-            </g>
-
-            <!-- CENTER ARCH: BROKER (FOCAL) -->
-            <g id="figmaNodeBroker" class="interactive-node" tabindex="0" role="button" aria-label="Center Arch: Port 9410 Rotary Commutator" style="cursor: pointer;">
-              <polygon points="720,60 900,155 900,345 720,440 540,345 540,155" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              
-              <rect x="580" y="80" width="280" height="36" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="103" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.08em" text-anchor="middle">WS BROKER : 9410 [FOCAL]</text>
-
-              <circle cx="720" cy="200" r="45" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <circle cx="720" cy="200" r="8" fill="var(--text-primary)"/>
-              <line x1="720" y1="160" x2="720" y2="240" stroke="var(--text-primary)" stroke-width="3" stroke-linecap="round"/>
-              <line x1="680" y1="200" x2="760" y2="200" stroke="var(--text-primary)" stroke-width="3" stroke-linecap="round"/>
-
-              <text x="720" y="270" font-family="var(--font-sans)" font-size="20" font-weight="900" fill="var(--text-primary)" text-anchor="middle">figma-agent Broker</text>
-              <text x="720" y="292" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)" text-anchor="middle">127.0.0.1:9410 WebSocket Engine</text>
-
-              <line x1="600" y1="315" x2="840" y2="315" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="720" y="338" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Atomic Token Serialization</text>
-              <text x="720" y="360" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Mutex Conflict-Lock Protocol</text>
-
-              <rect x="580" y="380" width="280" height="36" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="403" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STATUS: Port 9410 Connected</text>
-            </g>
-
-            <!-- EAST BANK: CANVAS -->
-            <g id="figmaNodeCanvas" class="interactive-node" tabindex="0" role="button" aria-label="East Bank: Live Figma Desktop Canvas" style="cursor: pointer;">
-              <rect x="1060" y="80" width="320" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1060" y="80" width="320" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1084" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">EAST BANK • CANVAS</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1084" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Figma Desktop Canvas</text>
-              <text x="1084" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Live Variables &amp; Auto-Layout</text>
-              <line x1="1084" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1084" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Liên kết trực tiếp Figma Variables</text>
-              <text x="1084" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Auto-Layout tương thích 1:1 Flexbox</text>
-              <text x="1084" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Designer chỉnh sửa = Gửi event WebSocket</text>
-              <text x="1084" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động bắt sự kiện qua Plugin manifest</text>
-
-              <rect x="1084" y="350" width="272" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1220" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SURFACE: Live Native Canvas</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-10">
-              <span class="readout-badge">BROKER: PORT 9410 READY</span>
-              <span class="readout-text" id="readout-text-slide-10">Click nodes or simulation button to inspect bi-directional Code-to-Canvas push and Canvas-to-Code pull mechanics.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">9410</div>
+              <div class="radiant-hero-label">Local Broker Port</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Figma Hand • Real-Time Bridge Architecture</div><div>10 / 28</div></footer>
-        <div data-speaker-notes="Broker port 9410 kết nối trực tiếp với Figma Desktop Plugin, cho phép AI dựng layout và gán token tự động."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>10 / 28</div>
+        </footer>
+        <div data-speaker-notes="The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."></div>
       </article>
 
 <article class="slide-item" id="slide-11" data-index="11">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Figma Craft</span></div>
-          <div>Hồi 3 • 10 • Auto-Layout &amp; Token Binding</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Token Pipeline</span>
+          </div>
+          <div>11 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Chuẩn Mực Figma</span>
-            <h2 class="slide-title-h1 gsap-reveal">Crafting Canvas Art: Auto-Layout &amp; Variables</h2>
-            <p class="slide-subtitle gsap-reveal">Không bao giờ vẽ hình chữ nhật tự do vô nghĩa. Mọi khung vẽ đều phải tuân thủ nghiêm ngặt Auto-Layout và Token Variables.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🪙</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 Source</div>
+              <div class="orb-label-main">design/tokens.json</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">W3C DTCG Standard</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Stale</div>
+              <div class="orb-label-tertiary">Synchronized AST</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. AUTO-LAYOUT SÂU</span>
-              <div class="stat-label" style="margin-top: 8px;">Auto-Layout 100%</div>
-              <p class="stat-desc" style="margin-top: 10px;">100% frame đều có layoutMode (HORIZONTAL / VERTICAL), padding và itemSpacing chuẩn token 4/8px.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>node.layoutMode = 'VERTICAL';</code><br>
-                <code>node.itemSpacing = 16;</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">CANONICAL<br>TOKENS</h1>
+              <p class="radiant-body-text">Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. INSTANCE SWAPPING</span>
-              <div class="stat-label" style="margin-top: 8px;">Tái Dùng Component</div>
-              <p class="stat-desc" style="margin-top: 10px;">Không vẽ lại Button hay Input. Trỏ tìm Component trong Library và gọi <code>createInstance()</code> chuẩn xác.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>const inst = comp.createInstance();</code><br>
-                <code>parent.appendChild(inst);</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. VARIABLE BINDING</span>
-              <div class="stat-label" style="margin-top: 8px;">Gắn Token Variables</div>
-              <p class="stat-desc" style="margin-top: 10px;">Màu sắc không tô raw hex. Ánh xạ trực tiếp sang Figma Variable Collection đã nhập từ DTCG tokens.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>node.setBoundVariable('fills', vId);</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Token AST Binding</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Figma Craft • Canonical Canvas Rules</div><div>11 / 28</div></footer>
-        <div data-speaker-notes="Canvas trên Figma được tạo ra có cấu trúc như mã nguồn thực tế: có auto-layout, instance component và variable tokens."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>11 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."></div>
       </article>
 
 <article class="slide-item" id="slide-12" data-index="12">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Audit Surfaces</span></div>
-          <div>Hồi 3 • 11 • Audit Disambiguation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Quality Audit</span>
+          </div>
+          <div>12 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bề Mặt Kiểm Định</span>
-            <h2 class="slide-title-h1 gsap-reveal">Dissecting the 4 'Audit' Surfaces</h2>
-            <p class="slide-subtitle gsap-reveal">4 công cụ khác nhau cùng mang từ khóa "Audit". Chọn đúng công cụ theo đúng đối tượng kiểm tra.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🔬</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">4 Surfaces</div>
+              <div class="orb-label-main">Chamber Sieve</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">6 Axes</div>
+              <div class="orb-label-secondary">Taste Rubric</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≤ 2</div>
+              <div class="orb-label-tertiary">Max Container Soup</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableAuditTitle fableAuditDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="auditQuad1"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableAuditTitle">The 4 Registered Audit Surfaces Matrix</title>
-            <desc id="fableAuditDesc">Quadrant architecture matrix showing the four deterministic verification surfaces: taste-lint, validate-layout, a11y-lint, and full-stack vr-gate release suites.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">4 QUALITY<br>SURFACES</h1>
+              <p class="radiant-body-text">The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE 4-CHAMBER QUALITY SIEVE • DETERMINISTIC VERIFICATION MATRIX</text>
-
-            <!-- Quad 1: Taste Lint -->
-            <g id="auditQuad1" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 1: ui taste-lint" style="cursor: pointer;">
-              <rect x="60" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <rect x="60" y="80" width="310" height="44" rx="16" fill="var(--text-primary)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.08em">SURFACE 01 • TASTE LINT [FOCAL]</text>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui taste-lint</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">6-Axis Aesthetic Rubric Floor</text>
-              <line x1="84" y1="205" x2="346" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét tĩnh HTML/CSS không cần render</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• 14 Luật cấm (Anti-Patterns)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kiểm tra Tracking &amp; Bo góc token</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tốc độ: &lt; 20ms thực thi</text>
-
-              <rect x="84" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="1.5"/>
-              <text x="215" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EXIT: Floor Score &ge; 8.0</text>
-            </g>
-
-            <!-- Quad 2: Validate Layout -->
-            <g id="auditQuad2" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 2: ui validate-layout" style="cursor: pointer;">
-              <rect x="400" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="400" y="80" width="310" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="424" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 02 • LAYOUT</text>
-
-              <text x="424" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui validate-layout</text>
-              <text x="424" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Container Soup &amp; Overflow</text>
-              <line x1="424" y1="205" x2="686" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="424" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bắt container lồng nhau &gt; 2 cấp</text>
-              <text x="424" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét tràn nội dung trục ngang</text>
-              <text x="424" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Phát hiện đứt gãy Grid / Flexbox</text>
-              <text x="424" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khắc phục tự động qua autofix</text>
-
-              <rect x="424" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="555" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">CHECK: Nesting &le; 2 Levels</text>
-            </g>
-
-            <!-- Quad 3: A11y Lint -->
-            <g id="auditQuad3" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 3: ui a11y-lint" style="cursor: pointer;">
-              <rect x="740" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="740" y="80" width="310" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="764" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 03 • ACCESSIBILITY</text>
-
-              <text x="764" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui a11y-lint</text>
-              <text x="764" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Tier-1 Static Accessibility Floor</text>
-              <line x1="764" y1="205" x2="1026" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="764" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tương phản WCAG 2.2 AA (4.5:1)</text>
-              <text x="764" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bắt buộc role, title, aria-labels</text>
-              <text x="764" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kiểm tra thứ tự Focus bàn phím</text>
-              <text x="764" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cấm thẻ img thiếu alt, button rỗng</text>
-
-              <rect x="764" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="895" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">LEVEL: WCAG 2.2 AA Static</text>
-            </g>
-
-            <!-- Quad 4: Full Audit -->
-            <g id="auditQuad4" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 4: design-os audit" style="cursor: pointer;">
-              <rect x="1080" y="80" width="300" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1080" y="80" width="300" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1104" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 04 • FULL SUITE</text>
-
-              <text x="1104" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">design-os audit</text>
-              <text x="1104" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">10-Tool Release Suite &amp; VR</text>
-              <line x1="1104" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1104" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kết hợp 10 công cụ kiểm định toàn diện</text>
-              <text x="1104" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét Visual Regression 3 Viewports</text>
-              <text x="1104" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đồng bộ Dark/Light Paired Tokens</text>
-              <text x="1104" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Điều kiện tiên quyết để tạo PR merge</text>
-
-              <rect x="1104" y="350" width="252" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1230" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">GATE: 0 Errors Required</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-12">
-              <span class="readout-badge">SURFACES: 4 REGISTERED</span>
-              <span class="readout-text" id="readout-text-slide-12">Click any of the 4 quadrants to inspect its exact CLI command, verification scope, and execution order.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0</div>
+              <div class="radiant-hero-label">Errors Allowed to Ship</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • The 4 Audit Surfaces</div><div>12 / 28</div></footer>
-        <div data-speaker-notes="Ma trận 2x2 giúp phân biệt rõ 4 loại lệnh audit để không bao giờ chạy nhầm đối tượng quét."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>12 / 28</div>
+        </footer>
+        <div data-speaker-notes="Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."></div>
       </article>
 
 <article class="slide-item" id="slide-13" data-index="13">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Finding Triage</span></div>
-          <div>Hồi 3 • 12 • Triage &amp; Core Rules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Triage Protocol</span>
+          </div>
+          <div>13 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Xử Lý Lỗi</span>
-            <h2 class="slide-title-h1 gsap-reveal">Finding Triage Workflow &amp; 2 Golden Rules</h2>
-            <p class="slide-subtitle gsap-reveal">Đọc kết quả linter một cách khoa học để đưa ra quyết định Iterate hay Escalate.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚖</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <div class="stat-label">Quy Trình Triage 3 Bước</div>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 16px;">
-                <li><strong>1. Luôn đọc cờ --json:</strong> Exit code <code>1</code> có thể do gọi sai flag (<code>BAD_ARG</code>) hoặc lỗi thiết kế thực sự. Xem envelope trước khi sửa code.</li>
-                <li><strong>2. Exit 0:</strong> Không có lỗi severity error → Sẵn sàng phát hành (Ship).</li>
-                <li><strong>3. Exit 1:</strong> Có lỗi nghiêm trọng → Chọn <strong>Iterate</strong> (sửa code và quét lại) hoặc <strong>Escalate</strong> (báo cáo mâu thuẫn yêu cầu).</li>
-              </ul>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Turns</div>
+              <div class="orb-label-main">Max Iteration Loop</div>
             </div>
 
-            <div style="display: flex; flex-direction: column; gap: 24px;">
-              <div class="slide-card gsap-card">
-                <span class="matrix-badge">NGUYÊN TẮC VÀNG 1</span>
-                <div class="stat-label" style="margin-top: 8px;">Xác Minh Trước Khi Sửa (Verify Before Fix)</div>
-                <p class="stat-desc">Kiểm tra xem cặp màu hoặc class bị linter bắt lỗi có thực sự được render trên màn hình không trước khi vội vàng sửa đổi file token gốc.</p>
-              </div>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Verify</div>
+              <div class="orb-label-secondary">Confirm Real Bug</div>
+            </div>
 
-              <div class="slide-card gsap-card">
-                <span class="matrix-badge">NGUYÊN TẮC VÀNG 2</span>
-                <div class="stat-label" style="margin-top: 8px;">A11y Luôn Thắng Phong Cách (A11y Always Wins)</div>
-                <p class="stat-desc">Nếu màu sắc từ yêu cầu của người dùng vi phạm độ tương phản WCAG AA, bắt buộc phải ưu tiên sửa màu A11y và báo cáo minh bạch cho người dùng.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Guess</div>
+              <div class="orb-label-tertiary">Evidence Grounded</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">TRIAGE &<br>AUTODETECT</h1>
+              <p class="radiant-body-text">Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">≤ 3</div>
+              <div class="radiant-hero-label">Turns to Convergence</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 90%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • Finding Triage</div><div>13 / 28</div></footer>
-        <div data-speaker-notes="A11y luôn là tiêu chuẩn cứng không thể thỏa hiệp trong DESIGN:OS."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>13 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."></div>
       </article>
 
 <article class="slide-item" id="slide-14" data-index="14">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Design Memory</span></div>
-          <div>Hồi 4 • 13 • Recall &amp; Reflect Loop</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Vector Memory</span>
+          </div>
+          <div>14 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bộ Nhớ Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">Design Memory Loop (Recall &amp; Reflect)</h2>
-            <p class="slide-subtitle gsap-reveal">DESIGN:OS ghi nhớ mọi kinh nghiệm thành công và bài học thất bại để AI ngày càng hoàn thiện sau mỗi phiên làm việc.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🧠</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">0.85</div>
+              <div class="orb-label-main">Cosine Similarity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">ONNX</div>
+              <div class="orb-label-secondary">Local Vector Space</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">On-Device Privacy</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableMemTitle fableMemDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="memReflect"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableMemTitle">Design Vector Memory: The Recall &amp; Reflection Distillation Loop</title>
-            <desc id="fableMemDesc">Vector manifold diagram showing the three phases of continuous design learning.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VECTOR<br>MEMORY LOOP</h1>
+              <p class="radiant-body-text">Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE RESONANT VECTOR MANIFOLD • PERSISTENT DISTILLATION LOOP</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- STEP 1: RECALL -->
-            <g id="memRecall" class="interactive-node" tabindex="0" role="button" aria-label="Step 1: Vector Recall Manifold" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">STEP 01 • VECTOR RECALL</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Recall Embedding Query</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Local ONNX Latent Space</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét Brief qua mô hình Vector ONNX cục bộ</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đo độ tương đồng Cosine (Cosine Similarity &ge; 0.85)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Truy hồi 2 bài học kinh nghiệm sát nhất</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Nạp trực tiếp vào ngữ cảnh Host AI Agent</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">LATENT: Cosine Match &ge; 0.85</text>
-            </g>
-
-            <!-- STEP 2: WORK EXECUTION -->
-            <g id="memWork" class="interactive-node" tabindex="0" role="button" aria-label="Step 2: Primed Work Execution" style="cursor: pointer;">
-              <rect x="520" y="80" width="400" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="520" y="80" width="400" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="544" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">STEP 02 • WORK EXECUTION</text>
-              <circle cx="890" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Primed Synthesis</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Grounded Generation Pass</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Sinh mã giao diện với bối cảnh đã tôi luyện</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tuyệt đối không lặp lại lỗi thiết kế cũ</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Áp dụng Persona và Token chuẩn xác</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tiết kiệm hàng triệu token context window</text>
-
-              <rect x="544" y="350" width="352" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="720" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EXECUTION: Zero Regression</text>
-            </g>
-
-            <!-- STEP 3: REFLECT -->
-            <g id="memReflect" class="interactive-node" tabindex="0" role="button" aria-label="Step 3: Reflection &amp; Distillation" style="cursor: pointer;">
-              <rect x="1000" y="70" width="380" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1000" y="70" width="380" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="1190" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">STEP 03 • REFLECT &amp; DISTILL [FOCAL]</text>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Crucible Distillation</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">.design/memory.json Repository</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đúc kết bài học sau mỗi lượt giao diện thành công</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đóng băng kinh nghiệm thành JSON có cấu trúc</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cập nhật kho tri thức vĩnh cửu .design/memory.json</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khép kín chu trình tự học vô hạn của Agent</text>
-
-              <rect x="1024" y="350" width="332" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1190" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">STORAGE: .design/memory.json</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-14">
-              <span class="readout-badge">VECTOR MEMORY: ONNX READY</span>
-              <span class="readout-text" id="readout-text-slide-14">Click steps to test Recall query embedding, execution context priming, and post-task lesson distillation.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0.85</div>
+              <div class="radiant-hero-label">Recall Cosine Threshold</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Memory • Living Learning Loop</div><div>14 / 28</div></footer>
-        <div data-speaker-notes="Vòng lặp bộ nhớ đảm bảo AI không bao giờ lặp lại sai lầm trong quá khứ."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>14 / 28</div>
+        </footer>
+        <div data-speaker-notes="Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."></div>
       </article>
 
 <article class="slide-item" id="slide-15" data-index="15">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Taste Voting</span></div>
-          <div>Hồi 4 • 14 • Elo Rating &amp; Corpus Curation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Crucible</span>
+          </div>
+          <div>15 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tiến Hóa Thẩm Mỹ</span>
-            <h2 class="slide-title-h1 gsap-reveal">Taste Elo Rating &amp; Sample Curation</h2>
-            <p class="slide-subtitle gsap-reveal">Cơ chế đấu cặp Blind A/B Comparison chấm điểm Elo giúp hệ thống tự động lọc ra các biến thể thiết kế xuất sắc nhất.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🧪</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Hooks</div>
+              <div class="orb-label-main">Capture Triggers</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 File</div>
+              <div class="orb-label-secondary">.design/memory.json</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Dups</div>
+              <div class="orb-label-tertiary">Deduplicated Lessons</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. BLIND A/B PAIRING</span>
-              <div class="stat-label" style="margin-top: 8px;">Đấu Cặp Ẩn Danh</div>
-              <p class="stat-desc" style="margin-top: 10px;">Hệ thống bốc ngẫu nhiên 2 biến thể ứng cử viên (Candidate A vs B) được sinh cùng một đề bài.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui taste next --domain landing</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">CRUCIBLE<br>DISTILLATION</h1>
+              <p class="radiant-body-text">Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. TASTE VOTING</span>
-              <div class="stat-label" style="margin-top: 8px;">Ghi Nhận Phán Quyết</div>
-              <p class="stat-desc" style="margin-top: 10px;">Designer hoặc Curator bình chọn biến thể chiến thắng dựa trên 6+1 trục thẩm mỹ.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui taste record --winner a</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. CORPUS ADMISSION</span>
-              <div class="stat-label" style="margin-top: 8px;">Nạp Kho Mẫu Vàng</div>
-              <p class="stat-desc" style="margin-top: 10px;">Các biến thể đạt Elo rating &gt; 1200 được tự động nạp vào corpus mẫu để huấn luyện và nạp prior cho AI.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui corpus promote --id cand-09</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Local Privacy Capture</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Taste Evolution • Elo Rating Matrix</div><div>15 / 28</div></footer>
-        <div data-speaker-notes="Hệ thống Elo định lượng hóa gu thẩm mỹ, giúp kho mẫu thiết kế ngày càng tinh hoa."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>15 / 28</div>
+        </footer>
+        <div data-speaker-notes="Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."></div>
       </article>
 
 <article class="slide-item" id="slide-16" data-index="16">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Color Science</span></div>
-          <div>Hồi 5 • 15 • OKLCH &amp; Perceptual Uniformity</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Color Science</span>
+          </div>
+          <div>16 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Khoa Học Màu Sắc</span>
-            <h2 class="slide-title-h1 gsap-reveal">OKLCH Mathematics, P3 Gamut &amp; Delta EOK</h2>
-            <p class="slide-subtitle gsap-reveal">Why DESIGN:OS deprecates legacy HSL/Hex in favor of the perceptually uniform OKLCH color space.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌈</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">360°</div>
+              <div class="orb-label-main">Perceptual Uniformity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">P3</div>
+              <div class="orb-label-secondary">Wide Color Gamut</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≤ 0.02</div>
+              <div class="orb-label-tertiary">Patch Semver Limit</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableColorTitle fableColorDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="colorOKLCH"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableColorTitle">Color Science: OKLCH &amp; Display P3 Perceptual Uniformity</title>
-            <desc id="fableColorDesc">Color gamut architecture diagram illustrating legacy HSL non-linear brightness distortion, uniform OKLCH perceived lightness across all 360-degree hues, and mathematical Semver breaking changes via Delta EOK calipers.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">OKLCH COLOR<br>SCIENCE</h1>
+              <p class="radiant-body-text">Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE POLARIZED OPTICAL CHAMBER • OKLCH COLOR SCIENCE &amp; DELTA E PRECISION</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- CHAMBER 1: HSL -->
-            <g id="colorHSL" class="interactive-node" tabindex="0" role="button" aria-label="Legacy HSL Flaw" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-muted)" letter-spacing="0.08em">LEGACY COLOR • HSL / sRGB</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-muted)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">HSL Perceptual Flaw</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Non-Linear Human Optical Perception</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Vàng L=50% sáng gấp 3 lần Xanh L=50%</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đổi tông màu (Hue) làm vỡ độ tương phản</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chỉ bao phủ không gian màu hẹp sRGB</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Ảo giác toán học không đáng tin cậy</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-muted)" text-anchor="middle">FLAW: Inconsistent Luminance</text>
-            </g>
-
-            <!-- CHAMBER 2: OKLCH -->
-            <g id="colorOKLCH" class="interactive-node" tabindex="0" role="button" aria-label="OKLCH Color Science" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">OKLCH SCIENCE • DISPLAY P3 [FOCAL]</text>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">OKLCH Uniformity</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Perceptually Constant Lightness L</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ sáng cảm nhận L=0.7 đồng đều mọi góc Hue</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động bảo đảm chuẩn tương phản WCAG 2.2</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khai thác 100% dải màu siêu rộng Display P3</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tích hợp trực tiếp lệnh CLI: ui color scale</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">STANDARD: 100% P3 Color Gamut</text>
-            </g>
-
-            <!-- CHAMBER 3: SEMVER DELTA -->
-            <g id="colorDelta" class="interactive-node" tabindex="0" role="button" aria-label="Delta EOK Semver Precision" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SEMVER DELTA • ΔEOK</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ΔEOK Precision Meter</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Mathematical Semver Versioning</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ΔEOK &gt; 0.05: Thay đổi lớn (MAJOR Breaking)</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• 0.02 &lt; ΔEOK &le; 0.05: Bổ sung (MINOR Additive)</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ΔEOK &le; 0.02: Vi chỉnh không lệch mắt (PATCH)</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đánh giá khách quan, loại bỏ tranh cãi cảm tính</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">CALIPER: Precise Semver Gate</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-16">
-              <span class="readout-badge">COLOR MATH: OKLCH / P3</span>
-              <span class="readout-text" id="readout-text-slide-16">Inspect why OKLCH delivers uniform perceptual lightness L across all hues and how ΔEOK enforces Semver breaking color changes.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">ΔE 0.02</div>
+              <div class="radiant-hero-label">Semver Patch Precision</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Color Science • OKLCH Space &amp; Delta EOK</div><div>16 / 28</div></footer>
-        <div data-speaker-notes="OKLCH Color Mathematics bảo đảm mọi thang bậc sáng đều có cùng độ tương phản mắt thấy."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>16 / 28</div>
+        </footer>
+        <div data-speaker-notes="Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."></div>
       </article>
 
 <article class="slide-item" id="slide-17" data-index="17">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Taste Rubric</span></div>
-          <div>Hồi 5 • 16 • 6+1 Craft Axes</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Taste Rubric</span>
+          </div>
+          <div>17 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tiêu Chuẩn Thẩm Mỹ</span>
-            <h2 class="slide-title-h1 gsap-reveal">6+1 Aesthetic Axes (Taste Rubric)</h2>
-            <p class="slide-subtitle gsap-reveal">Scoring every axis from 0 to 10. AI synthesizes layouts against these principles, and Curator enforces compliance.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎯</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6+1</div>
+              <div class="orb-label-main">Heptagonal Axes</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">Core 0</div>
+              <div class="orb-label-secondary">Consistency Mandate</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≥ 8.0</div>
+              <div class="orb-label-tertiary">Release Quality Floor</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableTasteTitle fableTasteDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="tasteCore7"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableTasteTitle">The 6+1 Taste Rubric Craft Radar Matrix</title>
-            <desc id="fableTasteDesc">Heptagonal craft resonator radar diagram evaluating generated UI against Consistency Core 7 and the 6 aesthetic axes.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">6+1 TASTE<br>RUBRIC RADAR</h1>
+              <p class="radiant-body-text">Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE HEPTAGONAL CRAFT RESONATOR • 6+1 TASTE RUBRIC FLOOR (ui taste-lint)</text>
-
-            <circle cx="720" cy="260" r="160" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-            <circle cx="720" cy="260" r="110" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-            <circle cx="720" cy="260" r="60" fill="none" stroke="var(--border-strong)" stroke-width="1.5"/>
-
-            <line x1="720" y1="260" x2="720" y2="80" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="880" y2="170" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="880" y2="350" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="720" y2="440" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="560" y2="350" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="560" y2="170" stroke="var(--border-strong)" stroke-width="1.5"/>
-
-            <!-- CENTER CORE -->
-            <g id="tasteCore7" class="interactive-node" tabindex="0" role="button" aria-label="Core Axis: Consistency" style="cursor: pointer;">
-              <circle cx="720" cy="260" r="54" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <circle cx="720" cy="260" r="46" fill="var(--text-primary)"/>
-              <text x="720" y="254" font-family="var(--font-mono)" font-size="11" font-weight="900" fill="var(--text-inverse)" text-anchor="middle">CORE 0</text>
-              <text x="720" y="272" font-family="var(--font-sans)" font-size="12" font-weight="800" fill="var(--text-inverse)" text-anchor="middle">Consistency</text>
-            </g>
-
-            <!-- AXES -->
-            <g id="tasteAxis1" class="interactive-node" tabindex="0" role="button" aria-label="Axis 1: Layout &amp; Hierarchy" style="cursor: pointer;">
-              <rect x="620" y="70" width="200" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="720" y="96" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">01 • LAYOUT &amp; HIERARCHY</text>
-              <text x="720" y="118" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Reading Order (Score: 9.0)</text>
-            </g>
-
-            <g id="tasteAxis2" class="interactive-node" tabindex="0" role="button" aria-label="Axis 2: Typography &amp; Rhythm" style="cursor: pointer;">
-              <rect x="910" y="140" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="1015" y="166" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">02 • TYPOGRAPHY</text>
-              <text x="1015" y="188" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Modular Scale (Score: 8.8)</text>
-            </g>
-
-            <g id="tasteAxis3" class="interactive-node" tabindex="0" role="button" aria-label="Axis 3: Spacing &amp; Geometry" style="cursor: pointer;">
-              <rect x="910" y="320" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="1015" y="346" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">03 • SPACING</text>
-              <text x="1015" y="368" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">8px Rhythm (Score: 9.2)</text>
-            </g>
-
-            <g id="tasteAxis4" class="interactive-node" tabindex="0" role="button" aria-label="Axis 4: Iconography &amp; Badges" style="cursor: pointer;">
-              <rect x="620" y="410" width="200" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="720" y="436" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">04 • ICONOGRAPHY</text>
-              <text x="720" y="458" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Single Family (Score: 9.5)</text>
-            </g>
-
-            <g id="tasteAxis5" class="interactive-node" tabindex="0" role="button" aria-label="Axis 5: Motion Ladder" style="cursor: pointer;">
-              <rect x="320" y="320" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="425" y="346" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">05 • MOTION LADDER</text>
-              <text x="425" y="368" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">T5 Choreography (Score: 9.0)</text>
-            </g>
-
-            <g id="tasteAxis6" class="interactive-node" tabindex="0" role="button" aria-label="Axis 6: Depth &amp; Surfaces" style="cursor: pointer;">
-              <rect x="320" y="140" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="425" y="166" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">06 • DEPTH &amp; SURFACES</text>
-              <text x="425" y="188" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Tonal Elevation (Score: 9.0)</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-17">
-              <span class="readout-badge">RADAR SCAN: 6+1 AXES</span>
-              <span class="readout-text" id="readout-text-slide-17">Click axes or press Scan to inspect individual craft score thresholds (Consistency 10/10, Layout & Typo >= 8.0).</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">8.0 +</div>
+              <div class="radiant-hero-label">Minimum Score to Ship</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 80%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Quality Floor • The 6+1 Taste Rubric</div><div>17 / 28</div></footer>
-        <div data-speaker-notes="Mô hình 6+1 trục thẩm mỹ: Consistency là lõi bất biến, 6 trục vệ tinh định hình vẻ đẹp thị giác."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>17 / 28</div>
+        </footer>
+        <div data-speaker-notes="A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."></div>
       </article>
 
 <article class="slide-item" id="slide-18" data-index="18">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Machine Floor</span></div>
-          <div>Hồi 5 • 17 • 14 Hard Linter Rules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • UX Laws</span>
+          </div>
+          <div>18 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Sàn Chất Lượng Tất Định</span>
-            <h2 class="slide-title-h1 gsap-reveal">14 Hard Machine Floor Linters</h2>
-            <p class="slide-subtitle gsap-reveal">Các linter <code>taste-lint</code>, <code>validate-layout</code>, <code>content-lint</code> tự động phát hiện và chặn đứng các lỗi AI code rác.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📐</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">CHUYỂN ĐỘNG &amp; LAYOUT SAFETY</span>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 14px;">
-                <li><code>no-transition-all</code>: Cấm dùng transition: all gây drop FPS.</li>
-                <li><code>no-layout-keyframes</code>: Cấm animate top, left, width, height.</li>
-                <li><code>require-reduced-motion</code>: Bắt buộc có media query giảm chuyển động.</li>
-                <li><code>no-100vw-scroll</code>: Cấm w-[100vw] gây thanh cuộn ngang khó chịu.</li>
-                <li><code>no-root-overflow-hidden</code>: Cấm overflow-x: hidden ở thẻ html/body làm liệt sticky.</li>
-              </ul>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">12 Laws</div>
+              <div class="orb-label-main">Cognitive Standards</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">TYPOGRAPHY &amp; NỘI DUNG UX</span>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 14px;">
-                <li><code>min-body-font</code>: Cấm font chữ body nhỏ hơn 16px.</li>
-                <li><code>no-font-scale-sprawl</code>: Cảnh báo &gt; 7 cỡ font tự chế, chặn khi &gt; 10 cỡ.</li>
-                <li><code>no-italic-headings</code>: Cấm tiêu đề display dùng font chữ nghiêng.</li>
-                <li><code>no-pure-black-shadow</code>: Cấm bóng đổ đen tuyệt đối rgba(0,0,0,...).</li>
-                <li><code>no-placeholder-copy</code>: Cấm văn bản rác vô nghĩa, tên giả vô định, link rỗng.</li>
-              </ul>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">≥ 44px</div>
+              <div class="orb-label-secondary">Fitts Law Tap Target</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">7 ± 2</div>
+              <div class="orb-label-tertiary">Miller Chunking Limit</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">12 COGNITIVE<br>UX LAWS</h1>
+              <p class="radiant-body-text">Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">12</div>
+              <div class="radiant-hero-label">Enforced Ergonomic Laws</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Quality Floor • 14 Machine Rules</div><div>18 / 28</div></footer>
-        <div data-speaker-notes="14 luật máy là sàn an toàn tuyệt đối, ngăn chặn hoàn toàn code rác từ LLM."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>18 / 28</div>
+        </footer>
+        <div data-speaker-notes="UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."></div>
       </article>
 
 <article class="slide-item" id="slide-19" data-index="19">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>UX Psychology</span></div>
-          <div>Hồi 5 • 18 • 12 Cognitive Laws</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Personas</span>
+          </div>
+          <div>19 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tâm Lý Học Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">12 Classical Cognitive UX Laws</h2>
-            <p class="slide-subtitle gsap-reveal">Giao diện đẹp phải đi đôi với sự thuận tự nhiên của não bộ. DESIGN:OS tích hợp trực tiếp các định luật nhận thức.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎭</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">11 Personas</div>
+              <div class="orb-label-main">Curated Families</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">5 Slugs</div>
+              <div class="orb-label-secondary">Contrasting Stances</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Cliché</div>
+              <div class="orb-label-tertiary">Banned Tropes</div>
+            </div>
           </div>
 
-          <div class="slide-grid-4">
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">FITTS'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Mục Tiêu &amp; Khoảng Cách</div>
-              <p class="stat-desc" style="font-size: 14px;">Touch target tối thiểu 44px; nút CTA chính đặt ở vị trí ngón tay chạm nhanh nhất.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DESIGN<br>PERSONAS</h1>
+              <p class="radiant-body-text">11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.</p>
             </div>
 
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">HICK'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Thời Gian Ra Quyết Định</div>
-              <p class="stat-desc" style="font-size: 14px;">Giảm bớt tùy chọn để tăng tốc độ chọn lựa; gom nhóm hành vi theo từng cấp bậc.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">MILLER'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Giới Hạn 7±2 Khối Nhớ</div>
-              <p class="stat-desc" style="font-size: 14px;">Phân đoạn thông tin thành các cụm (chunking) từ 5 đến 9 phần tử trong một tầm nhìn.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">DOHERTY THRESHOLD</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Ngưỡng Phản Hồi 400ms</div>
-              <p class="stat-desc" style="font-size: 14px;">Mọi tương tác click/hover phải phản hồi thị giác trong vòng dưới 400ms để giữ sự tập trung.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">ZEIGARNIK EFFECT</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Thanh Tiến Trình Dang Dở</div>
-              <p class="stat-desc" style="font-size: 14px;">Bộ não luôn bị thôi thúc hoàn thành các tác vụ dở dang; áp dụng cho onboarding steps.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">JAKOB'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Kỳ Vọng Thói Quen Cũ</div>
-              <p class="stat-desc" style="font-size: 14px;">Người dùng dành phần lớn thời gian trên web khác; giữ nguyên các quy ước điều hướng quen thuộc.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">VON RESTORFF</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Hiệu Ứng Nổi Bật Độc Bản</div>
-              <p class="stat-desc" style="font-size: 14px;">Phần tử có hình dáng khác biệt nhất (như thẻ Pricing Recommended) sẽ được ghi nhớ sâu nhất.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">SERIAL POSITION</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Hiệu Ứng Đầu &amp; Cuối</div>
-              <p class="stat-desc" style="font-size: 14px;">Người dùng nhớ nhất mục đầu tiên và mục cuối cùng của thanh menu hay danh sách tính năng.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">11</div>
+              <div class="radiant-hero-label">Bespoke Design Personas</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 90%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS UX Psychology • Cognitive Design Laws</div><div>19 / 28</div></footer>
-        <div data-speaker-notes="12 định luật UX định hình cách tổ chức giao diện thuận theo tự nhiên của nhận thức con người."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>19 / 28</div>
+        </footer>
+        <div data-speaker-notes="Explicit persona declarations prevent generic corporate dashboard syndrome."></div>
       </article>
 
 <article class="slide-item" id="slide-20" data-index="20">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Motion Ladder</span></div>
-          <div>Hồi 6 • 19 • The 6 Motion Tiers</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Motion Ladder</span>
+          </div>
+          <div>20 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">The Motion Ladder</span>
-            <h2 class="slide-title-h1 gsap-reveal">6-Tier Motion Ladder (T1–T6)</h2>
-            <p class="slide-subtitle gsap-reveal">Chỉ nâng lên bậc chuyển động cao hơn khi câu chuyện thiết kế thực sự đòi hỏi và ngân sách hiệu năng cho phép.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Tiers</div>
+              <div class="orb-label-main">T1 to T6 Standards</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">60 FPS</div>
+              <div class="orb-label-secondary">Frame Budget</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">Reduced Motion Safe</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T1 • MICRO-FEEDBACK</span>
-              <div class="stat-label" style="margin-top: 8px;">Hover &amp; Active States</div>
-              <p class="stat-desc">CSS transition 150-200ms trên <code>transform</code> và <code>opacity</code>. Phản hồi bấm nút, hover thẻ. Zero bundle cost.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">THE MOTION<br>LADDER</h1>
+              <p class="radiant-body-text">Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T2 • STATE TRANSITION</span>
-              <div class="stat-label" style="margin-top: 8px;">Chuyển Đổi Trạng Thái</div>
-              <p class="stat-desc">Mở Modal, bung Accordion, hoán đổi Tabs. Sử dụng CSS transitions kết hợp ARIA expanded.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T3 • ENTRANCE REVEAL</span>
-              <div class="stat-label" style="margin-top: 8px;">Scroll-Driven CSS</div>
-              <p class="stat-desc">Hiệu ứng xuất hiện khi cuộn trang bằng native CSS <code>animation-timeline: view()</code>. Không tốn Javascript.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T4 • LAYOUT CHOREO</span>
-              <div class="stat-label" style="margin-top: 8px;">FLIP Layout Animation</div>
-              <p class="stat-desc">Tái sắp xếp lưới sản phẩm, mở rộng thẻ chi tiết bằng kỹ thuật FLIP không gây giật khung hình.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T5 • GSAP SCROLLTRIGGER</span>
-              <div class="stat-label" style="margin-top: 8px;">Biên Đạo Thời Gian</div>
-              <p class="stat-desc">Ghim khung hình (Pinning), scrub tiến trình cuộn, phối hợp timeline đa tầng phức tạp cho landing page.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T6 • AUTHORING &amp; 3D</span>
-              <div class="stat-label" style="margin-top: 8px;">Scroll-Cinema &amp; WebGL</div>
-              <p class="stat-desc">Cuộn phim 3D không gian, WebGL shaders, camera flight đa phân đoạn qua GFlow hand.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">60 FPS</div>
+              <div class="radiant-hero-label">Locked Kinetic Budget</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Motion Ladder • Tiered Kinetic Standards</div><div>20 / 28</div></footer>
-        <div data-speaker-notes="Thang bậc chuyển động giúp kiểm soát hiệu năng: chỉ leo lên T6 khi thực sự cần trải nghiệm điện ảnh."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>20 / 28</div>
+        </footer>
+        <div data-speaker-notes="Animations must serve narrative purpose. Decorative motion without function is classified as code debt."></div>
       </article>
 
 <article class="slide-item" id="slide-21" data-index="21">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Scroll-Cinema</span></div>
-          <div>Hồi 6 • 20 • Seam Physics &amp; Continuous Take</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Scroll Cinema</span>
+          </div>
+          <div>21 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Điện Ảnh Cuộn Trang</span>
-            <h2 class="slide-title-h1 gsap-reveal">Scroll-Cinema: The Art of Seamless Camera Flight</h2>
-            <p class="slide-subtitle gsap-reveal">Chaining separately rendered video clips into a single continuous take driven directly by scroll gestures.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎬</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Legs</div>
+              <div class="orb-label-main">Camera Waypoints</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">2 Seams</div>
+              <div class="orb-label-secondary">Kinetic Joint Locks</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Stutter</div>
+              <div class="orb-label-tertiary">Zero Rewind Match</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableCinemaTitle fableCinemaDesc"
-            data-diagram-grammar="sequence"
-            data-reading-order="ltr"
-            data-focal-id="cinemaLeg2"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableCinemaTitle">Scroll-Cinema: The 3-Leg Continuous Camera Flight with Kinetic Seam Physics</title>
-            <desc id="fableCinemaDesc">Continuous camera flight sequence diagram showing Leg 1 Hero Orbit, Leg 2 Exploded View, and Leg 3 Macro Core connected via frame-locked velocity seams guaranteeing zero-rewind stutter.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">SCROLL-CINEMA<br>FLIGHT</h1>
+              <p class="radiant-body-text">Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE CONTINUOUS FLIGHT PATH • ZERO-REWIND SCROLL-CINEMA SEAM PHYSICS</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="8 6" />
-
-            <rect x="440" y="210" width="80" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="480" y="225" font-family="var(--font-mono)" font-size="9" font-weight="800" fill="var(--text-primary)" text-anchor="middle">SEAM 1: LOCK</text>
-
-            <rect x="920" y="210" width="80" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="960" y="225" font-family="var(--font-mono)" font-size="9" font-weight="800" fill="var(--text-primary)" text-anchor="middle">SEAM 2: LOCK</text>
-
-            <!-- LEG 1 -->
-            <g id="cinemaLeg1" class="interactive-node" tabindex="0" role="button" aria-label="Leg 1: Hero Orbit" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">LEG 01 • SPATIAL ORBIT</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Hero Spatial Orbit</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">360&deg; Camera Spatial Path</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Camera quay quanh vật thể 3D sản phẩm</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tốc độ cuộn Scrub đồng bộ 60fps mượt mà</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tọa độ đích: Khóa vị trí Seam 1 (Delta = 0)</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kết thúc tại góc nhìn trực diện chuẩn bị nổ</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PHYSICS: 60 FPS Interpolation</text>
-            </g>
-
-            <!-- LEG 2 (FOCAL) -->
-            <g id="cinemaLeg2" class="interactive-node" tabindex="0" role="button" aria-label="Leg 2: Exploded View" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">LEG 02 • EXPLODED VIEW [FOCAL]</text>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Exploded Z-Disassembly</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Internal Component Separation</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tách lớp linh kiện dọc theo trục sâu Z-axis</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Seam 1 &rarr; Seam 2: Vận tốc vector khớp 100%</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu hoàn toàn hiện tượng giật cục (Stutter)</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cảm giác cinematic điện ảnh đẳng cấp cao</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">SEAM QUALITY: Zero-Rewind Lock</text>
-            </g>
-
-            <!-- LEG 3 -->
-            <g id="cinemaLeg3" class="interactive-node" tabindex="0" role="button" aria-label="Leg 3: Macro 2K Core" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">LEG 03 • MACRO 2K ZOOM</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Macro Core 2K Flight</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Sub-Pixel Micro-Texture Dive</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Camera lao sâu vào bề mặt vi cấu trúc chip</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Hiển thị vân kim loại và chi tiết máy cực nét</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đáp an toàn xuống vị trí CTA chuyển đổi</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động dừng mượt mà khi người dùng ngừng cuộn</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">RESOLUTION: 2K Sub-Pixel Flight</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-21">
-              <span class="readout-badge">SEAM PHYSICS: VERIFIED</span>
-              <span class="readout-text" id="readout-text-slide-21">Test 3-leg continuous camera flight: Seam 1 (Position match) and Seam 2 (Velocity vector lock) zero-rewind guarantee.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0 ms</div>
+              <div class="radiant-hero-label">Seam Handoff Stutter</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Scroll-Cinema • The Seam Physics Contract</div><div>21 / 28</div></footer>
-        <div data-speaker-notes="Mối nối (Seam) là sản phẩm: đảm bảo tính liên tục về vị trí và vận tốc để người xem cảm nhận như 1 cú máy one-take duy nhất."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>21 / 28</div>
+        </footer>
+        <div data-speaker-notes="Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."></div>
       </article>
 
 <article class="slide-item" id="slide-22" data-index="22">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>GFlow Hand</span></div>
-          <div>Hồi 6 • 21 • Google Flow Automation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • 3D GFlow</span>
+          </div>
+          <div>22 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tự Động Hóa Video AI</span>
-            <h2 class="slide-title-h1 gsap-reveal">GFlow Hand: Google Flow Automation (Veo / Imagen)</h2>
-            <p class="slide-subtitle gsap-reveal">Điều khiển Google Flow qua Playwright với cơ chế an toàn <strong>Verify-then-Spend</strong> bảo vệ số dư tài khoản.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌐</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 Canvas</div>
+              <div class="orb-label-main">Hardware Accelerated</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">2K Texture</div>
+              <div class="orb-label-secondary">Subpixel Detail</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Memory</div>
+              <div class="orb-label-tertiary">Lifecycle Teardown</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. THE GOLDEN PATH</span>
-              <div class="stat-label" style="margin-top: 8px;">ui gflow i2v</div>
-              <p class="stat-desc" style="margin-top: 10px;">Lệnh an toàn duy nhất: sinh video từ ảnh, kiểm tra tải file MP4 thật, tự trích xuất last frame qua ffmpeg.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui gflow i2v "flight..." --initial-frame seed.png</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">3D SPATIAL<br>GFLOW</h1>
+              <p class="radiant-body-text">Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. VERIFY-THEN-SPEND</span>
-              <div class="stat-label" style="margin-top: 8px;">Chống Rơi Render</div>
-              <p class="stat-desc" style="margin-top: 10px;">Không bao giờ gọi lệnh <code>chain</code> mù quáng. Mỗi phân đoạn phải tải về thành công trước khi sinh đoạn tiếp theo.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>DOWNLOAD_MISSING → Recovery Plan</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. WEBP CONVERSION</span>
-              <div class="stat-label" style="margin-top: 8px;">Trích Xuất Khung Hình</div>
-              <p class="stat-desc" style="margin-top: 10px;">Chuyển đổi MP4 thành chuỗi WebP nén chất lượng cao sẵn sàng cho Canvas Scrubbing mượt mà trên mobile.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ffmpeg -i clip.mp4 frame_%04d.webp</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">2 K</div>
+              <div class="radiant-hero-label">Subpixel Texture Resolution</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS GFlow Hand • Automated Video Pipeline</div><div>22 / 28</div></footer>
-        <div data-speaker-notes="GFlow Hand tự động hóa quy trình sinh video phức tạp bằng phương pháp verify-then-spend an toàn."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>22 / 28</div>
+        </footer>
+        <div data-speaker-notes="All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."></div>
       </article>
 
 <article class="slide-item" id="slide-23" data-index="23">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Canvas UI</span></div>
-          <div>Hồi 6 • 22 • Shaders &amp; Teardown Contract</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Visual Regression</span>
+          </div>
+          <div>23 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đồ Họa Bậc Cao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Canvas T6 &amp; WebGL Shaders: Liquid Glass &amp; Teardown Contract</h2>
-            <p class="slide-subtitle gsap-reveal">Hiệu ứng bề mặt chất liệu cao cấp nhưng tuyệt đối tuân thủ ngân sách hiệu năng 60 FPS và dọn dẹp bộ nhớ.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📸</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Screens</div>
+              <div class="orb-label-main">Desktop / Laptop / Mobile</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Drift</div>
+              <div class="orb-label-secondary">Pixel Hash Match</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">CI Headless Test</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. ONE-EFFECT CAP</span>
-              <div class="stat-label" style="margin-top: 8px;">Giới Hạn 1 Hiệu Ứng</div>
-              <p class="stat-desc" style="margin-top: 10px;">Chỉ được phép có duy nhất 1 hiệu ứng Canvas T6 trên toàn trang (ví dụ: Liquid Glass hoặc Particle Mesh).</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VISUAL<br>REGRESSION</h1>
+              <p class="radiant-body-text">Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. TEARDOWN CONTRACT</span>
-              <div class="stat-label" style="margin-top: 8px;">Hợp Đồng Dọn Dẹp</div>
-              <p class="stat-desc" style="margin-top: 10px;">Bắt buộc phải hủy <code>cancelAnimationFrame</code>, giải phóng WebGL contexts và dọn sạch Event Listeners khi unmount.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. 60 FPS PERFORMANCE FLOOR</span>
-              <div class="stat-label" style="margin-top: 8px;">Sàn Hiệu Năng 60 FPS</div>
-              <p class="stat-desc" style="margin-top: 10px;">Giới hạn kích thước render buffer theo DPR tối đa 2; tự động hạ cấp xuống ảnh tĩnh trên thiết bị yếu.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3 / 3</div>
+              <div class="radiant-hero-label">Viewports Verified</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Canvas UI • T6 Engineering Standard</div><div>23 / 28</div></footer>
-        <div data-speaker-notes="Canvas T6 chỉ được kích hoạt khi có lý do chính đáng và bắt buộc phải có teardown function để tránh rò rỉ bộ nhớ."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>23 / 28</div>
+        </footer>
+        <div data-speaker-notes="Automated headless Playwright sweeps catch subtle overflow and clipping before human review."></div>
       </article>
 
 <article class="slide-item" id="slide-24" data-index="24">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Qualified Delivery</span></div>
-          <div>Hồi 7 • 23 • Release Verification</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Taste Voting</span>
+          </div>
+          <div>24 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Qualified Delivery Contract v2</h2>
-            <p class="slide-subtitle gsap-reveal">Biến việc sinh UI thành quy trình phát hành có bằng chứng kiểm định rõ ràng (Evidence-based release).</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏆</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">100%</div>
+              <div class="orb-label-main">Compounded Taste</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">N Variants</div>
+              <div class="orb-label-secondary">Parallel Generation</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">1 Winner</div>
+              <div class="orb-label-tertiary">Highest Scoring PR</div>
+            </div>
           </div>
 
-          <div class="slide-grid-4">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 1 • BRIEF</span>
-              <div class="stat-label" style="margin-top: 10px;">design-brief.json</div>
-              <p class="stat-desc">Biến yêu cầu sơ khai thành hợp đồng nghiệp vụ: đối tượng, mục tiêu, tuyên bố bị cấm.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">COMPOUNDED<br>CRAFT REFLECTION</h1>
+              <p class="radiant-body-text">Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 2 • CONTRACT</span>
-              <div class="stat-label" style="margin-top: 10px;">generation-contract.json</div>
-              <p class="stat-desc">Khai báo 3 hướng cấu trúc, nhiệm vụ từng vùng, hình ảnh và icon Phosphor bắt buộc.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 3 • EVIDENCE</span>
-              <div class="stat-label" style="margin-top: 10px;">Renders 1440 / 768 / 390</div>
-              <p class="stat-desc">Sinh candidate và chụp ảnh render thực tế ở cả 3 kích thước Desktop, Tablet và Mobile.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 4 • VERDICT</span>
-              <div class="stat-label" style="margin-top: 10px;">QUALIFIED</div>
-              <p class="stat-desc">Curator đối chiếu bằng chứng. Đạt 100% gates → Phát hành; Thiếu sót → DRAFT_WITH_CONCERNS.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">10 X</div>
+              <div class="radiant-hero-label">Design Team Velocity</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 95%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Qualified Delivery v2</div><div>24 / 28</div></footer>
-        <div data-speaker-notes="Trạng thái QUALIFIED bắt buộc phải có bằng chứng render thực tế cả 3 viewport, không thể nói suông."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>24 / 28</div>
+        </footer>
+        <div data-speaker-notes="Compounding craft transforms single-use generations into permanent organizational capability."></div>
       </article>
 
 <article class="slide-item" id="slide-25" data-index="25">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Full-Stack Audit</span></div>
-          <div>Hồi 7 • 24 • The 6-Step Audit Pipeline</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Delivery Pipeline</span>
+          </div>
+          <div>25 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">The Mandatory 6-Step Full-Stack Audit Pipeline</h2>
-            <p class="slide-subtitle gsap-reveal">Thứ tự thực thi mang tính quyết định: chạy sai thứ tự sẽ dẫn đến kết quả kiểm định sai lệch.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🚀</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Stages</div>
+              <div class="orb-label-main">Ordered Pipeline</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Static & Rendered</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Bypass</div>
+              <div class="orb-label-tertiary">Strict CI Gates</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fablePipeTitle fablePipeDesc"
-            data-diagram-grammar="sequence"
-            data-reading-order="ltr"
-            data-focal-id="pipeStep6"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fablePipeTitle">The 6-Step Full-Stack Delivery Pipeline</title>
-            <desc id="fablePipeDesc">Sequential delivery pipeline diagram executing verification gates in exact defect-catching order.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DELIVERY<br>PIPELINE</h1>
+              <p class="radiant-body-text">The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE 6-STAGE FRACTIONAL REFINERY • ORDERED QUALITY GATES</text>
-
-            <!-- Step 1 -->
-            <g id="pipeStep1" class="interactive-node" tabindex="0" role="button" aria-label="Step 1: Flow Lint" style="cursor: pointer;">
-              <rect x="40" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="40" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="145" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 01 • FLOW</text>
-              <text x="145" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Flow Lint</text>
-              <text x="145" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui flow lint</text>
-              <line x1="56" y1="195" x2="234" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="56" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Bắt lỗi cụt (dead-end)</text>
-              <text x="56" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét unreachable</text>
-              <text x="56" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Đủ trạng thái error</text>
-              <rect x="56" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="145" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">FLOW PASS</text>
-            </g>
-
-            <!-- Step 2 -->
-            <g id="pipeStep2" class="interactive-node" tabindex="0" role="button" aria-label="Step 2: User Evidence" style="cursor: pointer;">
-              <rect x="270" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="270" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="375" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 02 • EVIDENCE</text>
-              <text x="375" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">User Evidence</text>
-              <text x="375" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui evidence</text>
-              <line x1="286" y1="195" x2="464" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="286" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Khảo sát người dùng</text>
-              <text x="286" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Dữ liệu định tính</text>
-              <text x="286" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Trọng số chuyển đổi</text>
-              <rect x="286" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="375" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EVIDENCE OK</text>
-            </g>
-
-            <!-- Step 3 -->
-            <g id="pipeStep3" class="interactive-node" tabindex="0" role="button" aria-label="Step 3: VR Baseline" style="cursor: pointer;">
-              <rect x="500" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="500" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="605" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 03 • VR GATE</text>
-              <text x="605" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">VR Baseline</text>
-              <text x="605" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui vr gate</text>
-              <line x1="516" y1="195" x2="694" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="516" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét ảnh 3 Viewports</text>
-              <text x="516" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• 1920 Desktop, Mobile</text>
-              <text x="516" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• So sánh pixel diff</text>
-              <rect x="516" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="605" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">VR MATCH 100%</text>
-            </g>
-
-            <!-- Step 4 -->
-            <g id="pipeStep4" class="interactive-node" tabindex="0" role="button" aria-label="Step 4: Paired Tokens" style="cursor: pointer;">
-              <rect x="730" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="730" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="835" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 04 • PAIRS</text>
-              <text x="835" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Paired Tokens</text>
-              <text x="835" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui paired-tokens</text>
-              <line x1="746" y1="195" x2="924" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="746" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Đối soát Dark / Light</text>
-              <text x="746" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Không lạc mất cặp màu</text>
-              <text x="746" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Giữ độ sâu quang học</text>
-              <rect x="746" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="835" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PAIRS CLEAN</text>
-            </g>
-
-            <!-- Step 5 -->
-            <g id="pipeStep5" class="interactive-node" tabindex="0" role="button" aria-label="Step 5: A11y Lint" style="cursor: pointer;">
-              <rect x="960" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="960" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="1065" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 05 • A11Y</text>
-              <text x="1065" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">A11y Lint</text>
-              <text x="1065" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui a11y-lint</text>
-              <line x1="976" y1="195" x2="1154" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="976" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét Axe Core máy cứng</text>
-              <text x="976" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Tương phản WCAG AA</text>
-              <text x="976" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Khả năng đọc màn hình</text>
-              <rect x="976" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1065" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">AXE PASS</text>
-            </g>
-
-            <!-- Step 6 -->
-            <g id="pipeStep6" class="interactive-node" tabindex="0" role="button" aria-label="Step 6: Full Audit" style="cursor: pointer;">
-              <rect x="1190" y="70" width="220" height="360" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1190" y="70" width="220" height="46" rx="16" fill="var(--text-primary)"/>
-              <text x="1300" y="98" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-inverse)" text-anchor="middle">STAGE 06 • FULL AUDIT [FOCAL]</text>
-              <text x="1300" y="155" font-family="var(--font-sans)" font-size="18" font-weight="900" fill="var(--text-primary)" text-anchor="middle">Full Audit</text>
-              <text x="1300" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">design-os audit</text>
-              <line x1="1206" y1="195" x2="1394" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="1206" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• taste-lint 6+1 trục</text>
-              <text x="1206" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• validate-layout tĩnh</text>
-              <text x="1206" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• 10 công cụ xuất xưởng</text>
-              <rect x="1206" y="350" width="188" height="44" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1300" y="378" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" text-anchor="middle">0 ERRORS &rarr; SHIP</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-25">
-              <span class="readout-badge">DELIVERY PIPELINE: 6 STEPS</span>
-              <span class="readout-text" id="readout-text-slide-25">Run simulation to watch linters execute in the exact defect-catching order: Flow -> Evidence -> VR -> Paired -> A11y -> Audit.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6 / 6</div>
+              <div class="radiant-hero-label">Pipeline Stages Passed</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Ordered 6-Step Audit</div><div>25 / 28</div></footer>
-        <div data-speaker-notes="Pipeline 6 bước bắt buộc chạy đúng thứ tự: Flow -> Evidence -> VR -> Pairs -> Rendered A11y -> Full Audit."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>25 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."></div>
       </article>
 
 <article class="slide-item" id="slide-26" data-index="26">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Release &amp; Semver</span></div>
-          <div>Hồi 7 • 25 • Checklist &amp; PR Review</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Semver Matrix</span>
+          </div>
+          <div>26 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đóng Gói Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Delivery Checklist &amp; PR Semver Matrix</h2>
-            <p class="slide-subtitle gsap-reveal">Tạo tài liệu component tự động, trang specimen độc lập và tự động tính toán mức độ breaking change cho Pull Request.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏷</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">5 LỆNH TRONG DELIVERY CHECKLIST</span>
-              <div class="code-terminal" style="font-size: 13px; margin-top: 12px; line-height: 1.6;">
-                <span class="code-comment"># 1. Kiểm tra thiếu trạng thái component</span><br>
-                <code>ui ds specimen --dir . --strict --json</code><br><br>
-                <span class="code-comment"># 2. Tái tạo tài liệu component từ Registry</span><br>
-                <code>ui ds docs --dir . --out docs/components.md</code><br><br>
-                <span class="code-comment"># 3. Tạo trang specimen HTML độc lập</span><br>
-                <code>ui ds preview --dir . --out preview.html</code><br><br>
-                <span class="code-comment"># 4. Quét Visual Regression component kit</span><br>
-                <code>design-os vr-matrix --project .</code><br><br>
-                <span class="code-comment"># 5. Xuất Changelog lịch sử thay đổi</span><br>
-                <code>ui changelog --dir . --format markdown</code>
-              </div>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Releases</div>
+              <div class="orb-label-main">Patch / Minor / Major</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">PHÂN LOẠI SEMVER (ui ds diff)</span>
-              <div class="code-terminal" style="font-size: 13px; margin-top: 12px;">
-                <code>ui ds diff base head --format pr-comment</code>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">≤ 0.02</div>
+              <div class="orb-label-secondary">Patch Delta EOK</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">> 0.05</div>
+              <div class="orb-label-tertiary">Major Breaking</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.7; margin-top: 14px;">
-                <li><strong>MAJOR (Breaking):</strong> Xóa token/component đang dùng; hoặc thay đổi màu sắc vượt ngưỡng Delta EOK.</li>
-                <li><strong>MINOR (Additive):</strong> Thêm mới token/component hoặc thêm variant mà không ảnh hưởng code cũ.</li>
-                <li><strong>PATCH:</strong> Sửa lỗi chính tả token, vi chỉnh không gây lệch thị giác.</li>
-              </ul>
+              <h1 class="radiant-display-title">SEMVER PR<br>MATRIX</h1>
+              <p class="radiant-body-text">Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">v1.0.0</div>
+              <div class="radiant-hero-label">Production Semver Bound</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Semver &amp; Handoff</div><div>26 / 28</div></footer>
-        <div data-speaker-notes="Checklist 5 bước và Semver Diff đảm bảo việc bàn giao sang cho đội ngũ Engineering diễn ra êm đẹp."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>26 / 28</div>
+        </footer>
+        <div data-speaker-notes="Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."></div>
       </article>
 
 <article class="slide-item" id="slide-27" data-index="27">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Fable Thinking</span></div>
-          <div>Hồi 7 • 26 • The 5 Design Fables</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • The 5 Fables</span>
+          </div>
+          <div>27 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tư Duy Ngụ Ngôn</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 5 Design Fables: Philosophy Behind Master Craft</h2>
-            <p class="slide-subtitle gsap-reveal">Distilling complex engineering mechanisms into intuitive allegorical archetypes.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📖</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">5 Fables</div>
+              <div class="orb-label-main">Spatial Mechanisms</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Generic</div>
+              <div class="orb-label-secondary">Meaningful Living UI</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">Metaphor Grounded</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 1 • THE SEAMLESS FLIGHT</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Seamless Flight</div>
-              <p class="stat-desc">"Một đường rách nhỏ làm tan biến cả giấc mơ". Vận tốc và vị trí tại mối nối clip phải tuyệt đối liên tục, không bao giờ được phép lùi bước.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">THE 5 DESIGN<br>FABLES</h1>
+              <p class="radiant-body-text">Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 2 • THE TWO-WAY BRIDGE</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Two-Way Bridge</div>
-              <p class="stat-desc">"Sự thật không thuộc về riêng Mã hay Tranh". figma-agent nối nhịp hai bờ, biến Canvas thành thực thể sống động gắn liền với Token.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 3 • THE 14-PLANK FLOOR</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The 14-Plank Floor</div>
-              <p class="stat-desc">"Đừng bao giờ tin vào lời hứa của AI". Hãy để 14 lưỡi cưa linter kiểm tra từng mối hàn code để bảo vệ chất lượng không tì vết.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 4 • THE MOTION LADDER</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Motion Ladder</div>
-              <p class="stat-desc">"Leo cao mà thiếu chân đế thì rơi". Chỉ leo từ T1 đến T6 khi câu chuyện đòi hỏi và người dùng cho phép qua reduced-motion.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 5 • MEMORY DISTILLATION</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Sol Memory Distillation</div>
-              <p class="stat-desc">"Sau mỗi chuyến đi, hãy đúc kết vào đá tảng". Recall lưu giữ bài học và giải phóng context để tiếp tục bay xa mà không tốn triệu token.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="background: var(--bg-surface-raised);">
-              <span class="matrix-badge">CORE TAKEAWAY</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">Discipline Breeds Master Craft</div>
-              <p class="stat-desc">DESIGN:OS không biến bạn thành nô lệ của công cụ, mà trao cho bạn sức mạnh của một xưởng thiết kế công nghiệp tự vận hành.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">5</div>
+              <div class="radiant-hero-label">Living Design Fables</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Philosophy • Fable Thinking</div><div>27 / 28</div></footer>
-        <div data-speaker-notes="5 câu chuyện ngụ ngôn là tổng kết triết lý sâu sắc nhất đằng sau toàn bộ công nghệ của DESIGN:OS."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>27 / 28</div>
+        </footer>
+        <div data-speaker-notes="Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."></div>
       </article>
 
 <article class="slide-item" id="slide-28" data-index="28">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Summary</span></div>
-          <div>Hồi 7 • 27 • Start Designing</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Production Ready</span>
+          </div>
+          <div>28 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone" style="justify-content: center;">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tổng Kết &amp; Thực Hành</span>
-            <h2 class="slide-title-display gsap-reveal">Start in 60 Seconds: Production Ready</h2>
-            <p class="slide-subtitle gsap-reveal">Toàn bộ hệ sinh thái DESIGN:OS đã được cấu hình và kiểm định hoàn chỉnh trong môi trường của bạn.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌟</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 CLI</div>
+              <div class="orb-label-main">ui / design-os</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Guess</div>
+              <div class="orb-label-secondary">Total Determinism</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">Ready</div>
+              <div class="orb-label-tertiary">Production Grade</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3" style="margin-top: 20px;">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 1</span>
-              <div class="stat-label" style="margin-top: 10px;">Khám Sức Khỏe</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>ui onboard &amp;&amp; ui doctor</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">READY FOR<br>PRODUCTION</h1>
+              <p class="radiant-body-text">Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 2</span>
-              <div class="stat-label" style="margin-top: 10px;">Khởi Tạo Dự Án</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>ui ds init my-app --persona aurora-minimal</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 3</span>
-              <div class="stat-label" style="margin-top: 10px;">Sinh Giao Diện</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>/ui:generate landing page for my next idea</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">SHIP</div>
+              <div class="radiant-hero-label">Qualified Delivery Floor</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Operating Manual • Ready for Production</div><div>28 / 28</div></footer>
-        <div data-speaker-notes="Cảm ơn bạn đã hoàn thành khóa Masterclass 28 slide. Chúc bạn tạo nên những giao diện đỉnh cao cùng DESIGN:OS!"></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>28 / 28</div>
+        </footer>
+        <div data-speaker-notes="Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"></div>
       </article>
 
     </div>

--- a/docs/translations.js
+++ b/docs/translations.js
@@ -1,5 +1,4 @@
-// DESIGN:OS 28-Slide Masterclass Internationalization System (i18n)
-// Supported languages: English (Default), Tiếng Việt, 한국어, 日本語, Español, Français, 中文
+// DESIGN:OS 28-Slide Radiant Editorial Internationalization Dictionary
 const DECK_I18N = {
   "languages": [
     {
@@ -41,1234 +40,1430 @@ const DECK_I18N = {
   "slides": {
     "1": {
       "en": {
-        "eyebrow": "Multi-Runtime Design CLI • Production Operating Manual",
-        "title": "Mastering DESIGN:OS<br>From AI Reasoning to Scroll-Cinema &amp; Figma.",
-        "subtitle": "7 Strategic Acts: AI vs Kernel Division, 6 Onboarding Roads, Live Figma Bridge 9410, Recall Vector Memory, OKLCH Color Science, 3D GFlow &amp; 2K Scroll-Cinema, and Qualified Delivery Floor.",
-        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. This manual covers everything from core mathematical foundations, Figma live sync, vector memory, to 3D scroll-cinema flights and Fable thinking."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "vi": {
-        "eyebrow": "Multi-Runtime Design CLI • Cẩm Nang Vận Hành Sản Xuất",
-        "title": "Làm chủ Toàn Năng DESIGN:OS<br>Từ AI Reasoning Đến Scroll-Cinema &amp; Figma.",
-        "subtitle": "7 Hồi Chiến Lược: Kiến trúc phân quyền AI vs Kernel, 6 Cổng Onboard, Figma Live Bridge 9410, Vòng lặp Học tập Recall, Khoa học màu OKLCH, 3D GFlow &amp; Scroll-Cinema 2K, và Sàn Qualified Delivery.",
-        "notes": "Chào mừng đến với DESIGN:OS Masterclass 28 slide. Bộ cẩm nang bao quát từ lõi toán học, cầu nối Figma, bộ nhớ vector đến điện ảnh cuộn trang 3D và 5 câu chuyện ngụ ngôn triết lý thiết kế."
+        "title": "LÀM CHỦ<br>DESIGN:OS",
+        "body": "Cẩm nang vận hành đa runtime cho thiết kế AI hiện đại. Chuyển đổi từ sự may rủi của LLM sang toán học màu tất định, đồng bộ trực tiếp Figma Desktop, truy hồi bộ nhớ vector và sàn kiểm định xuất xưởng.",
+        "heroNum": "0 %",
+        "heroLabel": "Không Dựa May Rủi",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "ko": {
-        "eyebrow": "멀티 런타임 디자인 CLI • 프로덕션 운영 매뉴얼",
-        "title": "DESIGN:OS 마스터하기<br>AI 추론부터 스크롤 시네마 &amp; Figma까지.",
-        "subtitle": "7개 전략적 장: AI와 커널 분권 구조, 6개 온보딩 경로, 피그마 브릿지 9410, 벡터 메모리 리콜, OKLCH 색채 과학, 3D GFlow 및 2K 스크롤 시네마, 품질 보증 납품 기준.",
-        "notes": "DESIGN:OS 28개 슬라이드 마스터클래스에 오신 것을 환영합니다. 핵심 수학 기초부터 피그마 실시간 연동, 벡터 메모리, 3D 스크롤 시네마까지 완벽하게 다룹니다."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "ja": {
-        "eyebrow": "マルチランタイム デザインCLI • 本番運用マニュアル",
-        "title": "DESIGN:OS を完全マスター<br>AI推論からスクロールシネマ＆Figmaまで.",
-        "subtitle": "7つの戦略的幕: AI対カーネル分権構造、6つのオンボーディング経路、Figmaブリッジ9410、ベクトルメモリRecall、OKLCH色彩科学、3D GFlow＆2Kスクロールシネマ、品質保証デリバリー基準。",
-        "notes": "DESIGN:OS 28スライド マスタークラスへようこそ。数学的基礎からFigmaリアルタイム連携、ベクトルメモリ、3Dスクロールシネマまで網羅しています。"
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "es": {
-        "eyebrow": "CLI de Diseño Multi-Runtime • Manual de Operación en Producción",
-        "title": "Dominando DESIGN:OS<br>Desde el Razonamiento AI hasta Scroll-Cinema y Figma.",
-        "subtitle": "7 Actos Estratégicos: División AI vs Kernel, 6 Vías de Onboarding, Figma Live Bridge 9410, Memoria Vectorial Recall, Ciencia del Color OKLCH, GFlow 3D y Scroll-Cinema 2K, y Entrega Calificada.",
-        "notes": "Bienvenidos a la Masterclass Completa de DESIGN:OS en 28 Diapositivas. Abarca desde fundamentos matemáticos hasta sincronización con Figma, memoria vectorial y vuelos 3D."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "fr": {
-        "eyebrow": "CLI de Design Multi-Runtime • Manuel d'Exploitation Production",
-        "title": "Maîtriser DESIGN:OS<br>Du Raisonnement IA au Scroll-Cinéma &amp; Figma.",
-        "subtitle": "7 Actes Stratégiques: Séparation IA vs Noyau, 6 Voies d'Intégration, Pont Figma 9410, Mémoire Vectorielle Recall, Science des Couleurs OKLCH, GFlow 3D &amp; Scroll-Cinéma 2K, et Livraison Qualifiée.",
-        "notes": "Bienvenue dans la Masterclass DESIGN:OS en 28 diapositives. Ce guide couvre des fondations mathématiques à la synchronisation Figma en direct, la mémoire vectorielle et le cinéma 3D."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "zh": {
-        "eyebrow": "多运行时设计CLI • 生产级系统操作手册",
-        "title": "全面掌握 DESIGN:OS<br>从 AI 推理到滚动电影与 Figma 实时画布.",
-        "subtitle": "7大核心篇章: AI与确定性内核分权架构、6大Onboarding入口、Figma桌面桥接9410、Recall向量记忆、OKLCH色彩科学、3D GFlow与2K滚动电影、Qualified Delivery交付底线。",
-        "notes": "欢迎来到 DESIGN:OS 28页大师课。涵盖从底层色彩数学、Figma实时桥接、向量记忆、到3D空间镜头控制与Design Fables哲学的全部核心体系。"
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       }
     },
     "2": {
       "en": {
-        "eyebrow": "Core Philosophy",
-        "title": "The 3 Supreme Truths of DESIGN:OS",
-        "subtitle": "Eliminating reliance on LLM luck. Enforcing quality through color science and deterministic machine floors.",
-        "notes": "The 3 core truths form our compass: converting stochastic LLM chaos into reliable, deterministic code."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "vi": {
-        "eyebrow": "Triết Lý Cốt Lõi",
-        "title": "3 Chân Lý Tối Thượng Của DESIGN:OS",
-        "subtitle": "Không dựa vào sự may rủi của mô hình LLM. Ép chất lượng bằng toán học màu sắc và sàn kiểm định tất định.",
-        "notes": "3 chân lý tối thượng là kim chỉ nam: biến sự hỗn loạn của LLM thành kết quả tất định."
+        "title": "3 CHÂN LÝ<br>TỐI THƯỢNG",
+        "body": "Xóa bỏ sự phụ thuộc vào sự may rủi của AI. Mọi token hình ảnh đều bắt nguồn từ khoa học màu sắc OKLCH, phân định rõ ràng giữa AI reasoning và UI kernel, cùng sàn 14 linter kiểm định tất định.",
+        "heroNum": "14",
+        "heroLabel": "Linter Kiểm Định Máy",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "ko": {
-        "eyebrow": "핵심 원칙",
-        "title": "DESIGN:OS의 3대 핵심 공리",
-        "subtitle": "LLM의 운에 의존하지 않고, 색채 과학과 결정론적 검증 바닥을 통해 품질을 강제합니다.",
-        "notes": "3대 핵심 공리는 LLM의 무작위성을 결정론적 결과물로 전환하는 기준입니다."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "ja": {
-        "eyebrow": "コア哲学",
-        "title": "DESIGN:OS 3つの至高の真理",
-        "subtitle": "LLMの偶然性に頼らず、色彩科学と決定論的検証フロアによって品質を担保します。",
-        "notes": "3つの至高の真理は、LLMの不確実性を決定論的なコードへと変換するための羅針盤です。"
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "es": {
-        "eyebrow": "Fundamentos Clave",
-        "title": "Las 3 Verdades Supremas de DESIGN:OS",
-        "subtitle": "Eliminando la suerte de los LLM. Garantizando calidad mediante ciencia del color y pisos deterministas.",
-        "notes": "Las 3 verdades supremas convierten el caos estocástico en código confiable y determinista."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "fr": {
-        "eyebrow": "Fondations Essentielles",
-        "title": "Les 3 Vérités Suprêmes de DESIGN:OS",
-        "subtitle": "Éliminer l'aléatoire des LLM. Forcer la qualité par la science des couleurs et des contrôles déterministes.",
-        "notes": "Ces 3 vérités transforment le chaos stochastique en code déterministe et fiable."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "zh": {
-        "eyebrow": "核心设计公理",
-        "title": "DESIGN:OS 的三大至高公理",
-        "subtitle": "告别对大模型运气的依赖，通过严密色彩数学与确定性机器底线死守品质。",
-        "notes": "三大公理是核心指南针：将大模型的随机混乱转化为确定性的工业级代码。"
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       }
     },
     "3": {
       "en": {
-        "eyebrow": "Architecture Split",
-        "title": "Division of Labor: AI Reasoning vs UI Kernel",
-        "subtitle": "Host AI Agent handles creative reasoning, while the deterministic UI Kernel handles color mathematics, tokens compilation, and lint enforcement.",
-        "notes": "AI agents reason and generate; UI Kernel verifies and enforces. Together they create an error-free self-repairing loop."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "vi": {
-        "eyebrow": "Kiến Trúc Phân Quyền",
-        "title": "Sơ Đồ Phân Quyền: AI Reasoning vs UI Kernel",
-        "subtitle": "Host AI Agent đóng vai trò sáng tạo (Reasoning), trong khi UI Kernel làm nhiệm vụ tính toán toán học và kiểm tra tuân thủ (Verification).",
-        "notes": "AI Agent suy luận, UI Kernel kiểm định. Hai bán cầu kết hợp thành vòng lặp tự sửa lỗi hoàn hảo."
+        "title": "PHÂN QUYỀN<br>KIẾN TRÚC",
+        "body": "Host AI Agent phụ trách tư duy sáng tạo bậc cao, giải quyết persona và cấu trúc DOM ngữ nghĩa. UI Kernel đảm bảo biên dịch DTCG, toán học màu và các cửa ải xuất xưởng không lỗi.",
+        "heroNum": "100 %",
+        "heroLabel": "Biên Dịch Tất Định",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "ko": {
-        "eyebrow": "역할 분권 아키텍처",
-        "title": "분권 구조: AI 추론 vs UI 커널",
-        "subtitle": "호스트 AI 에이전트는 창의적 추론을 담당하고, 결정론적 UI 커널은 색채 수학, 토큰 컴파일 및 린트 검증을 수행합니다.",
-        "notes": "AI 에이전트의 추론과 UI 커널의 결정론적 검증이 결합되어 완벽한 자동 복구 루프를 형성합니다."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "ja": {
-        "eyebrow": "分権アーキテクチャ",
-        "title": "役割分担: AI推論 vs UIカーネル",
-        "subtitle": "ホストAIエージェントが創造的推論を担い、決定論的UIカーネルが色彩数学、トークン変換、Lint検証を実行します。",
-        "notes": "AIの柔軟な推論とカーネルの厳格な検証が組み合わさり、自動修復ループを実現します。"
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "es": {
-        "eyebrow": "División de Arquitectura",
-        "title": "División de Trabajo: Razonamiento AI vs UI Kernel",
-        "subtitle": "El agente AI maneja el razonamiento creativo, mientras que el Kernel UI ejecuta las matemáticas de color y las verificaciones.",
-        "notes": "El agente AI razona y el Kernel UI verifica, creando un bucle perfecto de auto-reparación."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "fr": {
-        "eyebrow": "Séparation d'Architecture",
-        "title": "Division du Travail: Raisonnement IA vs Noyau UI",
-        "subtitle": "L'agent IA gère le raisonnement créatif, tandis que le Noyau UI déterministe assure les calculs mathématiques et la conformité.",
-        "notes": "L'IA raisonne et le Noyau vérifie, créant une boucle d'auto-correction robuste."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "zh": {
-        "eyebrow": "分权架构设计",
-        "title": "分权体系: AI 空间推理 vs UI 确定性内核",
-        "subtitle": "Host AI Agent 负责美学推演与结构生成，UI Kernel 负责 OKLCH 色彩数学计算、Token 编译与 14 大机器红线裁决。",
-        "notes": "AI 大脑负责发散推理，UI 机器内核负责确定性判决，构成闭环的自愈修复系统。"
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       }
     },
     "4": {
       "en": {
-        "eyebrow": "Specialized Modules",
-        "title": "The 6 Specialized Optional Hands Ecosystem",
-        "subtitle": "Specialized modular hands extend multi-dimensional design capabilities, gracefully degrading when unconfigured.",
-        "notes": "These 6 optional hands transform DESIGN:OS into a complete design operating system from flat web to 3D and Figma."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "vi": {
-        "eyebrow": "Module Mở Rộng",
-        "title": "Hệ Sinh Thái 6 \"Cánh Tay\" Chuyên Trách (Optional Hands)",
-        "subtitle": "Các module chuyên trách mở rộng năng lực thiết kế đa chiều, tự suy giảm nhẹ nhàng khi vắng mặt (Graceful Degradation).",
-        "notes": "6 cánh tay này biến DESIGN:OS thành hệ điều hành thiết kế toàn năng từ giao diện web phẳng đến không gian 3D và canvas Figma."
+        "title": "6 ĐÔI TAY<br>MỞ RỘNG",
+        "body": "Hệ sinh thái tay chuyên biệt—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall và color science—tự động suy giảm nhẹ nhàng khi không cấu hình, giữ bundle siêu nhẹ.",
+        "heroNum": "6",
+        "heroLabel": "Module Đa Runtime",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "ko": {
-        "eyebrow": "특화 모듈",
-        "title": "6대 전문 옵셔널 핸즈(Optional Hands) 생태계",
-        "subtitle": "다차원 디자인 역량을 확장하며, 모듈 부재 시 우아한 기능 저하(Graceful Degradation)를 제공합니다.",
-        "notes": "이 6개의 핸즈는 DESIGN:OS를 평면 웹부터 3D, 피그마 캔버스까지 아우르는 완벽한 OS로 만듭니다."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "ja": {
-        "eyebrow": "専門モジュール",
-        "title": "6つの特化型オプショナル・ハンズ（Optional Hands）エコシステム",
-        "subtitle": "多次元のデザイン能力を拡張し、未設定時も安全にフォールバック（Graceful Degradation）します。",
-        "notes": "これら6つの拡張機能により、Webから3D、Figmaまで統一されたデザイン体験を提供します。"
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "es": {
-        "eyebrow": "Módulos Especializados",
-        "title": "Ecosistema de 6 Manos Opcionales Especializadas",
-        "subtitle": "Módulos que expanden capacidades de diseño multidimensional, degradándose suavemente si no están presentes.",
-        "notes": "Estas 6 manos transforman a DESIGN:OS en un sistema operativo de diseño completo."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "fr": {
-        "eyebrow": "Modules Spécialisés",
-        "title": "L'Écosystème des 6 Mains Optionnelles Spécialisées",
-        "subtitle": "Des modules qui étendent les capacités de design multidimensionnel avec une dégradation élégante en cas d'absence.",
-        "notes": "Ces 6 modules font de DESIGN:OS un véritable système d'exploitation de design global."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "zh": {
-        "eyebrow": "扩展手柄体系",
-        "title": "6 大专业特化手柄生态 (Optional Hands)",
-        "subtitle": "高内聚的专业功能模块，拓展从矢量画布到 3D 电影的全部能力，缺失时自动优雅降级。",
-        "notes": "这 6 大专业手柄将 DESIGN:OS 从简单的代码生成器升维为全场景设计操作系统。"
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       }
     },
     "5": {
       "en": {
-        "eyebrow": "Design Identity",
-        "title": "3-Tier Design Soul Hierarchy (Never / Always / Voice)",
-        "subtitle": "Establishing aesthetic stances and consistent design vocabulary from Studio level down to specific projects.",
-        "notes": "Design Soul defines aesthetic identity. The user's explicit brief always holds the highest precedence."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "vi": {
-        "eyebrow": "Bản Sắc Thiết Kế",
-        "title": "Hệ Thống 3 Tầng Design Soul (Never / Always / Voice)",
-        "subtitle": "Định hình lập trường thẩm mỹ và ngôn ngữ thiết kế nhất quán từ cấp Studio đến từng dự án cụ thể.",
-        "notes": "Soul thiết lập lập trường thẩm mỹ. Explicit Brief từ user luôn có quyền ghi đè cao nhất."
+        "title": "THỨ BẬC<br>LINH HỒN",
+        "body": "Quy tắc ưu tiên 3 tầng bảo vệ bản sắc thẩm mỹ: Bất biến Factory làm nền tảng, quy ước Studio duy trì đồng bộ, và Linh hồn Project giữ quyền quyết định tối cao.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Cấp Độ Quyền Lực",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "ko": {
-        "eyebrow": "디자인 아이덴티티",
-        "title": "3계층 디자인 소울(Design Soul) 아키텍처",
-        "subtitle": "스튜디오 레벨부터 개별 프로젝트까지 일관된 미학적 입장과 디자인 어휘를 수립합니다.",
-        "notes": "디자인 소울은 미학적 기준을 세우며, 사용자의 명시적 지시가 항상 최우선 순위를 갖습니다."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "ja": {
-        "eyebrow": "デザイン・アイデンティティ",
-        "title": "3層のデザインソウル（Design Soul）構造",
-        "subtitle": "スタジオ全体から個別プロジェクトに至るまで、一貫した美学方針と語彙を定義します。",
-        "notes": "ソウルは美学の規範を定義します。ユーザーの明示的な要求が常に最優先されます。"
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "es": {
-        "eyebrow": "Identidad de Diseño",
-        "title": "Jerarquía de 3 Niveles de Design Soul",
-        "subtitle": "Establece posturas estéticas y vocabulario consistente desde el estudio hasta proyectos individuales.",
-        "notes": "Soul define la postura estética. Las instrucciones explícitas del usuario siempre tienen máxima prioridad."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "fr": {
-        "eyebrow": "Identité Visuelle",
-        "title": "Hiérarchie à 3 Niveaux du Design Soul",
-        "subtitle": "Établit les partis pris esthétiques et le vocabulaire de design du studio jusqu'au projet.",
-        "notes": "Le Soul définit l'identité visuelle. Les directives explicites priment toujours."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "zh": {
-        "eyebrow": "设计美学灵魂",
-        "title": "3 级 Design Soul 美学灵魂体系",
-        "subtitle": "通过 Never / Always / Voice 规则建立从工作室全局到具体项目的统一美学立场。",
-        "notes": "Soul 定义团队的美学红线与设计语调，用户的 Explicit Brief 永远拥有最高覆盖权。"
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       }
     },
     "6": {
       "en": {
-        "eyebrow": "Onboarding Matrix",
-        "title": "6 Entry Roads for Project Onboarding (E1–E6)",
-        "subtitle": "Seamlessly onboarding any project state: from zero codebase, existing repos, reference URLs, to Figma frames.",
-        "notes": "E1 to E6 provide deterministic routes for every project starting state."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "vi": {
-        "eyebrow": "Ma Trận Tiếp Nhận",
-        "title": "Router 6 Cổng Vào Onboarding (E1–E6)",
-        "subtitle": "Tiếp nhận mọi hiện trạng dự án: từ con số 0, codebase có sẵn, URL tham chiếu, đến file Figma thực tế.",
-        "notes": "E1 đến E6 mở đường cho mọi trạng thái dự án bắt đầu với DESIGN:OS một cách tất định."
+        "title": "6 LỘ TRÌNH<br>ONBOARDING",
+        "body": "Lệnh ui scan tự động quét và phân tích trạng thái dự án để điều hướng vào đường băng tối ưu—từ dự án mới (E1), codebase có sẵn (E2), bóc tách URL (E3) hay Figma tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Cổng Khởi Tạo Chuẩn",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "ko": {
-        "eyebrow": "온보딩 라우터",
-        "title": "프로젝트 온보딩을 위한 6가지 진입 경로 (E1–E6)",
-        "subtitle": "완전한 제로 베이스, 기존 코드베이스, 참조 URL, 피그마 프레임까지 모든 프로젝트 상태를 원활하게 수용합니다.",
-        "notes": "E1부터 E6까지의 경로는 프로젝트의 시작 상태에 맞춰 최적의 온보딩 워크플로우를 제공합니다."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "ja": {
-        "eyebrow": "オンボーディング・ルーター",
-        "title": "プロジェクト受入の6つの進入路 (E1–E6)",
-        "subtitle": "新規プロジェクト、既存コード、参照URL、Figmaフレームまで、あらゆる状態から即座に導入可能です。",
-        "notes": "E1からE6のルートにより、どのような初期状態のプロジェクトでも決定論的に統合できます。"
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "es": {
-        "eyebrow": "Matriz de Incorporación",
-        "title": "6 Vías de Entrada para Onboarding (E1–E6)",
-        "subtitle": "Integración fluida para cualquier estado: proyectos nuevos, código existente, URLs o Figma.",
-        "notes": "E1 a E6 proporcionan rutas deterministas para cada estado inicial."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "fr": {
-        "eyebrow": "Matrice d'Intégration",
-        "title": "6 Voies d'Entrée pour l'Intégration (E1–E6)",
-        "subtitle": "Intégration sans couture pour tout projet: nouveau, existant, URL de référence ou Figma.",
-        "notes": "E1 à E6 assurent une transition fluide quel que soit le point de départ."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "zh": {
-        "eyebrow": "Onboarding 路由体系",
-        "title": "6 大项目接入路由通道 (E1–E6)",
-        "subtitle": "无缝适配从零冷启动、已有工程改建、线上站点逆向、到 Figma 实时画板等任意初始状态。",
-        "notes": "E1 至 E6 构筑了覆盖全场景的精准接入流水线。"
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       }
     },
     "7": {
       "en": {
-        "eyebrow": "Workflow Discipline",
-        "title": "5-Step Setup Protocol &amp; Mandatory STOP-Gates",
-        "subtitle": "Strict discipline: never generate UI code without passing the prerequisite configuration gates.",
-        "notes": "STOP-Gates prevent premature code generation before tokens and design soul are compiled."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "vi": {
-        "eyebrow": "Kỷ Luật Quy Trình",
-        "title": "Quy Trình 5 Bước &amp; Các STOP-Gates Bắt Buộc",
-        "subtitle": "Kỷ luật thép: không bao giờ sinh mã HTML/CSS khi chưa vượt qua các cổng kiểm tra cấu hình tiên quyết.",
-        "notes": "STOP-Gates ngăn chặn tình trạng sinh mã vô tội vạ khi chưa có token và design soul."
+        "title": "QUY TRÌNH<br>5 BƯỚC THIẾT LẬP",
+        "body": "Vòng đời thiết lập 5 bước tuần tự được bảo vệ bởi các cổng STOP bắt buộc: Kiểm tra Doctor, biên dịch Design System, khai báo Soul, kết nối AI staff và khởi tạo cầu nối Figma.",
+        "heroNum": "5 / 5",
+        "heroLabel": "Cửa Ải STOP Vượt Qua",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "ko": {
-        "eyebrow": "워크플로우 규율",
-        "title": "5단계 셋업 프로토콜 및 필수 STOP-Gates",
-        "subtitle": "철저한 규율: 선행 구성 게이트를 통과하기 전에는 절대 UI 코드를 생성하지 않습니다.",
-        "notes": "STOP-Gates는 토큰과 디자인 소울이 컴파일되기 전 불완전한 코드 생성을 엄격히 차단합니다."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "ja": {
-        "eyebrow": "ワークフロー規律",
-        "title": "5段階セットアップ手順と必須 STOP-Gates",
-        "subtitle": "厳格な規律: 前提となる構成ゲートを通過するまで、UIコードの生成を行ってはなりません。",
-        "notes": "STOP-Gatesはトークンやデザインソウルが準備される前の早まったコード生成を防止します。"
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "es": {
-        "eyebrow": "Disciplina de Trabajo",
-        "title": "Protocolo de 5 Pasos y STOP-Gates Obligatorios",
-        "subtitle": "Disciplina estricta: nunca generar código UI sin superar las puertas de configuración previas.",
-        "notes": "Los STOP-Gates evitan la generación prematura de código sin tokens validados."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "fr": {
-        "eyebrow": "Discipline de Flux",
-        "title": "Protocole en 5 Étapes &amp; STOP-Gates Obligatoires",
-        "subtitle": "Discipline stricte: ne jamais générer de code UI sans valider les étapes de configuration préalables.",
-        "notes": "Les STOP-Gates empêchent toute génération de code avant la validation des tokens."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "zh": {
-        "eyebrow": "初始化铁律",
-        "title": "5 步初始化规程与强制 STOP-Gates 红线",
-        "subtitle": "绝对纪律：在未完成环境诊断、Token 编译与 Soul 声明前，严禁越级直接生成 UI 代码。",
-        "notes": "STOP-Gates 坚决杜绝在缺少设计地基时的盲目瞎写。"
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       }
     },
     "8": {
       "en": {
-        "eyebrow": "Autonomous Collaboration",
-        "title": "Virtual Design Staff &amp; Periodic Heartbeat",
-        "subtitle": "Self-coordinating virtual agent team executing continuous tasks through the deterministic heartbeat daemon.",
-        "notes": "Designer, Curator, and Figma Hand work together under heartbeat supervision."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "vi": {
-        "eyebrow": "Cộng Tác Tự Trị",
-        "title": "Đội Ngũ Subagents Ảo &amp; Heartbeat Định Kỳ",
-        "subtitle": "Bộ 3 nhân sự ảo tự phối hợp, chạy các tác vụ định kỳ qua cơ chế Heartbeat độc lập.",
-        "notes": "Designer, Curator, và Figma Hand phối hợp nhịp nhàng dưới sự điều phối của Heartbeat."
+        "title": "ĐỘI NGŨ<br>VIRTUAL STAFF",
+        "body": "Một lệnh ui agents init cấp cho dự án đội ngũ 3 chuyên gia: System Architect phụ trách cấu trúc, Craft Stylist trau chuốt thẩm mỹ và Release Auditor kiểm soát chất lượng.",
+        "heroNum": "3",
+        "heroLabel": "Vai Trò AI Chuyên Biệt",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "ko": {
-        "eyebrow": "자율 협업 팀",
-        "title": "가상 디자인 스태프 및 주기적 하트비트(Heartbeat)",
-        "subtitle": "결정론적 하트비트 데몬을 통해 지속적인 유지보수 작업을 수행하는 자율 협업 가상 에이전트 팀.",
-        "notes": "디자이너, 큐레이터, 피그마 핸드가 하트비트 감시 하에 완벽한 분업을 이룹니다."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "ja": {
-        "eyebrow": "自律協調スタッフ",
-        "title": "仮想デザインチームと周期的ハートビート",
-        "subtitle": "決定論的ハートビートデーモンにより継続的なタスクを実行する自律型仮想エージェントチーム。",
-        "notes": "Designer、Curator、Figma Handがハートビート管理下で有機的に連携します。"
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "es": {
-        "eyebrow": "Colaboración Autónoma",
-        "title": "Equipo de Diseño Virtual y Heartbeat Periódico",
-        "subtitle": "Equipo de agentes virtuales autónomos que ejecutan tareas continuas mediante el demonio de heartbeat.",
-        "notes": "Designer, Curator y Figma Hand colaboran bajo la supervisión de Heartbeat."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "fr": {
-        "eyebrow": "Collaboration Autonome",
-        "title": "Équipe de Design Virtuelle &amp; Heartbeat Périodique",
-        "subtitle": "Équipe d'agents virtuels autonomes exécutant des tâches continues via le démon heartbeat déterministe.",
-        "notes": "Le Designer, le Curateur et Figma Hand collaborent sous la régulation du heartbeat."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "zh": {
-        "eyebrow": "自主协同体系",
-        "title": "虚拟设计班组与周期性 Heartbeat 心跳守护",
-        "subtitle": "Designer、Curator 与 Figma Hand 虚拟专员协同作业，通过确定性心跳守护实现无人值守维护。",
-        "notes": "三大虚拟角色各司其职，在 Heartbeat 的精确节拍下完成资产巡检与自动优化。"
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       }
     },
     "9": {
       "en": {
-        "eyebrow": "Daily Operations",
-        "title": "The 6 Core Daily Verbs (/ui:* Commands)",
-        "subtitle": "Standardized slash commands covering every day-to-day design requirement with absolute determinism.",
-        "notes": "From generate to iterate and to-figma, these 6 verbs structure every agent workflow."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "vi": {
-        "eyebrow": "Thao Tác Thường Nhật",
-        "title": "6 Động Từ Thường Nhật (Daily Verbs)",
-        "subtitle": "Bộ lệnh slash command chuẩn hóa đáp ứng mọi nhu cầu thiết kế hàng ngày với độ tất định tuyệt đối.",
-        "notes": "Từ generate đến iterate và to-figma, 6 động từ này định hình toàn bộ luồng làm việc của agent."
+        "title": "6 ĐỘNG TỪ<br>VẬN HÀNH CLI",
+        "body": "Trải nghiệm CLI mượt mà với các lệnh tự nhiên: /ui:generate tạo màn hình mới, /ui:iterate tinh chỉnh, /ui:audit kiểm tra tiêu chuẩn và /ui:design khám phá biến thể.",
+        "heroNum": "6",
+        "heroLabel": "Động Từ Thao Tác Cốt Lõi",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "ko": {
-        "eyebrow": "일일 운영 커맨드",
-        "title": "6대 일상 동사 커맨드 (Daily Verbs)",
-        "subtitle": "절대적인 결정론을 기반으로 매일의 디자인 요구사항을 완벽히 충족하는 표준 슬래시 명령어 세트.",
-        "notes": "생성부터 반복 개선, 피그마 전송까지 6개 명령어가 모든 워크플로우를 주도합니다."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "ja": {
-        "eyebrow": "日常オペレーション",
-        "title": "6つの日常コマンド（Daily Verbs）",
-        "subtitle": "決定論的な品質を維持しながら、日々のデザイン作業を網羅する標準スラッシュコマンド群。",
-        "notes": "generateからiterate、to-figmaまで、6つのコマンドがエージェントの作業を定義します。"
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "es": {
-        "eyebrow": "Operaciones Diarias",
-        "title": "Los 6 Verbos Clave de Operación Diaria",
-        "subtitle": "Comandos slash estandarizados que cubren cada necesidad de diseño con total determinismo.",
-        "notes": "Desde generate hasta iterate y to-figma, estos 6 verbos estructuran todo el flujo de trabajo."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "fr": {
-        "eyebrow": "Opérations Quotidiennes",
-        "title": "Les 6 Verbes Quotidiens Essentiels",
-        "subtitle": "Commandes slash standardisées couvrant tous les besoins de conception avec un déterminisme absolu.",
-        "notes": "De generate à iterate et to-figma, ces 6 verbes structurent le travail des agents."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "zh": {
-        "eyebrow": "日常操作动词",
-        "title": "6 大日常核心设计动词 (/ui:* 指令集)",
-        "subtitle": "标准化的斜杠指令集，以高度确定性的协议覆盖从草图生成、局部迭代到画布推送的全部场景。",
-        "notes": "6 大日常指令是驱动 DESIGN:OS 运转的核心交互接口。"
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       }
     },
     "10": {
       "en": {
-        "eyebrow": "Bi-directional Bridge",
-        "title": "Figma Desktop Bridge: Broker Port 9410",
-        "subtitle": "AI Agents and Designers collaborate on a real-time Figma file with secure conflict locking.",
-        "notes": "The local broker on port 9410 connects directly to the Figma Desktop plugin for live layout synthesis and token binding."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "vi": {
-        "eyebrow": "Cầu Nối Hai Chiều",
-        "title": "Cây Cầu Figma Desktop: Broker Port 9410",
-        "subtitle": "AI Agent và Designer cùng làm việc trên một file Figma thời gian thực với cơ chế khóa xung đột an toàn.",
-        "notes": "Broker port 9410 kết nối trực tiếp với Figma Desktop Plugin, cho phép AI dựng layout và gán token tự động."
+        "title": "CẦU NỐI TRỰC TIẾP<br>FIGMA DESKTOP",
+        "body": "Đồng bộ WebSocket cục bộ hai chiều giữa Git code và canvas Figma Desktop thời gian thực. Đẩy tokens DTCG thành Figma Variables và kéo Auto-Layout frames thành mã AST.",
+        "heroNum": "9410",
+        "heroLabel": "Cổng Broker Cục Bộ",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "ko": {
-        "eyebrow": "양방향 실시간 브릿지",
-        "title": "피그마 데스크톱 브릿지: 브로커 포트 9410",
-        "subtitle": "AI 에이전트와 디자이너가 안전한 충돌 방지 락을 통해 실시간 피그마 파일에서 협업합니다.",
-        "notes": "포트 9410 브로커를 통해 피그마 플러그인과 연결하여 오토레이아웃과 토큰을 실시간 동기화합니다."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "ja": {
-        "eyebrow": "双方向ブリッジ",
-        "title": "Figma デスクトップブリッジ: Broker Port 9410",
-        "subtitle": "AIエージェントとデザイナーが衝突防止ロック付きでリアルタイムにFigmaファイルを共同編集します。",
-        "notes": "ポート9410のローカルブローカーを介して、Figmaプラグインとトークンを双方向同期します。"
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "es": {
-        "eyebrow": "Puente Bidireccional",
-        "title": "Puente Figma Desktop: Broker Port 9410",
-        "subtitle": "Los agentes AI y diseñadores colaboran en tiempo real en Figma con bloqueo de conflictos.",
-        "notes": "El broker en el puerto 9410 permite la síntesis de layouts y la vinculación de tokens en vivo."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "fr": {
-        "eyebrow": "Pont Bidirectionnel",
-        "title": "Pont Figma Desktop: Broker Port 9410",
-        "subtitle": "Les agents IA et les designers collaborent en temps réel sur Figma avec verrouillage sécurisé.",
-        "notes": "Le broker sur le port 9410 connecte directement le plugin Figma pour la synchronisation des tokens."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "zh": {
-        "eyebrow": "双向实时桥接",
-        "title": "Figma 桌面级桥接体系: Broker 端口 9410",
-        "subtitle": "AI Agent 与设计师在 Figma 画布上实时协同，具备安全无锁的冲突避让与断线保护机制。",
-        "notes": "9410 端口本地 Broker 直连官方 Plugin，实现代码 Tokens 与 Figma Variables 的 1:1 双向映射。"
-      }
-    },
-    "16": {
-      "en": {
-        "eyebrow": "Color Science",
-        "title": "OKLCH Mathematics, P3 Gamut &amp; Delta EOK",
-        "subtitle": "Why DESIGN:OS deprecates legacy HSL/Hex in favor of the perceptually uniform OKLCH color space.",
-        "notes": "OKLCH ensures uniform perceived lightness across all hues, guaranteeing true accessibility."
-      },
-      "vi": {
-        "eyebrow": "Khoa Học Màu Sắc",
-        "title": "Toán Học Màu OKLCH, Gamut P3 &amp; Delta EOK",
-        "subtitle": "Tại sao DESIGN:OS cấm hoàn toàn HSL và sRGB cổ điển để chuyển sang không gian cảm nhận đồng đều OKLCH.",
-        "notes": "Toán học màu OKLCH bảo đảm mọi thang bậc sáng đều có cùng độ tương phản mắt thấy."
-      },
-      "ko": {
-        "eyebrow": "색채 과학",
-        "title": "OKLCH 수학, P3 색역 및 델타 EOK",
-        "subtitle": "DESIGN:OS가 기존 HSL/Hex를 완전히 배제하고 지각적 균일 공간인 OKLCH를 선택한 이유입니다.",
-        "notes": "OKLCH는 모든 색상에서 인간의 눈이 느끼는 균일한 밝기를 제공하여 완벽한 웹 접근성을 보장합니다."
-      },
-      "ja": {
-        "eyebrow": "色彩科学",
-        "title": "OKLCH 色彩数学、P3色域、Delta EOK",
-        "subtitle": "従来のHSLやHexを廃止し、知覚的に均一なOKLCH色空間を採用する理由を解説します。",
-        "notes": "OKLCH数学により、あらゆる色相で視覚的に均一な明度とコントラスト比を保証します。"
-      },
-      "es": {
-        "eyebrow": "Ciencia del Color",
-        "title": "Matemáticas OKLCH, Gama P3 y Delta EOK",
-        "subtitle": "Por qué DESIGN:OS abandona HSL/Hex en favor del espacio perceptualmente uniforme OKLCH.",
-        "notes": "OKLCH garantiza una luminosidad percibida uniforme, asegurando verdadera accesibilidad."
-      },
-      "fr": {
-        "eyebrow": "Science des Couleurs",
-        "title": "Mathématiques OKLCH, Espace P3 &amp; Delta EOK",
-        "subtitle": "Pourquoi DESIGN:OS abandonne HSL/Hex au profit de l'espace perceptuellement uniforme OKLCH.",
-        "notes": "OKLCH assure une luminosité perçue constante sur toutes les teintes pour une accessibilité parfaite."
-      },
-      "zh": {
-        "eyebrow": "色彩科学与数学",
-        "title": "OKLCH 感知均匀色彩空间、P3 广色域与 ΔEOK",
-        "subtitle": "揭秘为何 DESIGN:OS 全面废黜传统 HSL/RGB，转向视觉感知一致的现代 OKLCH 色彩体系。",
-        "notes": "OKLCH 严格保证感知亮度 L 的物理一致性，结合 ΔEOK 实现 Semver 破坏性颜色变更的自动判定。"
-      }
-    },
-    "21": {
-      "en": {
-        "eyebrow": "Scroll-Driven Cinema",
-        "title": "Scroll-Cinema: The Art of Seamless Camera Flight",
-        "subtitle": "Chaining separately rendered video clips into a single continuous take driven directly by scroll gestures.",
-        "notes": "The seam is the product: position and velocity continuity must hold perfectly so the flight feels like one unbroken take."
-      },
-      "vi": {
-        "eyebrow": "Điện Ảnh Cuộn Trang",
-        "title": "Scroll-Cinema: Nghệ Thuật Cuộn Phim Không Vết Cắt",
-        "subtitle": "Kỹ thuật ráp nối các đoạn clip riêng lẻ thành một cú máy one-take duy nhất điều khiển trực tiếp bằng ngón tay cuộn chuột.",
-        "notes": "Mối nối (Seam) là sản phẩm: đảm bảo tính liên tục về vị trí và vận tốc để người xem cảm nhận như 1 cú máy one-take duy nhất."
-      },
-      "ko": {
-        "eyebrow": "스크롤 시네마",
-        "title": "스크롤 시네마: 이음새 없는 카메라 비행의 미학",
-        "subtitle": "개별 렌더링된 클립들을 스크롤 제스처로 직접 제어하는 하나의 연속적인 원테이크로 결합합니다.",
-        "notes": "이음새(Seam)가 곧 제품입니다. 위치와 속도의 연속성이 유지되어야 단절 없는 비행 경험이 완성됩니다."
-      },
-      "ja": {
-        "eyebrow": "スクロール・シネマ",
-        "title": "スクロールシネマ: 継ぎ目のないカメラ飛行の美学",
-        "subtitle": "個別にレンダリングされた映像を、スクロール操作で操る1つの連続ワンテイクへと結合します。",
-        "notes": "シーム（継ぎ目）こそが品質の核心です。位置と速度の連続性を厳格に保持します。"
-      },
-      "es": {
-        "eyebrow": "Cine Guiado por Scroll",
-        "title": "Scroll-Cinema: El Arte del Vuelo de Cámara Continuo",
-        "subtitle": "Uniendo clips independientes en una toma continua impulsada directamente por el desplazamiento.",
-        "notes": "La costura es el producto: la continuidad de posición y velocidad debe mantenerse intacta."
-      },
-      "fr": {
-        "eyebrow": "Cinéma au Défilement",
-        "title": "Scroll-Cinéma: L'Art du Vol de Caméra Continu",
-        "subtitle": "Assembler des clips distincts en un plan-séquence unique contrôlé par le défilement.",
-        "notes": "La jointure est le produit: la continuité de position et de vitesse doit être absolue."
-      },
-      "zh": {
-        "eyebrow": "滚动电影工程",
-        "title": "Scroll-Cinema: 无缝一镜到底的滚动电影艺术",
-        "subtitle": "通过接缝物理定律（Seam Physics），将多段 AI 生成的视频切片拼接为单手指掌控的超高清一镜到底体验。",
-        "notes": "接缝即产品：严格遵循位置连续性与速度矢量锁定，绝不允许在接缝处产生任何倒车眩晕卡顿。"
-      }
-    },
-    "27": {
-      "en": {
-        "eyebrow": "Fable Thinking",
-        "title": "The 5 Design Fables: Philosophy Behind Master Craft",
-        "subtitle": "Distilling complex engineering mechanisms into intuitive allegorical archetypes.",
-        "notes": "These 5 fables embody the deep design engineering philosophy behind DESIGN:OS."
-      },
-      "vi": {
-        "eyebrow": "Tư Duy Ngụ Ngôn",
-        "title": "5 Ngụ Ngôn Triết Lý Thiết Kế (Design Fables)",
-        "subtitle": "Đúc kết những cơ chế kỹ thuật phức tạp thành các hình tượng ngụ ngôn trực quan dễ ghi nhớ.",
-        "notes": "5 câu chuyện ngụ ngôn là tổng kết triết lý sâu sắc nhất đằng sau toàn bộ công nghệ của DESIGN:OS."
-      },
-      "ko": {
-        "eyebrow": "우화적 사고 모델",
-        "title": "5가지 디자인 우화: 마스터 크래프트 뒤에 숨겨진 철학",
-        "subtitle": "복잡한 엔지니어링 메커니즘을 직관적인 우화적 아키타입으로 압축하여 전달합니다.",
-        "notes": "이 5가지 우화는 DESIGN:OS 기술 전반에 흐르는 깊은 디자인 철학을 상징합니다."
-      },
-      "ja": {
-        "eyebrow": "寓話的思考法",
-        "title": "5つのデザイン寓話: 卓越したクラフトを支える哲学",
-        "subtitle": "複雑なエンジニアリング構造を、記憶に残りやすい直感的な寓話モデルへと昇華します。",
-        "notes": "これら5つの寓話は、DESIGN:OSの設計思想の真髄を端的に物語っています。"
-      },
-      "es": {
-        "eyebrow": "Pensamiento de Fábulas",
-        "title": "Las 5 Fábulas de Diseño: Filosofía Detrás del Diseño Maestro",
-        "subtitle": "Sintetizando mecanismos complejos en arquetipos alegóricos memorables.",
-        "notes": "Estas 5 fábulas representan la filosofía fundamental de ingeniería de DESIGN:OS."
-      },
-      "fr": {
-        "eyebrow": "Pensée par Fables",
-        "title": "Les 5 Fables de Design: La Philosophie du Grand Design",
-        "subtitle": "Transformer des mécanismes complexes en archétypes allégoriques mémorables.",
-        "notes": "Ces 5 fables incarnent la philosophie profonde d'ingénierie qui anime DESIGN:OS."
-      },
-      "zh": {
-        "eyebrow": "AK 寓言式思维",
-        "title": "5 大设计寓言: 卓越工程背后的系统哲学",
-        "subtitle": "将极其精密复杂的软件架构与美学规范，提炼为直指人心的 5 大直觉寓言模型。",
-        "notes": "5 大寓言是 DESIGN:OS 最深层的灵魂沉淀：用无缝飞行、双向之桥与14块坚硬踏板构筑工业级奇迹。"
-      }
-    },
-    "28": {
-      "en": {
-        "eyebrow": "Quickstart Guide",
-        "title": "Start in 60 Seconds: Production Ready",
-        "subtitle": "Install toolchain, compile design tokens, and launch your first AI agent with deterministic quality guarantees.",
-        "notes": "You are now fully equipped to build production-grade web interfaces and Figma canvases with DESIGN:OS."
-      },
-      "vi": {
-        "eyebrow": "Khởi Động Nhanh",
-        "title": "Bắt Đầu Ngay Trong 60 Giây",
-        "subtitle": "Cài đặt bộ công cụ, biên dịch design tokens và khởi chạy agent đầu tiên với bảo chứng chất lượng tuyệt đối.",
-        "notes": "Bạn đã sẵn sàng để xây dựng các sản phẩm web và canvas Figma đẳng cấp thế giới cùng DESIGN:OS."
-      },
-      "ko": {
-        "eyebrow": "빠른 시작 가이드",
-        "title": "60초 안에 시작하기: 프로덕션 준비 완료",
-        "subtitle": "툴체인을 설치하고, 디자인 토큰을 컴파일하며, 결정론적 품질 보증을 갖춘 첫 AI 에이전트를 실행하세요.",
-        "notes": "이제 DESIGN:OS와 함께 최고 수준의 웹 및 피그마 캔버스를 구축할 준비가 완료되었습니다."
-      },
-      "ja": {
-        "eyebrow": "クイックスタート",
-        "title": "60秒で始める: 本番対応",
-        "subtitle": "ツールチェーンをインストールし、トークンをコンパイルして、決定論的な品質保証のもとで最初のAIを起動します。",
-        "notes": "これでDESIGN:OSを活用して、最高品質のWebとFigmaを制作する準備が整いました。"
-      },
-      "es": {
-        "eyebrow": "Inicio Rápido",
-        "title": "Comienza en 60 Segundos: Listo para Producción",
-        "subtitle": "Instala la suite de herramientas, compila tus tokens y lanza tu primer agente AI con calidad garantizada.",
-        "notes": "Ahora estás listo para construir interfaces web y lienzos de Figma de clase mundial con DESIGN:OS."
-      },
-      "fr": {
-        "eyebrow": "Démarrage Rapide",
-        "title": "Démarrer en 60 Secondes: Prêt pour la Production",
-        "subtitle": "Installez les outils, compilez les tokens et lancez votre premier agent IA avec une garantie totale de qualité.",
-        "notes": "Vous êtes désormais équipé pour créer des interfaces web et des maquettes Figma de niveau mondial."
-      },
-      "zh": {
-        "eyebrow": "快速上手",
-        "title": "60 秒极速起步: 生产级就绪",
-        "subtitle": "安装全局工具链，编译 DTCG 设计令牌，以完全确定性的质量保障启动您的第一个 AI 设计智能体。",
-        "notes": "恭喜！您已全面掌握 DESIGN:OS 的全套精髓，开启确定性工业级设计之旅。"
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       }
     },
     "11": {
       "en": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Slide 11 architectural overview."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "vi": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Tổng quan kiến trúc slide 11."
+        "title": "TOKEN CHÂN LÝ<br>W3C DTCG",
+        "body": "Hệ thống token biên dịch qua chuẩn W3C DTCG là nguồn chân lý duy nhất, xuất bản đồng thời CSS custom properties, Tailwind plugin và native Figma Variables.",
+        "heroNum": "100 %",
+        "heroLabel": "Ràng Buộc AST Token",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "ko": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "슬라이드 11 아키텍처 개요."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "ja": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "スライド 11 アーキテクチャ概要。"
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "es": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Resumen arquitectónico de la diapositiva 11."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "fr": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Aperçu architectural de la diapositive 11."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "zh": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "第 11 页系统架构深度解析。"
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       }
     },
     "12": {
       "en": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Slide 12 architectural overview."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "vi": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Tổng quan kiến trúc slide 12."
+        "title": "4 CỬA ẢI<br>KIỂM ĐỊNH",
+        "body": "Tháp lọc 4 tầng kiểm tra mọi bản dựng trước khi phát hành: taste-lint bắt anti-pattern, validate-layout ngăn tràn lề và container soup, a11y-lint đạt WCAG 2.2 AA và audit tổng.",
+        "heroNum": "0",
+        "heroLabel": "Lỗi Được Phép Xuất Xưởng",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "ko": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "슬라이드 12 아키텍처 개요."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "ja": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "スライド 12 アーキテクチャ概要。"
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "es": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Resumen arquitectónico de la diapositiva 12."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "fr": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Aperçu architectural de la diapositive 12."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "zh": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "第 12 页系统架构深度解析。"
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       }
     },
     "13": {
       "en": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Slide 13 architectural overview."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "vi": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Tổng quan kiến trúc slide 13."
+        "title": "GIAO THỨC<br>XỬ LÝ LỖI",
+        "body": "Mọi cảnh báo tuân thủ quy tắc 3 bước: Tự động sửa qua ui autofix, tái cấu trúc layout tối đa 3 vòng lặp, và chuyển tiếp lên người dùng nếu có xung đột không thể tự giải quyết.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Vòng Lặp Hội Tụ Tối Đa",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "ko": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "슬라이드 13 아키텍처 개요."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "ja": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "スライド 13 アーキテクチャ概要。"
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "es": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Resumen arquitectónico de la diapositiva 13."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "fr": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Aperçu architectural de la diapositive 13."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "zh": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "第 13 页系统架构深度解析。"
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       }
     },
     "14": {
       "en": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Slide 14 architectural overview."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "vi": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Tổng quan kiến trúc slide 14."
+        "title": "VÒNG LẶP<br>KÝ ỨC VECTOR",
+        "body": "Học hỏi liên tục qua không gian vector ONNX cục bộ. Đề bài mới truy vấn ký ức thiết kế cũ, các bài học trước đó mồi agent để không bao giờ lặp lại sai lầm trong quá khứ.",
+        "heroNum": "0.85",
+        "heroLabel": "Ngưỡng Truy Hồi Cosine",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "ko": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "슬라이드 14 아키텍처 개요."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "ja": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "スライド 14 アーキテクチャ概要。"
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "es": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Resumen arquitectónico de la diapositiva 14."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "fr": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Aperçu architectural de la diapositive 14."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "zh": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "第 14 页系统架构深度解析。"
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       }
     },
     "15": {
       "en": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Slide 15 architectural overview."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "vi": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Tổng quan kiến trúc slide 15."
+        "title": "LÒ LUYỆN<br>ĐÚC KẾT BÀI HỌC",
+        "body": "Phản tư sau khi sinh giao diện tự động trích xuất quy tắc thẩm mỹ từ chỉnh sửa của người dùng và PR diff, lưu trữ vào .design/memory.json hoàn toàn riêng tư cục bộ.",
+        "heroNum": "100 %",
+        "heroLabel": "Bảo Mật Ký Ức Cục Bộ",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "ko": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "슬라이드 15 아키텍처 개요."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "ja": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "スライド 15 アーキテクチャ概要。"
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "es": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Resumen arquitectónico de la diapositiva 15."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "fr": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Aperçu architectural de la diapositive 15."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "zh": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "第 15 页系统架构深度解析。"
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
+      }
+    },
+    "16": {
+      "en": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "vi": {
+        "title": "KHOA HỌC MÀU<br>OKLCH DISPLAY P3",
+        "body": "Chuẩn hóa không gian màu OKLCH triệt tiêu biến dạng độ sáng cảm nhận của HSL. Tạo dải màu hài hòa toán học với độ sáng đồng nhất trên 100% dải màu rộng Display P3.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Độ Chuẩn Xác Semver Patch",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "ko": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "ja": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "es": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "fr": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "zh": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
       }
     },
     "17": {
       "en": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Slide 17 architectural overview."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "vi": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Tổng quan kiến trúc slide 17."
+        "title": "RADAR THẨM MỸ<br>6+1 TRỤC",
+        "body": "Đánh giá thẩm mỹ khách quan trên 6 chiều giác quan: Layout, Typography, Spacing, Iconography, Motion và Depth, xoay quanh mỏ neo bắt buộc Core 0 Tính nhất quán.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Điểm Tối Thiểu Xuất Xưởng",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "ko": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "슬라이드 17 아키텍처 개요."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "ja": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "スライド 17 アーキテクチャ概要。"
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "es": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Resumen arquitectónico de la diapositiva 17."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "fr": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Aperçu architectural de la diapositive 17."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "zh": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "第 17 页系统架构深度解析。"
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       }
     },
     "18": {
       "en": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Slide 18 architectural overview."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "vi": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Tổng quan kiến trúc slide 18."
+        "title": "12 ĐỊNH LUẬT<br>CÔNG HỌC UX",
+        "body": "Áp dụng công học kinh điển—vùng chạm Fitts Law (≥ 44px), phân đoạn Miller Law, độ trễ Hick Law và mô hình tâm trí Jakob Law trực tiếp vào linter và token.",
+        "heroNum": "12",
+        "heroLabel": "Luật Công Học Thực Thi",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "ko": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "슬라이드 18 아키텍처 개요."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "ja": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "スライド 18 アーキテクチャ概要。"
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "es": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Resumen arquitectónico de la diapositiva 18."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "fr": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Aperçu architectural de la diapositive 18."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "zh": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "第 18 页系统架构深度解析。"
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       }
     },
     "19": {
       "en": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Slide 19 architectural overview."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "vi": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Tổng quan kiến trúc slide 19."
+        "title": "BỘ PERSONA<br>BẢN SẮC THIẾT KẾ",
+        "body": "11 bản sắc thiết kế độc đáo: Editorial, Hyper-Density, Brutalist, Spatial Glass, Retro Terminal. Mỗi persona định hình thang phông, bo góc, độ sâu bóng đổ và tốc độ chuyển động.",
+        "heroNum": "11",
+        "heroLabel": "Bản Sắc Thiết Kế Riêng",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "ko": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "슬라이드 19 아키텍처 개요."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "ja": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "スライド 19 アーキテクチャ概要。"
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "es": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Resumen arquitectónico de la diapositiva 19."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "fr": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Aperçu architectural de la diapositive 19."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "zh": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "第 19 页系统架构深度解析。"
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       }
     },
     "20": {
       "en": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Slide 20 architectural overview."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "vi": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Tổng quan kiến trúc slide 20."
+        "title": "THANG BẬC<br>CHUYỂN ĐỘNG",
+        "body": "Kỷ luật chuyển động phân tầng: Chỉ leo từ T1 Phản hồi xúc giác lên T6 WebGL khi câu chuyện đòi hỏi và ngân sách cho phép, bảo vệ tuyệt đối bởi prefers-reduced-motion.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Ngân Sách Khung Hình Khóa",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "ko": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "슬라이드 20 아키텍처 개요."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "ja": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "スライド 20 アーキテクチャ概要。"
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "es": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Resumen arquitectónico de la diapositiva 20."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "fr": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Aperçu architectural de la diapositive 20."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "zh": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "第 20 页系统架构深度解析。"
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
+      }
+    },
+    "21": {
+      "en": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "vi": {
+        "title": "ĐIỆN ẢNH CUỘN<br>SCROLL-CINEMA",
+        "body": "Nối chuỗi các phân đoạn camera không gian thành đường bay liên tục 60fps điều khiển trực tiếp bằng thao tác cuộn, khóa chính xác bằng ngàm vật lý vận tốc tiếp tuyến.",
+        "heroNum": "0 ms",
+        "heroLabel": "Độ Giật Cục Chuyển Tiếp",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "ko": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "ja": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "es": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "fr": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "zh": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
       }
     },
     "22": {
       "en": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Slide 22 architectural overview."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "vi": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Tổng quan kiến trúc slide 22."
+        "title": "KHÔNG GIAN 3D<br>GFLOW HARDWARE",
+        "body": "Module GFlow chuyên biệt mang lại shader WebGL tăng tốc phần cứng, nén hình học Draco và vòng đời thu hồi bộ nhớ nghiêm ngặt chống rò rỉ GPU.",
+        "heroNum": "2 K",
+        "heroLabel": "Độ Phân Giải Subpixel 2K",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "ko": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "슬라이드 22 아키텍처 개요."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "ja": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "スライド 22 アーキテクチャ概要。"
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "es": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Resumen arquitectónico de la diapositiva 22."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "fr": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Aperçu architectural de la diapositive 22."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "zh": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "第 22 页系统架构深度解析。"
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       }
     },
     "23": {
       "en": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Slide 23 architectural overview."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "vi": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Tổng quan kiến trúc slide 23."
+        "title": "KIỂM ĐỊNH<br>HÌNH ẢNH HỒI QUY",
+        "body": "Ma trận hồi quy thị giác headless tự động chụp toàn trang trên 3 kích thước 1920, 1440 và 390, chứng minh không có độ trôi layout hay lỗi font trước khi duyệt PR.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Màn Hình Đã Xác Minh",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "ko": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "슬라이드 23 아키텍처 개요."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "ja": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "スライド 23 アーキテクチャ概要。"
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "es": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Resumen arquitectónico de la diapositiva 23."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "fr": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Aperçu architectural de la diapositive 23."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "zh": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "第 23 页系统架构深度解析。"
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       }
     },
     "24": {
       "en": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Slide 24 architectural overview."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "vi": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Tổng quan kiến trúc slide 24."
+        "title": "ĐÚC KẾT &<br>TÍCH LŨY TAY NGHỀ",
+        "body": "Mỗi lần giao hàng kích hoạt phản tư tự động: chấm điểm biến thể, ghi nhận lựa chọn của con người và tích lũy gu thẩm mỹ vào kho tri thức chung của tổ chức.",
+        "heroNum": "10 X",
+        "heroLabel": "Gia Tốc Tốc Độ Đội Ngũ",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "ko": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "슬라이드 24 아키텍처 개요."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "ja": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "スライド 24 アーキテクチャ概要。"
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "es": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Resumen arquitectónico de la diapositiva 24."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "fr": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Aperçu architectural de la diapositive 24."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "zh": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "第 24 页系统架构深度解析。"
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       }
     },
     "25": {
       "en": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Slide 25 architectural overview."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "vi": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Tổng quan kiến trúc slide 25."
+        "title": "QUY TRÌNH<br>ĐÓNG GÓI 6 BƯỚC",
+        "body": "Tháp tinh chế đóng gói bắt buộc chạy công cụ theo đúng thứ tự bắt lỗi: Flow state machine, Evidence mục tiêu, VR baseline, Token cặp đôi, Rendered a11y và Full audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Cửa Ải Đạt Chuẩn",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "ko": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "슬라이드 25 아키텍처 개요."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "ja": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "スライド 25 アーキテクチャ概要。"
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "es": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Resumen arquitectónico de la diapositiva 25."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "fr": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Aperçu architectural de la diapositive 25."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "zh": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "第 25 页系统架构深度解析。"
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       }
     },
     "26": {
       "en": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Slide 26 architectural overview."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "vi": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Tổng quan kiến trúc slide 26."
+        "title": "BẢNG PHÂN LOẠI<br>PHIÊN BẢN SEMVER",
+        "body": "Quy tắc Semantic Versioning chặt chẽ cho thiết kế: Chỉnh token nhỏ là Patch, thêm component là Minor, thay đổi màu Delta E > 0.05 bắt buộc nâng Major.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Ràng Buộc Semver Sản Xuất",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "ko": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "슬라이드 26 아키텍처 개요."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "ja": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "スライド 26 アーキテクチャ概要。"
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "es": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Resumen arquitectónico de la diapositiva 26."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "fr": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Aperçu architectural de la diapositive 26."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "zh": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "第 26 页系统架构深度解析。"
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
+      }
+    },
+    "27": {
+      "en": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "vi": {
+        "title": "5 CÂU CHUYỆN<br>NGỤ NGÔN THIẾT KẾ",
+        "body": "Chuyển hóa sơ đồ mã khô khan thành thực thể cơ học sống động: Chuyến Bay Liền Mạch, Cây Cầu Hai Bờ, Sàn Thép 14 Tấm, Thang Chuyển Động và Ký Ức Đúc Kết.",
+        "heroNum": "5",
+        "heroLabel": "Ngụ Ngôn Không Gian Sống",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "ko": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "ja": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "es": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "fr": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "zh": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      }
+    },
+    "28": {
+      "en": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "vi": {
+        "title": "SẴN SÀNG CHO<br>SẢN XUẤT",
+        "body": "Hệ thống thiết kế đa runtime của bạn đã được biên dịch, kiểm định và sẵn sàng. Chạy ui generate để tạo trải nghiệm tiếp theo với độ chuẩn xác tuyệt đối và tốc độ tức thì.",
+        "heroNum": "SHIP",
+        "heroLabel": "Sàn Chất Lượng Giao Hàng",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "ko": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "ja": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "es": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "fr": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "zh": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
       }
     }
   }

--- a/site/deck.css
+++ b/site/deck.css
@@ -1156,3 +1156,435 @@
     transition: none !important;
   }
 }
+
+
+
+/* =========================================================
+   RADIANT EDITORIAL THEME (BIG NUMBER • LESS CONTENT)
+   High-Contrast Asymmetric Split Layout
+   Obsidian Dark Backdrop + Luminous Gradient Master Card + Tactile Metric Orbs
+   ========================================================= */
+
+:root {
+  --bg-obsidian: #040507;
+  --bg-obsidian-card: #0c0d12;
+  --text-obsidian-primary: #f5f6f8;
+  --text-obsidian-muted: #8e929b;
+  
+  /* Luminous Radiant Card Palette */
+  --luminous-grad: linear-gradient(135deg, #e4fed2 0%, #f7fed8 40%, #9ef5b4 100%);
+  --luminous-text-primary: #07080a;
+  --luminous-text-muted: #2d323b;
+  --luminous-track: rgba(0, 0, 0, 0.12);
+  --luminous-bar: #07080a;
+
+  /* Tactile Orbs Palette */
+  --orb-lime-bg: #e2fed0;
+  --orb-lime-text: #07080a;
+  --orb-dark-bg: radial-gradient(circle at 30% 30%, #22252e 0%, #0d0e12 100%);
+  --orb-dark-text: #f3f4f6;
+  --orb-dark-border: rgba(255, 255, 255, 0.1);
+  --orb-dark-shadow: 0 24px 60px rgba(0, 0, 0, 0.7);
+}
+
+.slide-stage {
+  background-color: var(--bg-obsidian) !important;
+  border-color: #1a1c24 !important;
+}
+
+.slide-item {
+  background-color: var(--bg-obsidian) !important;
+  color: var(--text-obsidian-primary);
+  padding: 48px 80px 40px !important;
+}
+
+.chrome-accent-strip {
+  background: var(--orb-lime-bg) !important;
+}
+
+.chrome-header {
+  top: 24px !important;
+  left: 80px !important;
+  right: 80px !important;
+  color: var(--text-obsidian-muted) !important;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+}
+
+.chrome-brand-badge {
+  background-color: var(--orb-lime-bg) !important;
+  color: var(--luminous-text-primary) !important;
+}
+
+.chrome-footer {
+  bottom: 20px !important;
+  left: 80px !important;
+  right: 80px !important;
+  color: var(--text-obsidian-muted) !important;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+/* Radiant Asymmetric Split Stage Layout */
+.radiant-stage-grid {
+  display: grid;
+  grid-template-columns: 46% 54%;
+  gap: 48px;
+  width: 100%;
+  height: calc(1080px - 140px);
+  margin-top: 10px;
+  align-items: center;
+}
+
+/* Left Column: Tactile Metric Orbs Cluster */
+.radiant-left-cluster {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.orb-badge-icon {
+  position: absolute;
+  top: 12%;
+  left: 12%;
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  background: var(--orb-lime-bg);
+  color: var(--orb-lime-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: 800;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+/* Primary Luminous Lime Orb */
+.orb-primary-lime {
+  position: absolute;
+  left: 6%;
+  bottom: 14%;
+  width: 330px;
+  height: 330px;
+  border-radius: 50%;
+  background: var(--orb-lime-bg);
+  color: var(--orb-lime-text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  text-align: center;
+  box-shadow: 0 20px 60px rgba(158, 245, 180, 0.25);
+  z-index: 3;
+  transition: transform 0.2s ease;
+}
+
+.orb-arrow {
+  font-size: 28px;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.orb-stat-huge {
+  font-size: 72px;
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+.orb-label-main {
+  font-size: 19px;
+  font-weight: 600;
+  margin-top: 10px;
+  letter-spacing: -0.01em;
+  opacity: 0.9;
+}
+
+/* Secondary Dark Glass Orb */
+.orb-secondary-dark {
+  position: absolute;
+  top: 16%;
+  right: 18%;
+  width: 270px;
+  height: 270px;
+  border-radius: 50%;
+  background: var(--orb-dark-bg);
+  color: var(--orb-dark-text);
+  border: 1px solid var(--orb-dark-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
+  box-shadow: var(--orb-dark-shadow);
+  z-index: 2;
+}
+
+.orb-stat-secondary {
+  font-size: 58px;
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+}
+
+.orb-label-secondary {
+  font-size: 17px;
+  font-weight: 500;
+  color: var(--text-obsidian-muted);
+  margin-top: 8px;
+}
+
+/* Tertiary Dark Glass Orb */
+.orb-tertiary-dark {
+  position: absolute;
+  right: 6%;
+  bottom: 12%;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: var(--orb-dark-bg);
+  color: var(--orb-dark-text);
+  border: 1px solid var(--orb-dark-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  text-align: center;
+  box-shadow: var(--orb-dark-shadow);
+  z-index: 1;
+}
+
+.orb-stat-tertiary {
+  font-size: 48px;
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+}
+
+.orb-label-tertiary {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-obsidian-muted);
+  margin-top: 6px;
+}
+
+/* Right Column: Luminous Master Card */
+.radiant-master-card {
+  width: 100%;
+  height: 100%;
+  max-height: 760px;
+  background: var(--luminous-grad);
+  border-radius: 36px;
+  padding: 56px 64px;
+  color: var(--luminous-text-primary);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6), 0 2px 10px rgba(0, 0, 0, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+.radiant-card-top {
+  display: flex;
+  flex-direction: column;
+}
+
+.radiant-dots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.radiant-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #07080a;
+  opacity: 0.85;
+}
+
+.radiant-display-title {
+  font-size: 60px;
+  font-weight: 800;
+  line-height: 1.04;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+  color: var(--luminous-text-primary);
+  margin-bottom: 22px;
+}
+
+.radiant-body-text {
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--luminous-text-muted);
+  max-width: 580px;
+  font-weight: 500;
+}
+
+.radiant-card-bottom {
+  margin-top: auto;
+  padding-top: 32px;
+}
+
+.radiant-hero-number {
+  font-size: 96px;
+  font-weight: 800;
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  color: var(--luminous-text-primary);
+}
+
+.radiant-hero-label {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--luminous-text-primary);
+  margin-top: 6px;
+}
+
+.radiant-progress-track {
+  width: 100%;
+  max-width: 220px;
+  height: 8px;
+  background: var(--luminous-track);
+  border-radius: 999px;
+  margin-top: 20px;
+  overflow: hidden;
+}
+
+.radiant-progress-fill {
+  height: 100%;
+  background: var(--luminous-bar);
+  border-radius: 999px;
+}
+
+/* Mobile & Tablet Responsive Breakdown */
+
+@media (max-width: 1023px) {
+  .radiant-stage-grid {
+    display: flex !important;
+    flex-direction: column !important;
+    height: auto !important;
+    gap: 24px !important;
+    margin-top: 40px !important;
+  }
+
+  .radiant-master-card {
+    order: 1 !important;
+    max-height: none !important;
+    padding: 32px 24px !important;
+    border-radius: 24px !important;
+  }
+
+  .radiant-display-title {
+    font-size: 34px !important;
+    line-height: 1.05 !important;
+    margin-bottom: 16px !important;
+  }
+
+  .radiant-body-text {
+    font-size: 15px !important;
+    line-height: 1.5 !important;
+  }
+
+  .radiant-card-bottom {
+    padding-top: 24px !important;
+  }
+
+  .radiant-hero-number {
+    font-size: 56px !important;
+  }
+
+  .radiant-hero-label {
+    font-size: 18px !important;
+  }
+
+  .radiant-left-cluster {
+    order: 2 !important;
+    position: relative !important;
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 12px !important;
+    height: auto !important;
+    width: 100% !important;
+    margin-top: 12px !important;
+  }
+
+  .orb-badge-icon {
+    position: relative !important;
+    top: auto !important;
+    left: auto !important;
+    grid-column: span 2;
+    width: 44px !important;
+    height: 44px !important;
+    font-size: 18px !important;
+    border-radius: 12px !important;
+    margin: 0 auto 8px auto !important;
+  }
+
+  .orb-primary-lime {
+    position: relative !important;
+    left: auto !important;
+    bottom: auto !important;
+    grid-column: span 2;
+    width: 100% !important;
+    height: auto !important;
+    border-radius: 20px !important;
+    padding: 24px !important;
+  }
+
+  .orb-stat-huge {
+    font-size: 48px !important;
+  }
+
+  .orb-label-main {
+    font-size: 15px !important;
+  }
+
+  .orb-secondary-dark {
+    position: relative !important;
+    top: auto !important;
+    right: auto !important;
+    width: 100% !important;
+    height: auto !important;
+    border-radius: 18px !important;
+    padding: 20px 14px !important;
+  }
+
+  .orb-stat-secondary {
+    font-size: 32px !important;
+  }
+
+  .orb-label-secondary {
+    font-size: 13px !important;
+  }
+
+  .orb-tertiary-dark {
+    position: relative !important;
+    right: auto !important;
+    bottom: auto !important;
+    width: 100% !important;
+    height: auto !important;
+    border-radius: 18px !important;
+    padding: 20px 14px !important;
+  }
+
+  .orb-stat-tertiary {
+    font-size: 32px !important;
+  }
+
+  .orb-label-tertiary {
+    font-size: 13px !important;
+  }
+}

--- a/site/deck.js
+++ b/site/deck.js
@@ -148,8 +148,8 @@
     if (!overviewGrid) return;
     overviewGrid.innerHTML = '';
     slides.forEach((slide, index) => {
-      const titleEl = slide.querySelector('.slide-title-display, .slide-title-h1');
-      const titleText = titleEl ? titleEl.textContent : 'Slide ' + (index + 1);
+      const titleEl = slide.querySelector('.radiant-display-title, .slide-title-display, .slide-title-h1');
+      const titleText = titleEl ? (titleEl.innerHTML.replace(/<br\s*\/?>/gi, ' ').replace(/<[^>]+>/g, '').trim()) : 'Slide ' + (index + 1);
       const card = document.createElement('div');
       card.className = 'overview-card' + (index === currentIndex ? ' active' : '');
       card.innerHTML = '<div style="font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 8px;">SLIDE ' + String(index + 1).padStart(2, '0') + '</div><div style="font-weight: 700; font-size: 14px; color: var(--text-primary); line-height: 1.3;">' + titleText + '</div>';
@@ -226,13 +226,21 @@
         const slideData = DECK_I18N.slides[slideNum] && (DECK_I18N.slides[slideNum][lang] || DECK_I18N.slides[slideNum].en);
         if (slideData) {
           const eyebrowEl = slide.querySelector('.slide-eyebrow');
-          const titleEl = slide.querySelector('.slide-title-display, .slide-title-h1');
+          const titleEl = slide.querySelector('.radiant-display-title, .slide-title-display, .slide-title-h1');
           const subtitleEl = slide.querySelector('.slide-subtitle');
           const notesEl = slide.querySelector('[data-speaker-notes]');
 
-          if (eyebrowEl && slideData.eyebrow) eyebrowEl.innerHTML = slideData.eyebrow;
+          const radTitle = slide.querySelector('.radiant-display-title');
+          const radBody = slide.querySelector('.radiant-body-text');
+          const radHeroNum = slide.querySelector('.radiant-hero-number');
+          const radHeroLabel = slide.querySelector('.radiant-hero-label');
+          if (radTitle && slideData.title) radTitle.innerHTML = slideData.title;
+          if (radBody && (slideData.body || slideData.subtitle)) radBody.innerHTML = slideData.body || slideData.subtitle;
+          if (radHeroNum && slideData.heroNum) radHeroNum.textContent = slideData.heroNum;
+          if (radHeroLabel && slideData.heroLabel) radHeroLabel.textContent = slideData.heroLabel;
+
           if (titleEl && slideData.title) titleEl.innerHTML = slideData.title;
-          if (subtitleEl && slideData.subtitle) subtitleEl.innerHTML = slideData.subtitle;
+          if (subtitleEl && (slideData.subtitle || slideData.body)) subtitleEl.innerHTML = slideData.subtitle || slideData.body;
           if (notesEl && slideData.notes) notesEl.setAttribute('data-speaker-notes', slideData.notes);
         }
       });

--- a/site/index.html
+++ b/site/index.html
@@ -53,2105 +53,1796 @@
   <main class="deck-viewport">
     <div class="slide-stage" id="slideStage">
 
-
 <article class="slide-item active" id="slide-1" data-index="1">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
           <div class="chrome-brand">
             <span class="chrome-brand-badge">DESIGN:OS</span>
-            <span>Masterclass Architecture Deck</span>
+            <span>Masterclass Operating Guide • V1.0</span>
           </div>
-          <div>The Complete 28-Slide Operating Guide • v1.0.0</div>
+          <div>01 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone" style="justify-content: center;">
-          <span class="slide-eyebrow gsap-reveal">Multi-Runtime Design CLI • Production Operating Manual</span>
-          <h1 class="slide-title-display gsap-reveal">
-            Mastering DESIGN:OS<br>From AI Reasoning to Scroll-Cinema &amp; Figma.
-          </h1>
-          <p class="slide-subtitle gsap-reveal" style="font-size: var(--font-size-xl);">
-            7 Strategic Acts: AI vs Kernel Division, 6 Onboarding Roads, Live Figma Bridge 9410, Recall Vector Memory, OKLCH Color Science, 3D GFlow &amp; 2K Scroll-Cinema, and Qualified Delivery Floor.
-          </p>
-          <div style="display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px;" class="gsap-reveal">
-            <span class="matrix-badge">28 Master Slides</span>
-            <span class="matrix-badge">Figma Desktop Hand</span>
-            <span class="matrix-badge">GFlow &amp; Scroll-Cinema</span>
-            <span class="matrix-badge">OKLCH &amp; P3 Gamut</span>
-            <span class="matrix-badge">12 UX Laws</span>
-            <span class="matrix-badge">Fable Thinking</span>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">✦</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">100%</div>
+              <div class="orb-label-main">Deterministic Floor</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">7 Acts</div>
+              <div class="orb-label-secondary">Strategic Chapters</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">28</div>
+              <div class="orb-label-tertiary">Master Slides</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">MASTERING<br>DESIGN:OS</h1>
+              <p class="radiant-body-text">The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0 %</div>
+              <div class="radiant-hero-label">LLM Luck Required</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
+            </div>
           </div>
         </section>
 
         <footer class="chrome-footer">
-          <div>Press [Left / Right Arrow] or [Space] to navigate • [S] Speaker Notes • [O] Overview • [L] Language • [T] Theme</div>
-          <div id="slideCounterDisplay">01 / 28</div>
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>01 / 28</div>
         </footer>
-        <div data-speaker-notes="Chào mừng đến với DESIGN:OS Masterclass mở rộng 28 slide. Đây là bộ cẩm nang hoàn chỉnh nhất, bao quát từ lõi toán học, cầu nối Figma, bộ nhớ vector đến điện ảnh cuộn trang 3D và 5 câu chuyện ngụ ngôn triết lý thiết kế."></div>
+        <div data-speaker-notes="Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."></div>
       </article>
 
 <article class="slide-item" id="slide-2" data-index="2">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Triết Lý Cốt Lõi</span></div>
-          <div>Hồi 1 • 01 • Core Foundations</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Core Philosophy</span>
+          </div>
+          <div>02 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Triết Lý Cốt Lõi</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 3 Supreme Truths of DESIGN:OS</h2>
-            <p class="slide-subtitle gsap-reveal">Eliminating reliance on LLM luck. Enforcing quality through color science and deterministic machine floors.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">360°</div>
+              <div class="orb-label-main">OKLCH Uniformity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0.02</div>
+              <div class="orb-label-secondary">ΔEOK Precision</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">14</div>
+              <div class="orb-label-tertiary">Quality Linters</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableTriadTitle fableTriadDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="nodePillar2"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableTriadTitle">The 3 Supreme Truths Architecture Triad</title>
-            <desc id="fableTriadDesc">Equilateral harmonic architecture diagram representing the three unbreakable foundational pillars: OKLCH Color Math, Sovereign Division of Labor, and the 14-Plank Machine Quality Floor.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">3 SUPREME<br>TRUTHS</h1>
+              <p class="radiant-body-text">Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.</p>
+            </div>
 
-            <defs>
-              <linearGradient id="triadBeam" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-primary)" stop-opacity="0.3"/>
-                <stop offset="50%" stop-color="var(--text-primary)" stop-opacity="0.9"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="0.3"/>
-              </linearGradient>
-            </defs>
-
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE HARMONIC FIELD • THREE INVIOLABLE TRUTHS</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="url(#triadBeam)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="url(#triadBeam)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <rect x="450" y="212" width="60" height="20" rx="10" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="480" y="226" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">FEEDS</text>
-
-            <rect x="930" y="212" width="60" height="20" rx="10" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="960" y="226" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">ENFORCES</text>
-
-            <!-- PILLAR 1: OKLCH COLOR SCIENCE (Prismatic Chamber) -->
-            <g id="nodePillar1" class="interactive-node" tabindex="0" role="button" aria-label="Truth 1: OKLCH Color Science" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TRUTH 01 • COLOR SCIENCE</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="104" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <polygon points="104,152 116,172 92,172" fill="var(--text-primary)"/>
-
-              <text x="136" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">OKLCH Color Math</text>
-              <text x="136" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Perceptual Uniformity Scale</text>
-
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu hoàn toàn HSL &amp; Hex ngẫu nhiên</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ sáng cảm nhận L đồng đều mọi góc Hue</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đạt chuẩn tương phản quang học WCAG AA</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khai thác 100% không gian màu Display P3</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">METRIC: ΔEOK &lt; 0.02 (Pure Precision)</text>
-            </g>
-
-            <!-- PILLAR 2: DIVISION OF LABOR (Dual Core Monolith - FOCAL) -->
-            <g id="nodePillar2" class="interactive-node" tabindex="0" role="button" aria-label="Truth 2: Division of Labor" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">TRUTH 02 • BRAIN &amp; BODY [FOCAL]</text>
-
-              <circle cx="564" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="564" cy="165" r="7" fill="var(--text-primary)"/>
-
-              <text x="596" y="162" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Division of Labor</text>
-              <text x="596" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Reasoning Brain vs UI Kernel</text>
-
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Host AI: Suy luận Persona, IA &amp; Component Tree</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• UI Kernel: Đóng gói DTCG Tokens &amp; Toán học màu</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tách bạch tuyệt đối giữa Ý Niệm và Thực Thi</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Không ảo giác token, không phụ thuộc may rủi</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">CONTRACT: Zero Stochastic Code</text>
-            </g>
-
-            <!-- PILLAR 3: MACHINE QUALITY FLOOR (14-Plank Grid) -->
-            <g id="nodePillar3" class="interactive-node" tabindex="0" role="button" aria-label="Truth 3: Deterministic Machine Floor" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TRUTH 03 • QUALITY FLOOR</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="1044" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <rect x="1038" y="159" width="12" height="12" fill="var(--text-primary)"/>
-
-              <text x="1076" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Deterministic Floor</text>
-              <text x="1076" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">14 Hard Machine Linters</text>
-
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui validate-layout: Bắt tràn màn hình &amp; soup &gt; 2</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui taste-lint: Sàn thẩm mỹ 6 trục (Taste Floor)</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui a11y-lint: Kiểm thử tĩnh chuẩn tiếp cận Tier-1</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Lỗi bất kỳ = Chặn merge Pull Request (Exit 1)</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">GATE: 14 Linters 100% Pass</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-2">
-              <span class="readout-badge">FOUNDATIONS TRIAD: ACTIVE</span>
-              <span class="readout-text" id="readout-text-slide-2">Click any Pillar node or trigger button to inspect architectural contract parameters.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">14</div>
+              <div class="radiant-hero-label">Machine Floor Linters</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Operating Manual • Core Philosophy</div><div>02 / 28</div></footer>
-        <div data-speaker-notes="3 chân lý tối thượng là kim chỉ nam: biến sự hỗn loạn của LLM thành kết quả tất định."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>02 / 28</div>
+        </footer>
+        <div data-speaker-notes="The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."></div>
       </article>
 
 <article class="slide-item" id="slide-3" data-index="3">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Kiến Trúc Phân Quyền</span></div>
-          <div>Hồi 1 • 02 • Architecture Split</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Architecture Split</span>
+          </div>
+          <div>03 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Kiến Trúc Phân Quyền</span>
-            <h2 class="slide-title-h1 gsap-reveal">Division of Labor: AI Reasoning vs UI Kernel</h2>
-            <p class="slide-subtitle gsap-reveal">Host AI Agent handles creative reasoning, while the deterministic UI Kernel executes color mathematics and strict compliance verification.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚙</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">2 Minds</div>
+              <div class="orb-label-main">Human & Host Agent</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Kernel</div>
+              <div class="orb-label-secondary">Deterministic Engine</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Leaks</div>
+              <div class="orb-label-tertiary">Stochastic Free</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableArchTitle fableArchDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="kernelChamber"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableArchTitle">The Division of Labor: From Human Beacon to Neural Prism and Monolithic Kernel Gate</title>
-            <desc id="fableArchDesc">Aerodynamic structural diagram illustrating the living transformation of human intent through neural reasoning into deterministic, mathematically verified UI code.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DIVISION<br>OF LABOR</h1>
+              <p class="radiant-body-text">The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.</p>
+            </div>
 
-            <defs>
-              <!-- Luminous Waveguide Gradients -->
-              <linearGradient id="beamGradient1" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-muted)" stop-opacity="0.2"/>
-                <stop offset="50%" stop-color="var(--text-primary)" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="1"/>
-              </linearGradient>
-              <linearGradient id="beamGradient2" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-primary)" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="1"/>
-              </linearGradient>
-              <filter id="glowFable" x="-20%" y="-20%" width="140%" height="140%">
-                <feGaussianBlur stdDeviation="6" result="blur" />
-                <feComposite in="SourceGraphic" in2="blur" operator="over" />
-              </filter>
-            </defs>
-
-            <!-- Background Atmospheric Energy Field -->
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--text-inverse)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE LIVING STREAM • BRAIN &amp; BODY DUALITY PIPELINE</text>
-
-            <!-- 1. Waveguide Conduit 1 (Human -> AI) -->
-            <path id="waveguide1" d="M 360 250 C 420 250, 440 250, 500 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 360 250 C 420 250, 440 250, 500 250" fill="none" stroke="url(#beamGradient1)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <!-- 2. Waveguide Conduit 2 (AI -> Kernel) -->
-            <path id="waveguide2" d="M 900 250 C 960 250, 980 250, 1040 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 900 250 C 960 250, 980 250, 1040 250" fill="none" stroke="url(#beamGradient2)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <!-- Photonic Packets (Data flow pulse) -->
-
-            <!-- Conduit Flow Status Badges -->
-            <rect x="395" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="430" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PROMPT</text>
-
-            <rect x="935" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="970" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">AST / DTCG</text>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 1: THE HUMAN BEACON (Intent Transmitter)        -->
-            <!-- ======================================================== -->
-            <g id="nodeUser" class="interactive-node" tabindex="0" role="button" aria-label="Organism 1: Human Intent Beacon" style="cursor: pointer;">
-              <!-- Outer Resonance Rings -->
-              <circle cx="200" cy="250" r="145" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-              <circle cx="200" cy="250" r="130" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              
-              <!-- Core Capsule -->
-              <rect x="80" y="150" width="240" height="200" rx="16" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              
-              <!-- Glowing Beacon Emitter -->
-              <circle cx="200" cy="180" r="22" fill="var(--text-inverse)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="200" cy="180" r="8" fill="var(--text-primary)"/>
-
-              <text x="200" y="228" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.1em" text-anchor="middle">ORGAN 01 • TRANSMITTER</text>
-              <text x="200" y="255" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Human Intent</text>
-              <text x="200" y="278" font-family="var(--font-mono)" font-size="12" fill="var(--text-secondary)" text-anchor="middle">Natural Language Brief</text>
-
-              <!-- Parametric Readout -->
-              <rect x="96" y="298" width="208" height="34" rx="8" fill="var(--bg-surface)" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="200" y="320" font-family="var(--font-mono)" font-size="11" font-weight="600" fill="var(--text-primary)" text-anchor="middle">INPUT: Brand • Mood • Target</text>
-            </g>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 2: THE NEURAL PRISM (Creative Reasoning Brain)  -->
-            <!-- ======================================================== -->
-            <g id="nodeAgent" class="interactive-node" tabindex="0" role="button" aria-label="Organism 2: Neural Synthesis Prism" style="cursor: pointer;">
-              <!-- Outer Prism Geometry (Hexagonal Resonator) -->
-              <polygon points="700,70 880,160 880,340 700,430 520,340 520,160" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              
-              <!-- Inner Refraction Core -->
-              <polygon points="700,100 850,175 850,325 700,400 550,325 550,175" fill="var(--bg-surface-raised)" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <!-- Central Synthesis Engine -->
-              <circle cx="700" cy="200" r="36" fill="var(--text-inverse)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <text x="700" y="195" font-family="'Inter'" font-size="22" font-weight="900" fill="var(--text-primary)" text-anchor="middle">AI</text>
-              <text x="700" y="215" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-muted)" text-anchor="middle">BRAIN</text>
-
-              <text x="700" y="260" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.1em" text-anchor="middle">ORGAN 02 • NEURAL PRISM</text>
-              <text x="700" y="285" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Host AI Agent</text>
-              <text x="700" y="308" font-family="var(--font-mono)" font-size="12" fill="var(--text-secondary)" text-anchor="middle">Creative Synthesis &amp; Persona</text>
-
-              <!-- Refraction Beams (Persona spectrum) -->
-              <line x1="600" y1="330" x2="800" y2="330" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="700" y="352" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Resolves Persona Family</text>
-              <text x="700" y="374" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Crafts Semantic DOM Tree</text>
-
-              <rect x="570" y="390" width="260" height="28" rx="6" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="700" y="408" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-primary)" text-anchor="middle">ROLE: Creative Reasoning</text>
-            </g>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 3: THE MONOLITHIC KERNEL GATE (Deterministic)   -->
-            <!-- ======================================================== -->
-            <g id="nodeKernel" class="interactive-node" tabindex="0" role="button" aria-label="Organism 3: Monolithic Kernel Gate" style="cursor: pointer;">
-              <!-- Outer Monolith Boundary (Heavy Structural Armor) -->
-              <rect x="1040" y="70" width="350" height="360" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              
-              <!-- Top Gate Header -->
-              <rect x="1040" y="70" width="350" height="50" rx="16" fill="var(--text-primary)"/>
-              <text x="1215" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">ORGAN 03 • MONOLITHIC GATE [FOCAL]</text>
-
-              <!-- Core Identity -->
-              <text x="1215" y="155" font-family="var(--font-sans)" font-size="22" font-weight="800" fill="var(--text-primary)" text-anchor="middle">UI Kernel Engine</text>
-              <text x="1215" y="178" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)" text-anchor="middle">Deterministic Color &amp; 14 Linters Floor</text>
-              <line x1="1070" y1="195" x2="1360" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <!-- 3 Gate Valves (The 3 Hard Machine Checks) -->
-              <g transform="translate(1065, 210)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">1. OKLCH / P3 Color Math</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">ΔEOK PASS</text>
-              </g>
-
-              <g transform="translate(1065, 256)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">2. DTCG Token Compiler</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">100% BOUND</text>
-              </g>
-
-              <g transform="translate(1065, 302)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">3. 14 Deterministic Linters</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">EXIT 0</text>
-              </g>
-
-              <!-- Qualified Delivery Seal -->
-              <rect x="1065" y="355" width="300" height="50" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1215" y="385" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.06em" text-anchor="middle">✓ ZERO-STOCHASTIC RELEASE</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-3">
-              <span class="readout-badge">PIPELINE: ACTIVE</span>
-              <span class="readout-text" id="readout-text-slide-3">Click any node or press 'Simulate Data Flow' to watch the prompt-to-kernel deterministic validation run.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Deterministic Compile</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Architecture • System Division of Labor</div><div>03 / 28</div></footer>
-        <div data-speaker-notes="AI Agent suy luận, UI Kernel kiểm định. Hai bán cầu kết hợp thành vòng lặp tự sửa lỗi hoàn hảo."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>03 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."></div>
       </article>
 
 <article class="slide-item" id="slide-4" data-index="4">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Optional Hands</span></div>
-          <div>Hồi 1 • 03 • Specialized Modules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Hands Ecosystem</span>
+          </div>
+          <div>04 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Module Mở Rộng</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 6 Specialized Optional Hands Ecosystem</h2>
-            <p class="slide-subtitle gsap-reveal">Specialized modular hands extend multi-dimensional design capabilities, gracefully degrading when unconfigured.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">✋</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Hands</div>
+              <div class="orb-label-main">Specialized Engines</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 CLI</div>
+              <div class="orb-label-secondary">Unified Toolchain</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 ms</div>
+              <div class="orb-label-tertiary">Runtime Bloat</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. FIGMA 1:1 MIRROR</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">figma-agent</div>
-              <p class="stat-desc">Connects to Figma Desktop via port 9410. Synthesizes precise auto-layout, swaps component instances, and syncs tokens bi-directionally.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">OPTIONAL<br>HANDS</h1>
+              <p class="radiant-body-text">Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. SEMANTIC MEMORY</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">recall (mind)</div>
-              <p class="stat-desc">Local vector memory powered by ONNX embeddings. Recalls historical lessons at task start and distills insights upon completion.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. 3D &amp; SCROLL CINEMA</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">gflow &amp; scrub</div>
-              <p class="stat-desc">Điều khiển camera 3D và cuộn video không vết cắt (Seam Physics) thông qua Google Flow (Veo/Imagen).</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">4. VISUAL REGRESSION</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">page-shot &amp; vr</div>
-              <p class="stat-desc">Chụp render thực tế và so sánh pixel-level diff cho từng component (vr-matrix), ngăn chặn layout shift ngoài ý muốn.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">5. RENDERED A11Y</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">a11y-audit</div>
-              <p class="stat-desc">Thực thi axe-core trên Chrome headless để kiểm tra độ tương phản thực tế và cây ngữ nghĩa ARIA ở trạng thái render thật.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">6. CANVAS &amp; SHADERS</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">canvas-ui (T6)</div>
-              <p class="stat-desc">Mô phỏng chất liệu Liquid Glass, hạt 3D và WebGL shaders với hợp đồng dọn dẹp bộ nhớ (Teardown Contract).</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6</div>
+              <div class="radiant-hero-label">Multi-Runtime Engines</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Toolchain • Optional Hands Ecosystem</div><div>04 / 28</div></footer>
-        <div data-speaker-notes="6 cánh tay này biến DESIGN:OS thành hệ điều hành thiết kế toàn năng từ giao diện web phẳng đến không gian 3D và canvas Figma."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>04 / 28</div>
+        </footer>
+        <div data-speaker-notes="The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."></div>
       </article>
 
 <article class="slide-item" id="slide-5" data-index="5">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Bản Sắc Thiết Kế</span></div>
-          <div>Hồi 1 • 04 • Design Soul Architecture</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Design Soul</span>
+          </div>
+          <div>05 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bản Sắc Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">3-Tier Design Soul Hierarchy (Never / Always / Voice)</h2>
-            <p class="slide-subtitle gsap-reveal">Establishing aesthetic stances and consistent design vocabulary from Studio level down to specific projects.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏛</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">WT 75</div>
+              <div class="orb-label-main">Project Overrides</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">WT 50</div>
+              <div class="orb-label-secondary">Studio Shared</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">WT 0</div>
+              <div class="orb-label-tertiary">Factory Invariant</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableSoulTitle fableSoulDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ttb"
-            data-focal-id="soulProject"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableSoulTitle">Design Soul: The 3 Tiers of Sovereignty &amp; Precedence Cascade</title>
-            <desc id="fableSoulDesc">Hierarchical cascade diagram showing the three tiers of design truth: Factory Invariants, Studio Standards, and Project Soul.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">CASCADE OF<br>SOVEREIGNTY</h1>
+              <p class="radiant-body-text">Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE SOVEREIGNTY CASCADE • THREE TIERS OF DESIGN TRUTH</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- TIER 0: FACTORY INVARIANTS -->
-            <g id="soulFactory" class="interactive-node" tabindex="0" role="button" aria-label="Tier 0: Factory Invariants" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TIER 0 • FACTORY (WEIGHT 0)</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="104" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <rect x="96" y="157" width="16" height="16" fill="var(--text-primary)"/>
-
-              <text x="136" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Factory Invariants</text>
-              <text x="136" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Immutable Architectural Laws</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu Purple-on-Dark &amp; Glow Borders</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cấm container lồng nhau quá 2 cấp (Soup)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chuẩn tiếp cận WCAG 2.2 AA bắt buộc</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Luật cứng: Không thể bị ghi đè (Immutable)</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SOVEREIGNTY: Absolute Floor</text>
-            </g>
-
-            <!-- TIER 1: STUDIO STANDARDS -->
-            <g id="soulStudio" class="interactive-node" tabindex="0" role="button" aria-label="Tier 1: Studio Standards" style="cursor: pointer;">
-              <rect x="520" y="80" width="400" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="520" y="80" width="400" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="544" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TIER 1 • STUDIO (WEIGHT 50)</text>
-              <circle cx="890" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="564" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <polygon points="564,152 576,172 552,172" fill="var(--text-primary)"/>
-
-              <text x="596" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Studio Standards</text>
-              <text x="596" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Workspace Shared Conventions</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chuẩn nhịp 8px Spacing Grid toàn team</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Thư viện Icon mặc định: Phosphor Icons</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Font typography mặc định theo phân khúc</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Định hình phong cách chung cả tổ chức</text>
-
-              <rect x="544" y="350" width="352" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="720" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">WORKSPACE: Shared Stance</text>
-            </g>
-
-            <!-- TIER 2: PROJECT SOUL -->
-            <g id="soulProject" class="interactive-node" tabindex="0" role="button" aria-label="Tier 2: Project Soul" style="cursor: pointer;">
-              <rect x="1000" y="70" width="380" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1000" y="70" width="380" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="1190" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">TIER 2 • PROJECT SOUL [FOCAL]</text>
-
-              <circle cx="1044" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="1044" cy="165" r="8" fill="var(--text-primary)"/>
-
-              <text x="1076" y="162" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Project Soul</text>
-              <text x="1076" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Bespoke Brand Persona</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Persona gia đình: Aurora Minimal / Brutalist</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bảng màu thương hiệu OKLCH độc bản</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ cao thang chuyển động (Motion Cap T5)</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Ghi đè Studio Stance khi Brief yêu cầu</text>
-
-              <rect x="1024" y="350" width="332" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1190" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">PRECEDENCE: Project Brief Wins</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-5">
-              <span class="readout-badge">PRECEDENCE: HIERARCHICAL</span>
-              <span class="readout-text" id="readout-text-slide-5">Click tiers to test rule resolution: Explicit User Brief (100) > Project Soul (75) > Studio Standards (50) > Factory Invariants (0).</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3 Tiers</div>
+              <div class="radiant-hero-label">Precedence Hierarchy</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 75%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Architecture • Soul Precedence</div><div>05 / 28</div></footer>
-        <div data-speaker-notes="Soul thiết lập lập trường thẩm mỹ. Explicit Brief từ user luôn có quyền ghi đè cao nhất."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>05 / 28</div>
+        </footer>
+        <div data-speaker-notes="Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."></div>
       </article>
 
 <article class="slide-item" id="slide-6" data-index="6">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Onboarding Router</span></div>
-          <div>Hồi 2 • 05 • The 6 Entry Roads</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Onboarding</span>
+          </div>
+          <div>06 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Onboarding</span>
-            <h2 class="slide-title-h1 gsap-reveal">6 Entry Roads for Project Onboarding (E1–E6)</h2>
-            <p class="slide-subtitle gsap-reveal">Chạy <code>ui scan --json</code> để tự động nhận diện tình trạng dự án và chọn đúng lộ trình khởi tạo.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🛣</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Roads</div>
+              <div class="orb-label-main">E1 to E6 Pathways</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Scan</div>
+              <div class="orb-label-secondary">Auto Diagnostics</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Guess</div>
+              <div class="orb-label-tertiary">Instant Setup</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E1 • GREENFIELD</span>
-              <div class="stat-label" style="margin-top: 10px;">Dự án mới hoàn toàn</div>
-              <p class="stat-desc">Khởi tạo Design System từ 1 trong 26 Personas có sẵn.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui ds init app --persona aurora-minimal</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">6 ENTRY<br>ROADS</h1>
+              <p class="radiant-body-text">Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E2 • BROWNFIELD</span>
-              <div class="stat-label" style="margin-top: 10px;">Codebase có sẵn</div>
-              <p class="stat-desc">Quét mã nguồn hiện tại và biên dịch thành Design System.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui scan --cwd . → /ui:learn</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E3 • LIVE URL</span>
-              <div class="stat-label" style="margin-top: 10px;">Bóc tách từ URL</div>
-              <p class="stat-desc">Trích xuất màu sắc, typography từ website bạn thích.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>/ui:from-url https://linear.app</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E4 • FIGMA LIBRARY</span>
-              <div class="stat-label" style="margin-top: 10px;">Thư viện Figma</div>
-              <p class="stat-desc">Quét Figma file và chuyển thành bundle tokens + registry.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>design-os figma scan → ui ingest-figma-ds</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E5 • DTCG TOKENS</span>
-              <div class="stat-label" style="margin-top: 10px;">Token shadcn / DTCG</div>
-              <p class="stat-desc">Nạp file token JSON có sẵn vào kho Design System.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui ds import tokens.json --name my-app</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E6 • MOODBOARD</span>
-              <div class="stat-label" style="margin-top: 10px;">Ảnh mẫu &amp; Shots</div>
-              <p class="stat-desc">Nạp ảnh chụp màn hình để trích xuất hạt giống Persona.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>design-os reference add ./shot.png</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">E1-E6</div>
+              <div class="radiant-hero-label">Deterministic Gateways</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 60%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Onboarding • Entry Roads E1-E6</div><div>06 / 28</div></footer>
-        <div data-speaker-notes="6 cổng vào này đảm bảo DESIGN:OS hòa nhập vào bất kỳ quy trình làm việc nào của team dù là vẽ Figma trước hay code trước."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>06 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."></div>
       </article>
 
 <article class="slide-item" id="slide-7" data-index="7">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Onboarding Checklist</span></div>
-          <div>Hồi 2 • 06 • Setup &amp; Stop-Gates</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Setup Protocol</span>
+          </div>
+          <div>07 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Onboarding</span>
-            <h2 class="slide-title-h1 gsap-reveal">5-Step Setup Protocol &amp; Mandatory STOP-Gates</h2>
-            <p class="slide-subtitle gsap-reveal">Tuân thủ thứ tự thiết lập để không bao giờ gặp lỗi lệch mã băm hoặc sai danh tính Agent.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🔒</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <div class="stat-label">5 Bước Khởi Tạo Chuẩn Xác</div>
-              <ol style="padding-left: 24px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 16px;">
-                <li><strong>Bước 0:</strong> Chạy <code>ui onboard</code> xem checklist và <code>ui scan</code>.</li>
-                <li><strong>Bước 1:</strong> Chọn cổng (E1–E6) để seal kho <code>design/</code>.</li>
-                <li><strong>Bước 2:</strong> Chạy cả 2 lệnh Doctor: <code>ui doctor</code> và <code>design-os doctor --versions</code>.</li>
-                <li><strong>Bước 3:</strong> Điền Never/Always/Voice vào <code>design/soul.md</code> rồi chạy <code>ui ds soul check</code>.</li>
-                <li><strong>Bước 4:</strong> Khởi tạo đội ngũ Agent: <code>ui agents init</code>.</li>
-              </ol>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">5 Steps</div>
+              <div class="orb-label-main">Ordered Setup</div>
             </div>
 
-            <div style="display: flex; flex-direction: column; gap: 24px;">
-              <div class="slide-card gsap-card" style="border-top-color: var(--text-primary);">
-                <span class="matrix-badge">⚠️ STOP-GATE 1: NAMING HYGIENE</span>
-                <div class="stat-label" style="margin-top: 8px;">Luôn truyền --name khi import token</div>
-                <p class="stat-desc">Nếu bỏ qua <code>--name &lt;slug&gt;</code>, hệ thống mặc định đặt tên là <code>imported-ds</code> và sau này toàn bộ AI Agent sẽ bị đặt tên là <code>designer-imported-ds</code>.</p>
-              </div>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Protocol Bound</div>
+            </div>
 
-              <div class="slide-card gsap-card" style="border-top-color: var(--text-primary);">
-                <span class="matrix-badge">🛑 STOP-GATE 2: GIT PREREQUISITE</span>
-                <div class="stat-label" style="margin-top: 8px;">Bắt buộc phải là Git Repository</div>
-                <p class="stat-desc">Dự án phải có <code>.git</code> (chạy <code>git init</code>). Nếu không có git, các lỗi lệch hash registry sau này sẽ không thể diff và truy vết.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Drift</div>
+              <div class="orb-label-tertiary">Token Hash Sync</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">SETUP<br>PROTOCOL</h1>
+              <p class="radiant-body-text">Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">5 / 5</div>
+              <div class="radiant-hero-label">STOP-Gates Cleared</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Onboarding • Verification &amp; Stop-Gates</div><div>07 / 28</div></footer>
-        <div data-speaker-notes="Hai bác sĩ kiểm tra 2 việc khác nhau: ui doctor kiểm tra kernel, còn design-os doctor kiểm tra các optional hands."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>07 / 28</div>
+        </footer>
+        <div data-speaker-notes="Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."></div>
       </article>
 
 <article class="slide-item" id="slide-8" data-index="8">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Agent Staff</span></div>
-          <div>Hồi 2 • 07 • Virtual Design Staff</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Virtual Staff</span>
+          </div>
+          <div>08 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đội Ngũ Agent</span>
-            <h2 class="slide-title-h1 gsap-reveal">Virtual Design Staff &amp; Periodic Heartbeat</h2>
-            <p class="slide-subtitle gsap-reveal">Một lệnh <code>ui agents init</code> cấp cho dự án một đội ngũ 3 chuyên gia AI với ranh giới trách nhiệm nghiêm ngặt.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">👥</div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">AI DESIGNER</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">designer-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Sinh giao diện, tinh chỉnh code HTML/CSS theo đúng Design Tokens.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ được tự chấm điểm bài làm của chính mình.</p>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Agents</div>
+              <div class="orb-label-main">Specialized Roles</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">AI CURATOR</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">curator-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Thanh tra độc lập, phê bình thẩm mỹ 6+1 trục, đối chiếu spec và đưa ra phán quyết.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ được trực tiếp sửa code.</p>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Heart</div>
+              <div class="orb-label-secondary">Cron Heartbeat</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FIGMA HAND</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">figma-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Thao tác trực tiếp trên canvas Figma qua broker port 9410.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ giả lập thao tác khi plugin Figma đang tắt.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">24 / 7</div>
+              <div class="orb-label-tertiary">Active Governance</div>
             </div>
           </div>
 
-          <div class="slide-card gsap-card" style="margin-top: 24px; padding: 20px 28px; flex-direction: row; align-items: center; justify-content: space-between;">
-            <div>
-              <strong style="font-size: var(--font-size-base);">❤️ Recurring Heartbeat (<code>design-os heartbeat</code>)</strong>
-              <p style="font-size: var(--font-size-sm); color: var(--text-muted); margin-top: 4px;">Tự động quét định kỳ: <code>nightly-a11y</code>, <code>weekly-specimen</code>, <code>preview-pages</code>, <code>figma-hygiene</code>.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VIRTUAL<br>STAFF</h1>
+              <p class="radiant-body-text">A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.</p>
             </div>
-            <span class="matrix-badge">HEALTH CHECK CỤC BỘ</span>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3</div>
+              <div class="radiant-hero-label">Specialized AI Roles</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
+            </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Agents • Specialized Roles</div><div>08 / 28</div></footer>
-        <div data-speaker-notes="Designer không bao giờ tự chấm điểm, Curator không bao giờ tự sửa code. Ranh giới trách nhiệm bảo đảm chất lượng khách quan."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>08 / 28</div>
+        </footer>
+        <div data-speaker-notes="Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."></div>
       </article>
 
 <article class="slide-item" id="slide-9" data-index="9">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Daily Verbs</span></div>
-          <div>Hồi 2 • 08 • Everyday Workflow</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Daily Operations</span>
+          </div>
+          <div>09 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Công Việc Hàng Ngày</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 6 Core Daily Verbs (/ui:* Commands)</h2>
-            <p class="slide-subtitle gsap-reveal">Tương tác bằng ngôn ngữ tự nhiên trong CLI. AI tự chuyển hóa thành kế hoạch và code chuẩn mực.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Verbs</div>
+              <div class="orb-label-main">Natural CLI Verbs</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Self-Healing</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 UI Lag</div>
+              <div class="orb-label-tertiary">Instant Output</div>
+            </div>
           </div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. TẠO GIAO DIỆN MỚI</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:generate</span> landing page for an AI developer tool, brutalist-editorial, dark theme
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
-              <p class="stat-desc" style="margin-top: 10px;">Biến yêu cầu sơ khai thành brief chuẩn, dựng layout gắn token, kiểm tra qua 6 linter.</p>
+              <h1 class="radiant-display-title">6 CORE<br>DAILY VERBS</h1>
+              <p class="radiant-body-text">High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. CHỈNH SỬA VI MÔ</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:iterate</span> make the hero headline larger and the CTA button warmer
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6</div>
+              <div class="radiant-hero-label">Core Operating Verbs</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
               </div>
-              <p class="stat-desc" style="margin-top: 10px;">Chỉnh sửa phẫu thuật từng dòng (line-diff) mà không làm vỡ cấu trúc của Design System.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. DỰNG LÊN FIGMA CANVAS</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:to-figma</span> 3-tier pricing card component with toggle
-              </div>
-              <p class="stat-desc" style="margin-top: 10px;">Vẽ trực tiếp lên Figma với cấu trúc auto-layout, instance component thật và biến màu token.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">4. TRUY VẤN BỘ NHỚ</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:why</span> why did we choose oklch(0.65 0.24 260) for primary CTA?
-              </div>
-              <p class="stat-desc" style="margin-top: 10px;">Truy vết nguồn gốc mọi quyết định thiết kế trong quá khứ từ Design Memory.</p>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • Core Verbs</div><div>09 / 28</div></footer>
-        <div data-speaker-notes="6 động từ thường nhật biến CLI thành bảng điều khiển trực quan cho designer và developer."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>09 / 28</div>
+        </footer>
+        <div data-speaker-notes="Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."></div>
       </article>
 
 <article class="slide-item" id="slide-10" data-index="10">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Figma Agent Hand</span></div>
-          <div>Hồi 3 • 09 • Real-Time Bridge</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Figma Bridge</span>
+          </div>
+          <div>10 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Cầu Nối Hai Chiều</span>
-            <h2 class="slide-title-h1 gsap-reveal">Figma Desktop Bridge: Broker Port 9410</h2>
-            <p class="slide-subtitle gsap-reveal">AI Agents and Designers collaborate on a real-time Figma file with secure conflict locking.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌉</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">9410</div>
+              <div class="orb-label-main">WebSocket Broker</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">127.0.0.1</div>
+              <div class="orb-label-secondary">Local Loopback</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Conflict</div>
+              <div class="orb-label-tertiary">Atomic Mutex</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableFigmaTitle fableFigmaDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="figmaNodeBroker"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableFigmaTitle">The Two-Way Bridge: Code Tokens to Live Figma Desktop Canvas</title>
-            <desc id="fableFigmaDesc">Bi-directional suspension bridge diagram connecting Code AST Tokens and Figma Desktop Canvas via Port 9410 Broker.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">FIGMA LIVE<br>DESKTOP BRIDGE</h1>
+              <p class="radiant-body-text">Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE TWO-WAY BRIDGE • PORT 9410 BI-DIRECTIONAL REAL-TIME SYNCHRONIZATION</text>
-
-            <path d="M 380 250 C 440 250, 460 250, 520 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 380 250 C 440 250, 460 250, 520 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <path d="M 920 250 C 980 250, 1000 250, 1060 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 920 250 C 980 250, 1000 250, 1060 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <rect x="415" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="450" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PUSH DTCG</text>
-
-            <rect x="955" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="990" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PULL AST</text>
-
-            <!-- WEST BANK: CODE -->
-            <g id="figmaNodeCode" class="interactive-node" tabindex="0" role="button" aria-label="West Bank: Code Token Matrix" style="cursor: pointer;">
-              <rect x="60" y="80" width="320" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="320" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">WEST BANK • CODE</text>
-              <circle cx="350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Code Repository</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">design/tokens.json (DTCG)</text>
-              <line x1="84" y1="205" x2="356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chân lý màu: design/tokens.json</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Lệnh biên dịch: ui tokens export</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khung mã AST ngữ nghĩa HTML/CSS</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động sinh Pull Request AST diff</text>
-
-              <rect x="84" y="350" width="272" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="220" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SOURCE: Canonical DTCG</text>
-            </g>
-
-            <!-- CENTER ARCH: BROKER (FOCAL) -->
-            <g id="figmaNodeBroker" class="interactive-node" tabindex="0" role="button" aria-label="Center Arch: Port 9410 Rotary Commutator" style="cursor: pointer;">
-              <polygon points="720,60 900,155 900,345 720,440 540,345 540,155" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              
-              <rect x="580" y="80" width="280" height="36" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="103" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.08em" text-anchor="middle">WS BROKER : 9410 [FOCAL]</text>
-
-              <circle cx="720" cy="200" r="45" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <circle cx="720" cy="200" r="8" fill="var(--text-primary)"/>
-              <line x1="720" y1="160" x2="720" y2="240" stroke="var(--text-primary)" stroke-width="3" stroke-linecap="round"/>
-              <line x1="680" y1="200" x2="760" y2="200" stroke="var(--text-primary)" stroke-width="3" stroke-linecap="round"/>
-
-              <text x="720" y="270" font-family="var(--font-sans)" font-size="20" font-weight="900" fill="var(--text-primary)" text-anchor="middle">figma-agent Broker</text>
-              <text x="720" y="292" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)" text-anchor="middle">127.0.0.1:9410 WebSocket Engine</text>
-
-              <line x1="600" y1="315" x2="840" y2="315" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="720" y="338" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Atomic Token Serialization</text>
-              <text x="720" y="360" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Mutex Conflict-Lock Protocol</text>
-
-              <rect x="580" y="380" width="280" height="36" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="403" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STATUS: Port 9410 Connected</text>
-            </g>
-
-            <!-- EAST BANK: CANVAS -->
-            <g id="figmaNodeCanvas" class="interactive-node" tabindex="0" role="button" aria-label="East Bank: Live Figma Desktop Canvas" style="cursor: pointer;">
-              <rect x="1060" y="80" width="320" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1060" y="80" width="320" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1084" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">EAST BANK • CANVAS</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1084" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Figma Desktop Canvas</text>
-              <text x="1084" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Live Variables &amp; Auto-Layout</text>
-              <line x1="1084" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1084" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Liên kết trực tiếp Figma Variables</text>
-              <text x="1084" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Auto-Layout tương thích 1:1 Flexbox</text>
-              <text x="1084" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Designer chỉnh sửa = Gửi event WebSocket</text>
-              <text x="1084" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động bắt sự kiện qua Plugin manifest</text>
-
-              <rect x="1084" y="350" width="272" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1220" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SURFACE: Live Native Canvas</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-10">
-              <span class="readout-badge">BROKER: PORT 9410 READY</span>
-              <span class="readout-text" id="readout-text-slide-10">Click nodes or simulation button to inspect bi-directional Code-to-Canvas push and Canvas-to-Code pull mechanics.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">9410</div>
+              <div class="radiant-hero-label">Local Broker Port</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Figma Hand • Real-Time Bridge Architecture</div><div>10 / 28</div></footer>
-        <div data-speaker-notes="Broker port 9410 kết nối trực tiếp với Figma Desktop Plugin, cho phép AI dựng layout và gán token tự động."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>10 / 28</div>
+        </footer>
+        <div data-speaker-notes="The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."></div>
       </article>
 
 <article class="slide-item" id="slide-11" data-index="11">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Figma Craft</span></div>
-          <div>Hồi 3 • 10 • Auto-Layout &amp; Token Binding</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Token Pipeline</span>
+          </div>
+          <div>11 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Chuẩn Mực Figma</span>
-            <h2 class="slide-title-h1 gsap-reveal">Crafting Canvas Art: Auto-Layout &amp; Variables</h2>
-            <p class="slide-subtitle gsap-reveal">Không bao giờ vẽ hình chữ nhật tự do vô nghĩa. Mọi khung vẽ đều phải tuân thủ nghiêm ngặt Auto-Layout và Token Variables.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🪙</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 Source</div>
+              <div class="orb-label-main">design/tokens.json</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">W3C DTCG Standard</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Stale</div>
+              <div class="orb-label-tertiary">Synchronized AST</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. AUTO-LAYOUT SÂU</span>
-              <div class="stat-label" style="margin-top: 8px;">Auto-Layout 100%</div>
-              <p class="stat-desc" style="margin-top: 10px;">100% frame đều có layoutMode (HORIZONTAL / VERTICAL), padding và itemSpacing chuẩn token 4/8px.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>node.layoutMode = 'VERTICAL';</code><br>
-                <code>node.itemSpacing = 16;</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">CANONICAL<br>TOKENS</h1>
+              <p class="radiant-body-text">Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. INSTANCE SWAPPING</span>
-              <div class="stat-label" style="margin-top: 8px;">Tái Dùng Component</div>
-              <p class="stat-desc" style="margin-top: 10px;">Không vẽ lại Button hay Input. Trỏ tìm Component trong Library và gọi <code>createInstance()</code> chuẩn xác.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>const inst = comp.createInstance();</code><br>
-                <code>parent.appendChild(inst);</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. VARIABLE BINDING</span>
-              <div class="stat-label" style="margin-top: 8px;">Gắn Token Variables</div>
-              <p class="stat-desc" style="margin-top: 10px;">Màu sắc không tô raw hex. Ánh xạ trực tiếp sang Figma Variable Collection đã nhập từ DTCG tokens.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>node.setBoundVariable('fills', vId);</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Token AST Binding</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Figma Craft • Canonical Canvas Rules</div><div>11 / 28</div></footer>
-        <div data-speaker-notes="Canvas trên Figma được tạo ra có cấu trúc như mã nguồn thực tế: có auto-layout, instance component và variable tokens."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>11 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."></div>
       </article>
 
 <article class="slide-item" id="slide-12" data-index="12">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Audit Surfaces</span></div>
-          <div>Hồi 3 • 11 • Audit Disambiguation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Quality Audit</span>
+          </div>
+          <div>12 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bề Mặt Kiểm Định</span>
-            <h2 class="slide-title-h1 gsap-reveal">Dissecting the 4 'Audit' Surfaces</h2>
-            <p class="slide-subtitle gsap-reveal">4 công cụ khác nhau cùng mang từ khóa "Audit". Chọn đúng công cụ theo đúng đối tượng kiểm tra.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🔬</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">4 Surfaces</div>
+              <div class="orb-label-main">Chamber Sieve</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">6 Axes</div>
+              <div class="orb-label-secondary">Taste Rubric</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≤ 2</div>
+              <div class="orb-label-tertiary">Max Container Soup</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableAuditTitle fableAuditDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="auditQuad1"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableAuditTitle">The 4 Registered Audit Surfaces Matrix</title>
-            <desc id="fableAuditDesc">Quadrant architecture matrix showing the four deterministic verification surfaces: taste-lint, validate-layout, a11y-lint, and full-stack vr-gate release suites.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">4 QUALITY<br>SURFACES</h1>
+              <p class="radiant-body-text">The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE 4-CHAMBER QUALITY SIEVE • DETERMINISTIC VERIFICATION MATRIX</text>
-
-            <!-- Quad 1: Taste Lint -->
-            <g id="auditQuad1" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 1: ui taste-lint" style="cursor: pointer;">
-              <rect x="60" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <rect x="60" y="80" width="310" height="44" rx="16" fill="var(--text-primary)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.08em">SURFACE 01 • TASTE LINT [FOCAL]</text>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui taste-lint</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">6-Axis Aesthetic Rubric Floor</text>
-              <line x1="84" y1="205" x2="346" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét tĩnh HTML/CSS không cần render</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• 14 Luật cấm (Anti-Patterns)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kiểm tra Tracking &amp; Bo góc token</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tốc độ: &lt; 20ms thực thi</text>
-
-              <rect x="84" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="1.5"/>
-              <text x="215" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EXIT: Floor Score &ge; 8.0</text>
-            </g>
-
-            <!-- Quad 2: Validate Layout -->
-            <g id="auditQuad2" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 2: ui validate-layout" style="cursor: pointer;">
-              <rect x="400" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="400" y="80" width="310" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="424" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 02 • LAYOUT</text>
-
-              <text x="424" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui validate-layout</text>
-              <text x="424" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Container Soup &amp; Overflow</text>
-              <line x1="424" y1="205" x2="686" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="424" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bắt container lồng nhau &gt; 2 cấp</text>
-              <text x="424" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét tràn nội dung trục ngang</text>
-              <text x="424" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Phát hiện đứt gãy Grid / Flexbox</text>
-              <text x="424" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khắc phục tự động qua autofix</text>
-
-              <rect x="424" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="555" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">CHECK: Nesting &le; 2 Levels</text>
-            </g>
-
-            <!-- Quad 3: A11y Lint -->
-            <g id="auditQuad3" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 3: ui a11y-lint" style="cursor: pointer;">
-              <rect x="740" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="740" y="80" width="310" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="764" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 03 • ACCESSIBILITY</text>
-
-              <text x="764" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui a11y-lint</text>
-              <text x="764" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Tier-1 Static Accessibility Floor</text>
-              <line x1="764" y1="205" x2="1026" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="764" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tương phản WCAG 2.2 AA (4.5:1)</text>
-              <text x="764" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bắt buộc role, title, aria-labels</text>
-              <text x="764" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kiểm tra thứ tự Focus bàn phím</text>
-              <text x="764" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cấm thẻ img thiếu alt, button rỗng</text>
-
-              <rect x="764" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="895" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">LEVEL: WCAG 2.2 AA Static</text>
-            </g>
-
-            <!-- Quad 4: Full Audit -->
-            <g id="auditQuad4" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 4: design-os audit" style="cursor: pointer;">
-              <rect x="1080" y="80" width="300" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1080" y="80" width="300" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1104" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 04 • FULL SUITE</text>
-
-              <text x="1104" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">design-os audit</text>
-              <text x="1104" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">10-Tool Release Suite &amp; VR</text>
-              <line x1="1104" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1104" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kết hợp 10 công cụ kiểm định toàn diện</text>
-              <text x="1104" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét Visual Regression 3 Viewports</text>
-              <text x="1104" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đồng bộ Dark/Light Paired Tokens</text>
-              <text x="1104" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Điều kiện tiên quyết để tạo PR merge</text>
-
-              <rect x="1104" y="350" width="252" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1230" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">GATE: 0 Errors Required</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-12">
-              <span class="readout-badge">SURFACES: 4 REGISTERED</span>
-              <span class="readout-text" id="readout-text-slide-12">Click any of the 4 quadrants to inspect its exact CLI command, verification scope, and execution order.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0</div>
+              <div class="radiant-hero-label">Errors Allowed to Ship</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • The 4 Audit Surfaces</div><div>12 / 28</div></footer>
-        <div data-speaker-notes="Ma trận 2x2 giúp phân biệt rõ 4 loại lệnh audit để không bao giờ chạy nhầm đối tượng quét."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>12 / 28</div>
+        </footer>
+        <div data-speaker-notes="Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."></div>
       </article>
 
 <article class="slide-item" id="slide-13" data-index="13">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Finding Triage</span></div>
-          <div>Hồi 3 • 12 • Triage &amp; Core Rules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Triage Protocol</span>
+          </div>
+          <div>13 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Xử Lý Lỗi</span>
-            <h2 class="slide-title-h1 gsap-reveal">Finding Triage Workflow &amp; 2 Golden Rules</h2>
-            <p class="slide-subtitle gsap-reveal">Đọc kết quả linter một cách khoa học để đưa ra quyết định Iterate hay Escalate.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚖</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <div class="stat-label">Quy Trình Triage 3 Bước</div>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 16px;">
-                <li><strong>1. Luôn đọc cờ --json:</strong> Exit code <code>1</code> có thể do gọi sai flag (<code>BAD_ARG</code>) hoặc lỗi thiết kế thực sự. Xem envelope trước khi sửa code.</li>
-                <li><strong>2. Exit 0:</strong> Không có lỗi severity error → Sẵn sàng phát hành (Ship).</li>
-                <li><strong>3. Exit 1:</strong> Có lỗi nghiêm trọng → Chọn <strong>Iterate</strong> (sửa code và quét lại) hoặc <strong>Escalate</strong> (báo cáo mâu thuẫn yêu cầu).</li>
-              </ul>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Turns</div>
+              <div class="orb-label-main">Max Iteration Loop</div>
             </div>
 
-            <div style="display: flex; flex-direction: column; gap: 24px;">
-              <div class="slide-card gsap-card">
-                <span class="matrix-badge">NGUYÊN TẮC VÀNG 1</span>
-                <div class="stat-label" style="margin-top: 8px;">Xác Minh Trước Khi Sửa (Verify Before Fix)</div>
-                <p class="stat-desc">Kiểm tra xem cặp màu hoặc class bị linter bắt lỗi có thực sự được render trên màn hình không trước khi vội vàng sửa đổi file token gốc.</p>
-              </div>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Verify</div>
+              <div class="orb-label-secondary">Confirm Real Bug</div>
+            </div>
 
-              <div class="slide-card gsap-card">
-                <span class="matrix-badge">NGUYÊN TẮC VÀNG 2</span>
-                <div class="stat-label" style="margin-top: 8px;">A11y Luôn Thắng Phong Cách (A11y Always Wins)</div>
-                <p class="stat-desc">Nếu màu sắc từ yêu cầu của người dùng vi phạm độ tương phản WCAG AA, bắt buộc phải ưu tiên sửa màu A11y và báo cáo minh bạch cho người dùng.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Guess</div>
+              <div class="orb-label-tertiary">Evidence Grounded</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">TRIAGE &<br>AUTODETECT</h1>
+              <p class="radiant-body-text">Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">≤ 3</div>
+              <div class="radiant-hero-label">Turns to Convergence</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 90%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • Finding Triage</div><div>13 / 28</div></footer>
-        <div data-speaker-notes="A11y luôn là tiêu chuẩn cứng không thể thỏa hiệp trong DESIGN:OS."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>13 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."></div>
       </article>
 
 <article class="slide-item" id="slide-14" data-index="14">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Design Memory</span></div>
-          <div>Hồi 4 • 13 • Recall &amp; Reflect Loop</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Vector Memory</span>
+          </div>
+          <div>14 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bộ Nhớ Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">Design Memory Loop (Recall &amp; Reflect)</h2>
-            <p class="slide-subtitle gsap-reveal">DESIGN:OS ghi nhớ mọi kinh nghiệm thành công và bài học thất bại để AI ngày càng hoàn thiện sau mỗi phiên làm việc.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🧠</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">0.85</div>
+              <div class="orb-label-main">Cosine Similarity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">ONNX</div>
+              <div class="orb-label-secondary">Local Vector Space</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">On-Device Privacy</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableMemTitle fableMemDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="memReflect"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableMemTitle">Design Vector Memory: The Recall &amp; Reflection Distillation Loop</title>
-            <desc id="fableMemDesc">Vector manifold diagram showing the three phases of continuous design learning.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VECTOR<br>MEMORY LOOP</h1>
+              <p class="radiant-body-text">Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE RESONANT VECTOR MANIFOLD • PERSISTENT DISTILLATION LOOP</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- STEP 1: RECALL -->
-            <g id="memRecall" class="interactive-node" tabindex="0" role="button" aria-label="Step 1: Vector Recall Manifold" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">STEP 01 • VECTOR RECALL</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Recall Embedding Query</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Local ONNX Latent Space</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét Brief qua mô hình Vector ONNX cục bộ</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đo độ tương đồng Cosine (Cosine Similarity &ge; 0.85)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Truy hồi 2 bài học kinh nghiệm sát nhất</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Nạp trực tiếp vào ngữ cảnh Host AI Agent</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">LATENT: Cosine Match &ge; 0.85</text>
-            </g>
-
-            <!-- STEP 2: WORK EXECUTION -->
-            <g id="memWork" class="interactive-node" tabindex="0" role="button" aria-label="Step 2: Primed Work Execution" style="cursor: pointer;">
-              <rect x="520" y="80" width="400" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="520" y="80" width="400" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="544" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">STEP 02 • WORK EXECUTION</text>
-              <circle cx="890" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Primed Synthesis</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Grounded Generation Pass</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Sinh mã giao diện với bối cảnh đã tôi luyện</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tuyệt đối không lặp lại lỗi thiết kế cũ</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Áp dụng Persona và Token chuẩn xác</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tiết kiệm hàng triệu token context window</text>
-
-              <rect x="544" y="350" width="352" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="720" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EXECUTION: Zero Regression</text>
-            </g>
-
-            <!-- STEP 3: REFLECT -->
-            <g id="memReflect" class="interactive-node" tabindex="0" role="button" aria-label="Step 3: Reflection &amp; Distillation" style="cursor: pointer;">
-              <rect x="1000" y="70" width="380" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1000" y="70" width="380" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="1190" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">STEP 03 • REFLECT &amp; DISTILL [FOCAL]</text>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Crucible Distillation</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">.design/memory.json Repository</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đúc kết bài học sau mỗi lượt giao diện thành công</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đóng băng kinh nghiệm thành JSON có cấu trúc</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cập nhật kho tri thức vĩnh cửu .design/memory.json</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khép kín chu trình tự học vô hạn của Agent</text>
-
-              <rect x="1024" y="350" width="332" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1190" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">STORAGE: .design/memory.json</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-14">
-              <span class="readout-badge">VECTOR MEMORY: ONNX READY</span>
-              <span class="readout-text" id="readout-text-slide-14">Click steps to test Recall query embedding, execution context priming, and post-task lesson distillation.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0.85</div>
+              <div class="radiant-hero-label">Recall Cosine Threshold</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Memory • Living Learning Loop</div><div>14 / 28</div></footer>
-        <div data-speaker-notes="Vòng lặp bộ nhớ đảm bảo AI không bao giờ lặp lại sai lầm trong quá khứ."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>14 / 28</div>
+        </footer>
+        <div data-speaker-notes="Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."></div>
       </article>
 
 <article class="slide-item" id="slide-15" data-index="15">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Taste Voting</span></div>
-          <div>Hồi 4 • 14 • Elo Rating &amp; Corpus Curation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Crucible</span>
+          </div>
+          <div>15 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tiến Hóa Thẩm Mỹ</span>
-            <h2 class="slide-title-h1 gsap-reveal">Taste Elo Rating &amp; Sample Curation</h2>
-            <p class="slide-subtitle gsap-reveal">Cơ chế đấu cặp Blind A/B Comparison chấm điểm Elo giúp hệ thống tự động lọc ra các biến thể thiết kế xuất sắc nhất.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🧪</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Hooks</div>
+              <div class="orb-label-main">Capture Triggers</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 File</div>
+              <div class="orb-label-secondary">.design/memory.json</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Dups</div>
+              <div class="orb-label-tertiary">Deduplicated Lessons</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. BLIND A/B PAIRING</span>
-              <div class="stat-label" style="margin-top: 8px;">Đấu Cặp Ẩn Danh</div>
-              <p class="stat-desc" style="margin-top: 10px;">Hệ thống bốc ngẫu nhiên 2 biến thể ứng cử viên (Candidate A vs B) được sinh cùng một đề bài.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui taste next --domain landing</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">CRUCIBLE<br>DISTILLATION</h1>
+              <p class="radiant-body-text">Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. TASTE VOTING</span>
-              <div class="stat-label" style="margin-top: 8px;">Ghi Nhận Phán Quyết</div>
-              <p class="stat-desc" style="margin-top: 10px;">Designer hoặc Curator bình chọn biến thể chiến thắng dựa trên 6+1 trục thẩm mỹ.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui taste record --winner a</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. CORPUS ADMISSION</span>
-              <div class="stat-label" style="margin-top: 8px;">Nạp Kho Mẫu Vàng</div>
-              <p class="stat-desc" style="margin-top: 10px;">Các biến thể đạt Elo rating &gt; 1200 được tự động nạp vào corpus mẫu để huấn luyện và nạp prior cho AI.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui corpus promote --id cand-09</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Local Privacy Capture</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Taste Evolution • Elo Rating Matrix</div><div>15 / 28</div></footer>
-        <div data-speaker-notes="Hệ thống Elo định lượng hóa gu thẩm mỹ, giúp kho mẫu thiết kế ngày càng tinh hoa."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>15 / 28</div>
+        </footer>
+        <div data-speaker-notes="Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."></div>
       </article>
 
 <article class="slide-item" id="slide-16" data-index="16">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Color Science</span></div>
-          <div>Hồi 5 • 15 • OKLCH &amp; Perceptual Uniformity</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Color Science</span>
+          </div>
+          <div>16 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Khoa Học Màu Sắc</span>
-            <h2 class="slide-title-h1 gsap-reveal">OKLCH Mathematics, P3 Gamut &amp; Delta EOK</h2>
-            <p class="slide-subtitle gsap-reveal">Why DESIGN:OS deprecates legacy HSL/Hex in favor of the perceptually uniform OKLCH color space.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌈</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">360°</div>
+              <div class="orb-label-main">Perceptual Uniformity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">P3</div>
+              <div class="orb-label-secondary">Wide Color Gamut</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≤ 0.02</div>
+              <div class="orb-label-tertiary">Patch Semver Limit</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableColorTitle fableColorDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="colorOKLCH"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableColorTitle">Color Science: OKLCH &amp; Display P3 Perceptual Uniformity</title>
-            <desc id="fableColorDesc">Color gamut architecture diagram illustrating legacy HSL non-linear brightness distortion, uniform OKLCH perceived lightness across all 360-degree hues, and mathematical Semver breaking changes via Delta EOK calipers.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">OKLCH COLOR<br>SCIENCE</h1>
+              <p class="radiant-body-text">Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE POLARIZED OPTICAL CHAMBER • OKLCH COLOR SCIENCE &amp; DELTA E PRECISION</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- CHAMBER 1: HSL -->
-            <g id="colorHSL" class="interactive-node" tabindex="0" role="button" aria-label="Legacy HSL Flaw" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-muted)" letter-spacing="0.08em">LEGACY COLOR • HSL / sRGB</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-muted)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">HSL Perceptual Flaw</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Non-Linear Human Optical Perception</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Vàng L=50% sáng gấp 3 lần Xanh L=50%</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đổi tông màu (Hue) làm vỡ độ tương phản</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chỉ bao phủ không gian màu hẹp sRGB</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Ảo giác toán học không đáng tin cậy</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-muted)" text-anchor="middle">FLAW: Inconsistent Luminance</text>
-            </g>
-
-            <!-- CHAMBER 2: OKLCH -->
-            <g id="colorOKLCH" class="interactive-node" tabindex="0" role="button" aria-label="OKLCH Color Science" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">OKLCH SCIENCE • DISPLAY P3 [FOCAL]</text>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">OKLCH Uniformity</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Perceptually Constant Lightness L</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ sáng cảm nhận L=0.7 đồng đều mọi góc Hue</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động bảo đảm chuẩn tương phản WCAG 2.2</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khai thác 100% dải màu siêu rộng Display P3</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tích hợp trực tiếp lệnh CLI: ui color scale</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">STANDARD: 100% P3 Color Gamut</text>
-            </g>
-
-            <!-- CHAMBER 3: SEMVER DELTA -->
-            <g id="colorDelta" class="interactive-node" tabindex="0" role="button" aria-label="Delta EOK Semver Precision" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SEMVER DELTA • ΔEOK</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ΔEOK Precision Meter</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Mathematical Semver Versioning</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ΔEOK &gt; 0.05: Thay đổi lớn (MAJOR Breaking)</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• 0.02 &lt; ΔEOK &le; 0.05: Bổ sung (MINOR Additive)</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ΔEOK &le; 0.02: Vi chỉnh không lệch mắt (PATCH)</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đánh giá khách quan, loại bỏ tranh cãi cảm tính</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">CALIPER: Precise Semver Gate</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-16">
-              <span class="readout-badge">COLOR MATH: OKLCH / P3</span>
-              <span class="readout-text" id="readout-text-slide-16">Inspect why OKLCH delivers uniform perceptual lightness L across all hues and how ΔEOK enforces Semver breaking color changes.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">ΔE 0.02</div>
+              <div class="radiant-hero-label">Semver Patch Precision</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Color Science • OKLCH Space &amp; Delta EOK</div><div>16 / 28</div></footer>
-        <div data-speaker-notes="OKLCH Color Mathematics bảo đảm mọi thang bậc sáng đều có cùng độ tương phản mắt thấy."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>16 / 28</div>
+        </footer>
+        <div data-speaker-notes="Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."></div>
       </article>
 
 <article class="slide-item" id="slide-17" data-index="17">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Taste Rubric</span></div>
-          <div>Hồi 5 • 16 • 6+1 Craft Axes</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Taste Rubric</span>
+          </div>
+          <div>17 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tiêu Chuẩn Thẩm Mỹ</span>
-            <h2 class="slide-title-h1 gsap-reveal">6+1 Aesthetic Axes (Taste Rubric)</h2>
-            <p class="slide-subtitle gsap-reveal">Scoring every axis from 0 to 10. AI synthesizes layouts against these principles, and Curator enforces compliance.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎯</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6+1</div>
+              <div class="orb-label-main">Heptagonal Axes</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">Core 0</div>
+              <div class="orb-label-secondary">Consistency Mandate</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≥ 8.0</div>
+              <div class="orb-label-tertiary">Release Quality Floor</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableTasteTitle fableTasteDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="tasteCore7"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableTasteTitle">The 6+1 Taste Rubric Craft Radar Matrix</title>
-            <desc id="fableTasteDesc">Heptagonal craft resonator radar diagram evaluating generated UI against Consistency Core 7 and the 6 aesthetic axes.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">6+1 TASTE<br>RUBRIC RADAR</h1>
+              <p class="radiant-body-text">Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE HEPTAGONAL CRAFT RESONATOR • 6+1 TASTE RUBRIC FLOOR (ui taste-lint)</text>
-
-            <circle cx="720" cy="260" r="160" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-            <circle cx="720" cy="260" r="110" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-            <circle cx="720" cy="260" r="60" fill="none" stroke="var(--border-strong)" stroke-width="1.5"/>
-
-            <line x1="720" y1="260" x2="720" y2="80" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="880" y2="170" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="880" y2="350" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="720" y2="440" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="560" y2="350" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="560" y2="170" stroke="var(--border-strong)" stroke-width="1.5"/>
-
-            <!-- CENTER CORE -->
-            <g id="tasteCore7" class="interactive-node" tabindex="0" role="button" aria-label="Core Axis: Consistency" style="cursor: pointer;">
-              <circle cx="720" cy="260" r="54" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <circle cx="720" cy="260" r="46" fill="var(--text-primary)"/>
-              <text x="720" y="254" font-family="var(--font-mono)" font-size="11" font-weight="900" fill="var(--text-inverse)" text-anchor="middle">CORE 0</text>
-              <text x="720" y="272" font-family="var(--font-sans)" font-size="12" font-weight="800" fill="var(--text-inverse)" text-anchor="middle">Consistency</text>
-            </g>
-
-            <!-- AXES -->
-            <g id="tasteAxis1" class="interactive-node" tabindex="0" role="button" aria-label="Axis 1: Layout &amp; Hierarchy" style="cursor: pointer;">
-              <rect x="620" y="70" width="200" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="720" y="96" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">01 • LAYOUT &amp; HIERARCHY</text>
-              <text x="720" y="118" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Reading Order (Score: 9.0)</text>
-            </g>
-
-            <g id="tasteAxis2" class="interactive-node" tabindex="0" role="button" aria-label="Axis 2: Typography &amp; Rhythm" style="cursor: pointer;">
-              <rect x="910" y="140" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="1015" y="166" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">02 • TYPOGRAPHY</text>
-              <text x="1015" y="188" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Modular Scale (Score: 8.8)</text>
-            </g>
-
-            <g id="tasteAxis3" class="interactive-node" tabindex="0" role="button" aria-label="Axis 3: Spacing &amp; Geometry" style="cursor: pointer;">
-              <rect x="910" y="320" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="1015" y="346" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">03 • SPACING</text>
-              <text x="1015" y="368" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">8px Rhythm (Score: 9.2)</text>
-            </g>
-
-            <g id="tasteAxis4" class="interactive-node" tabindex="0" role="button" aria-label="Axis 4: Iconography &amp; Badges" style="cursor: pointer;">
-              <rect x="620" y="410" width="200" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="720" y="436" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">04 • ICONOGRAPHY</text>
-              <text x="720" y="458" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Single Family (Score: 9.5)</text>
-            </g>
-
-            <g id="tasteAxis5" class="interactive-node" tabindex="0" role="button" aria-label="Axis 5: Motion Ladder" style="cursor: pointer;">
-              <rect x="320" y="320" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="425" y="346" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">05 • MOTION LADDER</text>
-              <text x="425" y="368" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">T5 Choreography (Score: 9.0)</text>
-            </g>
-
-            <g id="tasteAxis6" class="interactive-node" tabindex="0" role="button" aria-label="Axis 6: Depth &amp; Surfaces" style="cursor: pointer;">
-              <rect x="320" y="140" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="425" y="166" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">06 • DEPTH &amp; SURFACES</text>
-              <text x="425" y="188" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Tonal Elevation (Score: 9.0)</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-17">
-              <span class="readout-badge">RADAR SCAN: 6+1 AXES</span>
-              <span class="readout-text" id="readout-text-slide-17">Click axes or press Scan to inspect individual craft score thresholds (Consistency 10/10, Layout & Typo >= 8.0).</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">8.0 +</div>
+              <div class="radiant-hero-label">Minimum Score to Ship</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 80%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Quality Floor • The 6+1 Taste Rubric</div><div>17 / 28</div></footer>
-        <div data-speaker-notes="Mô hình 6+1 trục thẩm mỹ: Consistency là lõi bất biến, 6 trục vệ tinh định hình vẻ đẹp thị giác."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>17 / 28</div>
+        </footer>
+        <div data-speaker-notes="A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."></div>
       </article>
 
 <article class="slide-item" id="slide-18" data-index="18">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Machine Floor</span></div>
-          <div>Hồi 5 • 17 • 14 Hard Linter Rules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • UX Laws</span>
+          </div>
+          <div>18 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Sàn Chất Lượng Tất Định</span>
-            <h2 class="slide-title-h1 gsap-reveal">14 Hard Machine Floor Linters</h2>
-            <p class="slide-subtitle gsap-reveal">Các linter <code>taste-lint</code>, <code>validate-layout</code>, <code>content-lint</code> tự động phát hiện và chặn đứng các lỗi AI code rác.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📐</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">CHUYỂN ĐỘNG &amp; LAYOUT SAFETY</span>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 14px;">
-                <li><code>no-transition-all</code>: Cấm dùng transition: all gây drop FPS.</li>
-                <li><code>no-layout-keyframes</code>: Cấm animate top, left, width, height.</li>
-                <li><code>require-reduced-motion</code>: Bắt buộc có media query giảm chuyển động.</li>
-                <li><code>no-100vw-scroll</code>: Cấm w-[100vw] gây thanh cuộn ngang khó chịu.</li>
-                <li><code>no-root-overflow-hidden</code>: Cấm overflow-x: hidden ở thẻ html/body làm liệt sticky.</li>
-              </ul>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">12 Laws</div>
+              <div class="orb-label-main">Cognitive Standards</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">TYPOGRAPHY &amp; NỘI DUNG UX</span>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 14px;">
-                <li><code>min-body-font</code>: Cấm font chữ body nhỏ hơn 16px.</li>
-                <li><code>no-font-scale-sprawl</code>: Cảnh báo &gt; 7 cỡ font tự chế, chặn khi &gt; 10 cỡ.</li>
-                <li><code>no-italic-headings</code>: Cấm tiêu đề display dùng font chữ nghiêng.</li>
-                <li><code>no-pure-black-shadow</code>: Cấm bóng đổ đen tuyệt đối rgba(0,0,0,...).</li>
-                <li><code>no-placeholder-copy</code>: Cấm văn bản rác vô nghĩa, tên giả vô định, link rỗng.</li>
-              </ul>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">≥ 44px</div>
+              <div class="orb-label-secondary">Fitts Law Tap Target</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">7 ± 2</div>
+              <div class="orb-label-tertiary">Miller Chunking Limit</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">12 COGNITIVE<br>UX LAWS</h1>
+              <p class="radiant-body-text">Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">12</div>
+              <div class="radiant-hero-label">Enforced Ergonomic Laws</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Quality Floor • 14 Machine Rules</div><div>18 / 28</div></footer>
-        <div data-speaker-notes="14 luật máy là sàn an toàn tuyệt đối, ngăn chặn hoàn toàn code rác từ LLM."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>18 / 28</div>
+        </footer>
+        <div data-speaker-notes="UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."></div>
       </article>
 
 <article class="slide-item" id="slide-19" data-index="19">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>UX Psychology</span></div>
-          <div>Hồi 5 • 18 • 12 Cognitive Laws</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Personas</span>
+          </div>
+          <div>19 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tâm Lý Học Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">12 Classical Cognitive UX Laws</h2>
-            <p class="slide-subtitle gsap-reveal">Giao diện đẹp phải đi đôi với sự thuận tự nhiên của não bộ. DESIGN:OS tích hợp trực tiếp các định luật nhận thức.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎭</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">11 Personas</div>
+              <div class="orb-label-main">Curated Families</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">5 Slugs</div>
+              <div class="orb-label-secondary">Contrasting Stances</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Cliché</div>
+              <div class="orb-label-tertiary">Banned Tropes</div>
+            </div>
           </div>
 
-          <div class="slide-grid-4">
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">FITTS'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Mục Tiêu &amp; Khoảng Cách</div>
-              <p class="stat-desc" style="font-size: 14px;">Touch target tối thiểu 44px; nút CTA chính đặt ở vị trí ngón tay chạm nhanh nhất.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DESIGN<br>PERSONAS</h1>
+              <p class="radiant-body-text">11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.</p>
             </div>
 
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">HICK'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Thời Gian Ra Quyết Định</div>
-              <p class="stat-desc" style="font-size: 14px;">Giảm bớt tùy chọn để tăng tốc độ chọn lựa; gom nhóm hành vi theo từng cấp bậc.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">MILLER'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Giới Hạn 7±2 Khối Nhớ</div>
-              <p class="stat-desc" style="font-size: 14px;">Phân đoạn thông tin thành các cụm (chunking) từ 5 đến 9 phần tử trong một tầm nhìn.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">DOHERTY THRESHOLD</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Ngưỡng Phản Hồi 400ms</div>
-              <p class="stat-desc" style="font-size: 14px;">Mọi tương tác click/hover phải phản hồi thị giác trong vòng dưới 400ms để giữ sự tập trung.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">ZEIGARNIK EFFECT</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Thanh Tiến Trình Dang Dở</div>
-              <p class="stat-desc" style="font-size: 14px;">Bộ não luôn bị thôi thúc hoàn thành các tác vụ dở dang; áp dụng cho onboarding steps.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">JAKOB'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Kỳ Vọng Thói Quen Cũ</div>
-              <p class="stat-desc" style="font-size: 14px;">Người dùng dành phần lớn thời gian trên web khác; giữ nguyên các quy ước điều hướng quen thuộc.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">VON RESTORFF</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Hiệu Ứng Nổi Bật Độc Bản</div>
-              <p class="stat-desc" style="font-size: 14px;">Phần tử có hình dáng khác biệt nhất (như thẻ Pricing Recommended) sẽ được ghi nhớ sâu nhất.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">SERIAL POSITION</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Hiệu Ứng Đầu &amp; Cuối</div>
-              <p class="stat-desc" style="font-size: 14px;">Người dùng nhớ nhất mục đầu tiên và mục cuối cùng của thanh menu hay danh sách tính năng.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">11</div>
+              <div class="radiant-hero-label">Bespoke Design Personas</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 90%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS UX Psychology • Cognitive Design Laws</div><div>19 / 28</div></footer>
-        <div data-speaker-notes="12 định luật UX định hình cách tổ chức giao diện thuận theo tự nhiên của nhận thức con người."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>19 / 28</div>
+        </footer>
+        <div data-speaker-notes="Explicit persona declarations prevent generic corporate dashboard syndrome."></div>
       </article>
 
 <article class="slide-item" id="slide-20" data-index="20">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Motion Ladder</span></div>
-          <div>Hồi 6 • 19 • The 6 Motion Tiers</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Motion Ladder</span>
+          </div>
+          <div>20 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">The Motion Ladder</span>
-            <h2 class="slide-title-h1 gsap-reveal">6-Tier Motion Ladder (T1–T6)</h2>
-            <p class="slide-subtitle gsap-reveal">Chỉ nâng lên bậc chuyển động cao hơn khi câu chuyện thiết kế thực sự đòi hỏi và ngân sách hiệu năng cho phép.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Tiers</div>
+              <div class="orb-label-main">T1 to T6 Standards</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">60 FPS</div>
+              <div class="orb-label-secondary">Frame Budget</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">Reduced Motion Safe</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T1 • MICRO-FEEDBACK</span>
-              <div class="stat-label" style="margin-top: 8px;">Hover &amp; Active States</div>
-              <p class="stat-desc">CSS transition 150-200ms trên <code>transform</code> và <code>opacity</code>. Phản hồi bấm nút, hover thẻ. Zero bundle cost.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">THE MOTION<br>LADDER</h1>
+              <p class="radiant-body-text">Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T2 • STATE TRANSITION</span>
-              <div class="stat-label" style="margin-top: 8px;">Chuyển Đổi Trạng Thái</div>
-              <p class="stat-desc">Mở Modal, bung Accordion, hoán đổi Tabs. Sử dụng CSS transitions kết hợp ARIA expanded.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T3 • ENTRANCE REVEAL</span>
-              <div class="stat-label" style="margin-top: 8px;">Scroll-Driven CSS</div>
-              <p class="stat-desc">Hiệu ứng xuất hiện khi cuộn trang bằng native CSS <code>animation-timeline: view()</code>. Không tốn Javascript.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T4 • LAYOUT CHOREO</span>
-              <div class="stat-label" style="margin-top: 8px;">FLIP Layout Animation</div>
-              <p class="stat-desc">Tái sắp xếp lưới sản phẩm, mở rộng thẻ chi tiết bằng kỹ thuật FLIP không gây giật khung hình.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T5 • GSAP SCROLLTRIGGER</span>
-              <div class="stat-label" style="margin-top: 8px;">Biên Đạo Thời Gian</div>
-              <p class="stat-desc">Ghim khung hình (Pinning), scrub tiến trình cuộn, phối hợp timeline đa tầng phức tạp cho landing page.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T6 • AUTHORING &amp; 3D</span>
-              <div class="stat-label" style="margin-top: 8px;">Scroll-Cinema &amp; WebGL</div>
-              <p class="stat-desc">Cuộn phim 3D không gian, WebGL shaders, camera flight đa phân đoạn qua GFlow hand.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">60 FPS</div>
+              <div class="radiant-hero-label">Locked Kinetic Budget</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Motion Ladder • Tiered Kinetic Standards</div><div>20 / 28</div></footer>
-        <div data-speaker-notes="Thang bậc chuyển động giúp kiểm soát hiệu năng: chỉ leo lên T6 khi thực sự cần trải nghiệm điện ảnh."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>20 / 28</div>
+        </footer>
+        <div data-speaker-notes="Animations must serve narrative purpose. Decorative motion without function is classified as code debt."></div>
       </article>
 
 <article class="slide-item" id="slide-21" data-index="21">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Scroll-Cinema</span></div>
-          <div>Hồi 6 • 20 • Seam Physics &amp; Continuous Take</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Scroll Cinema</span>
+          </div>
+          <div>21 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Điện Ảnh Cuộn Trang</span>
-            <h2 class="slide-title-h1 gsap-reveal">Scroll-Cinema: The Art of Seamless Camera Flight</h2>
-            <p class="slide-subtitle gsap-reveal">Chaining separately rendered video clips into a single continuous take driven directly by scroll gestures.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎬</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Legs</div>
+              <div class="orb-label-main">Camera Waypoints</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">2 Seams</div>
+              <div class="orb-label-secondary">Kinetic Joint Locks</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Stutter</div>
+              <div class="orb-label-tertiary">Zero Rewind Match</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableCinemaTitle fableCinemaDesc"
-            data-diagram-grammar="sequence"
-            data-reading-order="ltr"
-            data-focal-id="cinemaLeg2"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableCinemaTitle">Scroll-Cinema: The 3-Leg Continuous Camera Flight with Kinetic Seam Physics</title>
-            <desc id="fableCinemaDesc">Continuous camera flight sequence diagram showing Leg 1 Hero Orbit, Leg 2 Exploded View, and Leg 3 Macro Core connected via frame-locked velocity seams guaranteeing zero-rewind stutter.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">SCROLL-CINEMA<br>FLIGHT</h1>
+              <p class="radiant-body-text">Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE CONTINUOUS FLIGHT PATH • ZERO-REWIND SCROLL-CINEMA SEAM PHYSICS</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="8 6" />
-
-            <rect x="440" y="210" width="80" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="480" y="225" font-family="var(--font-mono)" font-size="9" font-weight="800" fill="var(--text-primary)" text-anchor="middle">SEAM 1: LOCK</text>
-
-            <rect x="920" y="210" width="80" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="960" y="225" font-family="var(--font-mono)" font-size="9" font-weight="800" fill="var(--text-primary)" text-anchor="middle">SEAM 2: LOCK</text>
-
-            <!-- LEG 1 -->
-            <g id="cinemaLeg1" class="interactive-node" tabindex="0" role="button" aria-label="Leg 1: Hero Orbit" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">LEG 01 • SPATIAL ORBIT</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Hero Spatial Orbit</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">360&deg; Camera Spatial Path</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Camera quay quanh vật thể 3D sản phẩm</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tốc độ cuộn Scrub đồng bộ 60fps mượt mà</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tọa độ đích: Khóa vị trí Seam 1 (Delta = 0)</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kết thúc tại góc nhìn trực diện chuẩn bị nổ</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PHYSICS: 60 FPS Interpolation</text>
-            </g>
-
-            <!-- LEG 2 (FOCAL) -->
-            <g id="cinemaLeg2" class="interactive-node" tabindex="0" role="button" aria-label="Leg 2: Exploded View" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">LEG 02 • EXPLODED VIEW [FOCAL]</text>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Exploded Z-Disassembly</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Internal Component Separation</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tách lớp linh kiện dọc theo trục sâu Z-axis</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Seam 1 &rarr; Seam 2: Vận tốc vector khớp 100%</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu hoàn toàn hiện tượng giật cục (Stutter)</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cảm giác cinematic điện ảnh đẳng cấp cao</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">SEAM QUALITY: Zero-Rewind Lock</text>
-            </g>
-
-            <!-- LEG 3 -->
-            <g id="cinemaLeg3" class="interactive-node" tabindex="0" role="button" aria-label="Leg 3: Macro 2K Core" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">LEG 03 • MACRO 2K ZOOM</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Macro Core 2K Flight</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Sub-Pixel Micro-Texture Dive</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Camera lao sâu vào bề mặt vi cấu trúc chip</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Hiển thị vân kim loại và chi tiết máy cực nét</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đáp an toàn xuống vị trí CTA chuyển đổi</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động dừng mượt mà khi người dùng ngừng cuộn</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">RESOLUTION: 2K Sub-Pixel Flight</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-21">
-              <span class="readout-badge">SEAM PHYSICS: VERIFIED</span>
-              <span class="readout-text" id="readout-text-slide-21">Test 3-leg continuous camera flight: Seam 1 (Position match) and Seam 2 (Velocity vector lock) zero-rewind guarantee.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0 ms</div>
+              <div class="radiant-hero-label">Seam Handoff Stutter</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Scroll-Cinema • The Seam Physics Contract</div><div>21 / 28</div></footer>
-        <div data-speaker-notes="Mối nối (Seam) là sản phẩm: đảm bảo tính liên tục về vị trí và vận tốc để người xem cảm nhận như 1 cú máy one-take duy nhất."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>21 / 28</div>
+        </footer>
+        <div data-speaker-notes="Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."></div>
       </article>
 
 <article class="slide-item" id="slide-22" data-index="22">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>GFlow Hand</span></div>
-          <div>Hồi 6 • 21 • Google Flow Automation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • 3D GFlow</span>
+          </div>
+          <div>22 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tự Động Hóa Video AI</span>
-            <h2 class="slide-title-h1 gsap-reveal">GFlow Hand: Google Flow Automation (Veo / Imagen)</h2>
-            <p class="slide-subtitle gsap-reveal">Điều khiển Google Flow qua Playwright với cơ chế an toàn <strong>Verify-then-Spend</strong> bảo vệ số dư tài khoản.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌐</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 Canvas</div>
+              <div class="orb-label-main">Hardware Accelerated</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">2K Texture</div>
+              <div class="orb-label-secondary">Subpixel Detail</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Memory</div>
+              <div class="orb-label-tertiary">Lifecycle Teardown</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. THE GOLDEN PATH</span>
-              <div class="stat-label" style="margin-top: 8px;">ui gflow i2v</div>
-              <p class="stat-desc" style="margin-top: 10px;">Lệnh an toàn duy nhất: sinh video từ ảnh, kiểm tra tải file MP4 thật, tự trích xuất last frame qua ffmpeg.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui gflow i2v "flight..." --initial-frame seed.png</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">3D SPATIAL<br>GFLOW</h1>
+              <p class="radiant-body-text">Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. VERIFY-THEN-SPEND</span>
-              <div class="stat-label" style="margin-top: 8px;">Chống Rơi Render</div>
-              <p class="stat-desc" style="margin-top: 10px;">Không bao giờ gọi lệnh <code>chain</code> mù quáng. Mỗi phân đoạn phải tải về thành công trước khi sinh đoạn tiếp theo.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>DOWNLOAD_MISSING → Recovery Plan</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. WEBP CONVERSION</span>
-              <div class="stat-label" style="margin-top: 8px;">Trích Xuất Khung Hình</div>
-              <p class="stat-desc" style="margin-top: 10px;">Chuyển đổi MP4 thành chuỗi WebP nén chất lượng cao sẵn sàng cho Canvas Scrubbing mượt mà trên mobile.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ffmpeg -i clip.mp4 frame_%04d.webp</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">2 K</div>
+              <div class="radiant-hero-label">Subpixel Texture Resolution</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS GFlow Hand • Automated Video Pipeline</div><div>22 / 28</div></footer>
-        <div data-speaker-notes="GFlow Hand tự động hóa quy trình sinh video phức tạp bằng phương pháp verify-then-spend an toàn."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>22 / 28</div>
+        </footer>
+        <div data-speaker-notes="All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."></div>
       </article>
 
 <article class="slide-item" id="slide-23" data-index="23">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Canvas UI</span></div>
-          <div>Hồi 6 • 22 • Shaders &amp; Teardown Contract</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Visual Regression</span>
+          </div>
+          <div>23 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đồ Họa Bậc Cao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Canvas T6 &amp; WebGL Shaders: Liquid Glass &amp; Teardown Contract</h2>
-            <p class="slide-subtitle gsap-reveal">Hiệu ứng bề mặt chất liệu cao cấp nhưng tuyệt đối tuân thủ ngân sách hiệu năng 60 FPS và dọn dẹp bộ nhớ.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📸</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Screens</div>
+              <div class="orb-label-main">Desktop / Laptop / Mobile</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Drift</div>
+              <div class="orb-label-secondary">Pixel Hash Match</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">CI Headless Test</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. ONE-EFFECT CAP</span>
-              <div class="stat-label" style="margin-top: 8px;">Giới Hạn 1 Hiệu Ứng</div>
-              <p class="stat-desc" style="margin-top: 10px;">Chỉ được phép có duy nhất 1 hiệu ứng Canvas T6 trên toàn trang (ví dụ: Liquid Glass hoặc Particle Mesh).</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VISUAL<br>REGRESSION</h1>
+              <p class="radiant-body-text">Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. TEARDOWN CONTRACT</span>
-              <div class="stat-label" style="margin-top: 8px;">Hợp Đồng Dọn Dẹp</div>
-              <p class="stat-desc" style="margin-top: 10px;">Bắt buộc phải hủy <code>cancelAnimationFrame</code>, giải phóng WebGL contexts và dọn sạch Event Listeners khi unmount.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. 60 FPS PERFORMANCE FLOOR</span>
-              <div class="stat-label" style="margin-top: 8px;">Sàn Hiệu Năng 60 FPS</div>
-              <p class="stat-desc" style="margin-top: 10px;">Giới hạn kích thước render buffer theo DPR tối đa 2; tự động hạ cấp xuống ảnh tĩnh trên thiết bị yếu.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3 / 3</div>
+              <div class="radiant-hero-label">Viewports Verified</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Canvas UI • T6 Engineering Standard</div><div>23 / 28</div></footer>
-        <div data-speaker-notes="Canvas T6 chỉ được kích hoạt khi có lý do chính đáng và bắt buộc phải có teardown function để tránh rò rỉ bộ nhớ."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>23 / 28</div>
+        </footer>
+        <div data-speaker-notes="Automated headless Playwright sweeps catch subtle overflow and clipping before human review."></div>
       </article>
 
 <article class="slide-item" id="slide-24" data-index="24">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Qualified Delivery</span></div>
-          <div>Hồi 7 • 23 • Release Verification</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Taste Voting</span>
+          </div>
+          <div>24 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Qualified Delivery Contract v2</h2>
-            <p class="slide-subtitle gsap-reveal">Biến việc sinh UI thành quy trình phát hành có bằng chứng kiểm định rõ ràng (Evidence-based release).</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏆</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">100%</div>
+              <div class="orb-label-main">Compounded Taste</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">N Variants</div>
+              <div class="orb-label-secondary">Parallel Generation</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">1 Winner</div>
+              <div class="orb-label-tertiary">Highest Scoring PR</div>
+            </div>
           </div>
 
-          <div class="slide-grid-4">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 1 • BRIEF</span>
-              <div class="stat-label" style="margin-top: 10px;">design-brief.json</div>
-              <p class="stat-desc">Biến yêu cầu sơ khai thành hợp đồng nghiệp vụ: đối tượng, mục tiêu, tuyên bố bị cấm.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">COMPOUNDED<br>CRAFT REFLECTION</h1>
+              <p class="radiant-body-text">Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 2 • CONTRACT</span>
-              <div class="stat-label" style="margin-top: 10px;">generation-contract.json</div>
-              <p class="stat-desc">Khai báo 3 hướng cấu trúc, nhiệm vụ từng vùng, hình ảnh và icon Phosphor bắt buộc.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 3 • EVIDENCE</span>
-              <div class="stat-label" style="margin-top: 10px;">Renders 1440 / 768 / 390</div>
-              <p class="stat-desc">Sinh candidate và chụp ảnh render thực tế ở cả 3 kích thước Desktop, Tablet và Mobile.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 4 • VERDICT</span>
-              <div class="stat-label" style="margin-top: 10px;">QUALIFIED</div>
-              <p class="stat-desc">Curator đối chiếu bằng chứng. Đạt 100% gates → Phát hành; Thiếu sót → DRAFT_WITH_CONCERNS.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">10 X</div>
+              <div class="radiant-hero-label">Design Team Velocity</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 95%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Qualified Delivery v2</div><div>24 / 28</div></footer>
-        <div data-speaker-notes="Trạng thái QUALIFIED bắt buộc phải có bằng chứng render thực tế cả 3 viewport, không thể nói suông."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>24 / 28</div>
+        </footer>
+        <div data-speaker-notes="Compounding craft transforms single-use generations into permanent organizational capability."></div>
       </article>
 
 <article class="slide-item" id="slide-25" data-index="25">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Full-Stack Audit</span></div>
-          <div>Hồi 7 • 24 • The 6-Step Audit Pipeline</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Delivery Pipeline</span>
+          </div>
+          <div>25 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">The Mandatory 6-Step Full-Stack Audit Pipeline</h2>
-            <p class="slide-subtitle gsap-reveal">Thứ tự thực thi mang tính quyết định: chạy sai thứ tự sẽ dẫn đến kết quả kiểm định sai lệch.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🚀</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Stages</div>
+              <div class="orb-label-main">Ordered Pipeline</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Static & Rendered</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Bypass</div>
+              <div class="orb-label-tertiary">Strict CI Gates</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fablePipeTitle fablePipeDesc"
-            data-diagram-grammar="sequence"
-            data-reading-order="ltr"
-            data-focal-id="pipeStep6"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fablePipeTitle">The 6-Step Full-Stack Delivery Pipeline</title>
-            <desc id="fablePipeDesc">Sequential delivery pipeline diagram executing verification gates in exact defect-catching order.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DELIVERY<br>PIPELINE</h1>
+              <p class="radiant-body-text">The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE 6-STAGE FRACTIONAL REFINERY • ORDERED QUALITY GATES</text>
-
-            <!-- Step 1 -->
-            <g id="pipeStep1" class="interactive-node" tabindex="0" role="button" aria-label="Step 1: Flow Lint" style="cursor: pointer;">
-              <rect x="40" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="40" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="145" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 01 • FLOW</text>
-              <text x="145" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Flow Lint</text>
-              <text x="145" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui flow lint</text>
-              <line x1="56" y1="195" x2="234" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="56" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Bắt lỗi cụt (dead-end)</text>
-              <text x="56" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét unreachable</text>
-              <text x="56" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Đủ trạng thái error</text>
-              <rect x="56" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="145" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">FLOW PASS</text>
-            </g>
-
-            <!-- Step 2 -->
-            <g id="pipeStep2" class="interactive-node" tabindex="0" role="button" aria-label="Step 2: User Evidence" style="cursor: pointer;">
-              <rect x="270" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="270" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="375" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 02 • EVIDENCE</text>
-              <text x="375" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">User Evidence</text>
-              <text x="375" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui evidence</text>
-              <line x1="286" y1="195" x2="464" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="286" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Khảo sát người dùng</text>
-              <text x="286" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Dữ liệu định tính</text>
-              <text x="286" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Trọng số chuyển đổi</text>
-              <rect x="286" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="375" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EVIDENCE OK</text>
-            </g>
-
-            <!-- Step 3 -->
-            <g id="pipeStep3" class="interactive-node" tabindex="0" role="button" aria-label="Step 3: VR Baseline" style="cursor: pointer;">
-              <rect x="500" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="500" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="605" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 03 • VR GATE</text>
-              <text x="605" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">VR Baseline</text>
-              <text x="605" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui vr gate</text>
-              <line x1="516" y1="195" x2="694" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="516" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét ảnh 3 Viewports</text>
-              <text x="516" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• 1920 Desktop, Mobile</text>
-              <text x="516" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• So sánh pixel diff</text>
-              <rect x="516" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="605" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">VR MATCH 100%</text>
-            </g>
-
-            <!-- Step 4 -->
-            <g id="pipeStep4" class="interactive-node" tabindex="0" role="button" aria-label="Step 4: Paired Tokens" style="cursor: pointer;">
-              <rect x="730" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="730" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="835" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 04 • PAIRS</text>
-              <text x="835" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Paired Tokens</text>
-              <text x="835" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui paired-tokens</text>
-              <line x1="746" y1="195" x2="924" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="746" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Đối soát Dark / Light</text>
-              <text x="746" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Không lạc mất cặp màu</text>
-              <text x="746" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Giữ độ sâu quang học</text>
-              <rect x="746" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="835" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PAIRS CLEAN</text>
-            </g>
-
-            <!-- Step 5 -->
-            <g id="pipeStep5" class="interactive-node" tabindex="0" role="button" aria-label="Step 5: A11y Lint" style="cursor: pointer;">
-              <rect x="960" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="960" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="1065" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 05 • A11Y</text>
-              <text x="1065" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">A11y Lint</text>
-              <text x="1065" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui a11y-lint</text>
-              <line x1="976" y1="195" x2="1154" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="976" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét Axe Core máy cứng</text>
-              <text x="976" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Tương phản WCAG AA</text>
-              <text x="976" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Khả năng đọc màn hình</text>
-              <rect x="976" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1065" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">AXE PASS</text>
-            </g>
-
-            <!-- Step 6 -->
-            <g id="pipeStep6" class="interactive-node" tabindex="0" role="button" aria-label="Step 6: Full Audit" style="cursor: pointer;">
-              <rect x="1190" y="70" width="220" height="360" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1190" y="70" width="220" height="46" rx="16" fill="var(--text-primary)"/>
-              <text x="1300" y="98" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-inverse)" text-anchor="middle">STAGE 06 • FULL AUDIT [FOCAL]</text>
-              <text x="1300" y="155" font-family="var(--font-sans)" font-size="18" font-weight="900" fill="var(--text-primary)" text-anchor="middle">Full Audit</text>
-              <text x="1300" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">design-os audit</text>
-              <line x1="1206" y1="195" x2="1394" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="1206" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• taste-lint 6+1 trục</text>
-              <text x="1206" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• validate-layout tĩnh</text>
-              <text x="1206" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• 10 công cụ xuất xưởng</text>
-              <rect x="1206" y="350" width="188" height="44" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1300" y="378" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" text-anchor="middle">0 ERRORS &rarr; SHIP</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-25">
-              <span class="readout-badge">DELIVERY PIPELINE: 6 STEPS</span>
-              <span class="readout-text" id="readout-text-slide-25">Run simulation to watch linters execute in the exact defect-catching order: Flow -> Evidence -> VR -> Paired -> A11y -> Audit.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6 / 6</div>
+              <div class="radiant-hero-label">Pipeline Stages Passed</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Ordered 6-Step Audit</div><div>25 / 28</div></footer>
-        <div data-speaker-notes="Pipeline 6 bước bắt buộc chạy đúng thứ tự: Flow -> Evidence -> VR -> Pairs -> Rendered A11y -> Full Audit."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>25 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."></div>
       </article>
 
 <article class="slide-item" id="slide-26" data-index="26">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Release &amp; Semver</span></div>
-          <div>Hồi 7 • 25 • Checklist &amp; PR Review</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Semver Matrix</span>
+          </div>
+          <div>26 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đóng Gói Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Delivery Checklist &amp; PR Semver Matrix</h2>
-            <p class="slide-subtitle gsap-reveal">Tạo tài liệu component tự động, trang specimen độc lập và tự động tính toán mức độ breaking change cho Pull Request.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏷</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">5 LỆNH TRONG DELIVERY CHECKLIST</span>
-              <div class="code-terminal" style="font-size: 13px; margin-top: 12px; line-height: 1.6;">
-                <span class="code-comment"># 1. Kiểm tra thiếu trạng thái component</span><br>
-                <code>ui ds specimen --dir . --strict --json</code><br><br>
-                <span class="code-comment"># 2. Tái tạo tài liệu component từ Registry</span><br>
-                <code>ui ds docs --dir . --out docs/components.md</code><br><br>
-                <span class="code-comment"># 3. Tạo trang specimen HTML độc lập</span><br>
-                <code>ui ds preview --dir . --out preview.html</code><br><br>
-                <span class="code-comment"># 4. Quét Visual Regression component kit</span><br>
-                <code>design-os vr-matrix --project .</code><br><br>
-                <span class="code-comment"># 5. Xuất Changelog lịch sử thay đổi</span><br>
-                <code>ui changelog --dir . --format markdown</code>
-              </div>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Releases</div>
+              <div class="orb-label-main">Patch / Minor / Major</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">PHÂN LOẠI SEMVER (ui ds diff)</span>
-              <div class="code-terminal" style="font-size: 13px; margin-top: 12px;">
-                <code>ui ds diff base head --format pr-comment</code>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">≤ 0.02</div>
+              <div class="orb-label-secondary">Patch Delta EOK</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">> 0.05</div>
+              <div class="orb-label-tertiary">Major Breaking</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.7; margin-top: 14px;">
-                <li><strong>MAJOR (Breaking):</strong> Xóa token/component đang dùng; hoặc thay đổi màu sắc vượt ngưỡng Delta EOK.</li>
-                <li><strong>MINOR (Additive):</strong> Thêm mới token/component hoặc thêm variant mà không ảnh hưởng code cũ.</li>
-                <li><strong>PATCH:</strong> Sửa lỗi chính tả token, vi chỉnh không gây lệch thị giác.</li>
-              </ul>
+              <h1 class="radiant-display-title">SEMVER PR<br>MATRIX</h1>
+              <p class="radiant-body-text">Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">v1.0.0</div>
+              <div class="radiant-hero-label">Production Semver Bound</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Semver &amp; Handoff</div><div>26 / 28</div></footer>
-        <div data-speaker-notes="Checklist 5 bước và Semver Diff đảm bảo việc bàn giao sang cho đội ngũ Engineering diễn ra êm đẹp."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>26 / 28</div>
+        </footer>
+        <div data-speaker-notes="Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."></div>
       </article>
 
 <article class="slide-item" id="slide-27" data-index="27">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Fable Thinking</span></div>
-          <div>Hồi 7 • 26 • The 5 Design Fables</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • The 5 Fables</span>
+          </div>
+          <div>27 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tư Duy Ngụ Ngôn</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 5 Design Fables: Philosophy Behind Master Craft</h2>
-            <p class="slide-subtitle gsap-reveal">Distilling complex engineering mechanisms into intuitive allegorical archetypes.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📖</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">5 Fables</div>
+              <div class="orb-label-main">Spatial Mechanisms</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Generic</div>
+              <div class="orb-label-secondary">Meaningful Living UI</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">Metaphor Grounded</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 1 • THE SEAMLESS FLIGHT</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Seamless Flight</div>
-              <p class="stat-desc">"Một đường rách nhỏ làm tan biến cả giấc mơ". Vận tốc và vị trí tại mối nối clip phải tuyệt đối liên tục, không bao giờ được phép lùi bước.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">THE 5 DESIGN<br>FABLES</h1>
+              <p class="radiant-body-text">Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 2 • THE TWO-WAY BRIDGE</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Two-Way Bridge</div>
-              <p class="stat-desc">"Sự thật không thuộc về riêng Mã hay Tranh". figma-agent nối nhịp hai bờ, biến Canvas thành thực thể sống động gắn liền với Token.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 3 • THE 14-PLANK FLOOR</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The 14-Plank Floor</div>
-              <p class="stat-desc">"Đừng bao giờ tin vào lời hứa của AI". Hãy để 14 lưỡi cưa linter kiểm tra từng mối hàn code để bảo vệ chất lượng không tì vết.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 4 • THE MOTION LADDER</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Motion Ladder</div>
-              <p class="stat-desc">"Leo cao mà thiếu chân đế thì rơi". Chỉ leo từ T1 đến T6 khi câu chuyện đòi hỏi và người dùng cho phép qua reduced-motion.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 5 • MEMORY DISTILLATION</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Sol Memory Distillation</div>
-              <p class="stat-desc">"Sau mỗi chuyến đi, hãy đúc kết vào đá tảng". Recall lưu giữ bài học và giải phóng context để tiếp tục bay xa mà không tốn triệu token.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="background: var(--bg-surface-raised);">
-              <span class="matrix-badge">CORE TAKEAWAY</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">Discipline Breeds Master Craft</div>
-              <p class="stat-desc">DESIGN:OS không biến bạn thành nô lệ của công cụ, mà trao cho bạn sức mạnh của một xưởng thiết kế công nghiệp tự vận hành.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">5</div>
+              <div class="radiant-hero-label">Living Design Fables</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Philosophy • Fable Thinking</div><div>27 / 28</div></footer>
-        <div data-speaker-notes="5 câu chuyện ngụ ngôn là tổng kết triết lý sâu sắc nhất đằng sau toàn bộ công nghệ của DESIGN:OS."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>27 / 28</div>
+        </footer>
+        <div data-speaker-notes="Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."></div>
       </article>
 
 <article class="slide-item" id="slide-28" data-index="28">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Summary</span></div>
-          <div>Hồi 7 • 27 • Start Designing</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Production Ready</span>
+          </div>
+          <div>28 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone" style="justify-content: center;">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tổng Kết &amp; Thực Hành</span>
-            <h2 class="slide-title-display gsap-reveal">Start in 60 Seconds: Production Ready</h2>
-            <p class="slide-subtitle gsap-reveal">Toàn bộ hệ sinh thái DESIGN:OS đã được cấu hình và kiểm định hoàn chỉnh trong môi trường của bạn.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌟</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 CLI</div>
+              <div class="orb-label-main">ui / design-os</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Guess</div>
+              <div class="orb-label-secondary">Total Determinism</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">Ready</div>
+              <div class="orb-label-tertiary">Production Grade</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3" style="margin-top: 20px;">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 1</span>
-              <div class="stat-label" style="margin-top: 10px;">Khám Sức Khỏe</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>ui onboard &amp;&amp; ui doctor</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">READY FOR<br>PRODUCTION</h1>
+              <p class="radiant-body-text">Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 2</span>
-              <div class="stat-label" style="margin-top: 10px;">Khởi Tạo Dự Án</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>ui ds init my-app --persona aurora-minimal</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 3</span>
-              <div class="stat-label" style="margin-top: 10px;">Sinh Giao Diện</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>/ui:generate landing page for my next idea</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">SHIP</div>
+              <div class="radiant-hero-label">Qualified Delivery Floor</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Operating Manual • Ready for Production</div><div>28 / 28</div></footer>
-        <div data-speaker-notes="Cảm ơn bạn đã hoàn thành khóa Masterclass 28 slide. Chúc bạn tạo nên những giao diện đỉnh cao cùng DESIGN:OS!"></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>28 / 28</div>
+        </footer>
+        <div data-speaker-notes="Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"></div>
       </article>
 
     </div>

--- a/site/slides.html
+++ b/site/slides.html
@@ -53,2105 +53,1796 @@
   <main class="deck-viewport">
     <div class="slide-stage" id="slideStage">
 
-
 <article class="slide-item active" id="slide-1" data-index="1">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
           <div class="chrome-brand">
             <span class="chrome-brand-badge">DESIGN:OS</span>
-            <span>Masterclass Architecture Deck</span>
+            <span>Masterclass Operating Guide • V1.0</span>
           </div>
-          <div>The Complete 28-Slide Operating Guide • v1.0.0</div>
+          <div>01 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone" style="justify-content: center;">
-          <span class="slide-eyebrow gsap-reveal">Multi-Runtime Design CLI • Production Operating Manual</span>
-          <h1 class="slide-title-display gsap-reveal">
-            Mastering DESIGN:OS<br>From AI Reasoning to Scroll-Cinema &amp; Figma.
-          </h1>
-          <p class="slide-subtitle gsap-reveal" style="font-size: var(--font-size-xl);">
-            7 Strategic Acts: AI vs Kernel Division, 6 Onboarding Roads, Live Figma Bridge 9410, Recall Vector Memory, OKLCH Color Science, 3D GFlow &amp; 2K Scroll-Cinema, and Qualified Delivery Floor.
-          </p>
-          <div style="display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px;" class="gsap-reveal">
-            <span class="matrix-badge">28 Master Slides</span>
-            <span class="matrix-badge">Figma Desktop Hand</span>
-            <span class="matrix-badge">GFlow &amp; Scroll-Cinema</span>
-            <span class="matrix-badge">OKLCH &amp; P3 Gamut</span>
-            <span class="matrix-badge">12 UX Laws</span>
-            <span class="matrix-badge">Fable Thinking</span>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">✦</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">100%</div>
+              <div class="orb-label-main">Deterministic Floor</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">7 Acts</div>
+              <div class="orb-label-secondary">Strategic Chapters</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">28</div>
+              <div class="orb-label-tertiary">Master Slides</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">MASTERING<br>DESIGN:OS</h1>
+              <p class="radiant-body-text">The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0 %</div>
+              <div class="radiant-hero-label">LLM Luck Required</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
+            </div>
           </div>
         </section>
 
         <footer class="chrome-footer">
-          <div>Press [Left / Right Arrow] or [Space] to navigate • [S] Speaker Notes • [O] Overview • [L] Language • [T] Theme</div>
-          <div id="slideCounterDisplay">01 / 28</div>
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>01 / 28</div>
         </footer>
-        <div data-speaker-notes="Chào mừng đến với DESIGN:OS Masterclass mở rộng 28 slide. Đây là bộ cẩm nang hoàn chỉnh nhất, bao quát từ lõi toán học, cầu nối Figma, bộ nhớ vector đến điện ảnh cuộn trang 3D và 5 câu chuyện ngụ ngôn triết lý thiết kế."></div>
+        <div data-speaker-notes="Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."></div>
       </article>
 
 <article class="slide-item" id="slide-2" data-index="2">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Triết Lý Cốt Lõi</span></div>
-          <div>Hồi 1 • 01 • Core Foundations</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Core Philosophy</span>
+          </div>
+          <div>02 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Triết Lý Cốt Lõi</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 3 Supreme Truths of DESIGN:OS</h2>
-            <p class="slide-subtitle gsap-reveal">Eliminating reliance on LLM luck. Enforcing quality through color science and deterministic machine floors.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">360°</div>
+              <div class="orb-label-main">OKLCH Uniformity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0.02</div>
+              <div class="orb-label-secondary">ΔEOK Precision</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">14</div>
+              <div class="orb-label-tertiary">Quality Linters</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableTriadTitle fableTriadDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="nodePillar2"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableTriadTitle">The 3 Supreme Truths Architecture Triad</title>
-            <desc id="fableTriadDesc">Equilateral harmonic architecture diagram representing the three unbreakable foundational pillars: OKLCH Color Math, Sovereign Division of Labor, and the 14-Plank Machine Quality Floor.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">3 SUPREME<br>TRUTHS</h1>
+              <p class="radiant-body-text">Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.</p>
+            </div>
 
-            <defs>
-              <linearGradient id="triadBeam" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-primary)" stop-opacity="0.3"/>
-                <stop offset="50%" stop-color="var(--text-primary)" stop-opacity="0.9"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="0.3"/>
-              </linearGradient>
-            </defs>
-
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE HARMONIC FIELD • THREE INVIOLABLE TRUTHS</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="url(#triadBeam)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="url(#triadBeam)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <rect x="450" y="212" width="60" height="20" rx="10" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="480" y="226" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">FEEDS</text>
-
-            <rect x="930" y="212" width="60" height="20" rx="10" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="960" y="226" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">ENFORCES</text>
-
-            <!-- PILLAR 1: OKLCH COLOR SCIENCE (Prismatic Chamber) -->
-            <g id="nodePillar1" class="interactive-node" tabindex="0" role="button" aria-label="Truth 1: OKLCH Color Science" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TRUTH 01 • COLOR SCIENCE</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="104" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <polygon points="104,152 116,172 92,172" fill="var(--text-primary)"/>
-
-              <text x="136" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">OKLCH Color Math</text>
-              <text x="136" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Perceptual Uniformity Scale</text>
-
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu hoàn toàn HSL &amp; Hex ngẫu nhiên</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ sáng cảm nhận L đồng đều mọi góc Hue</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đạt chuẩn tương phản quang học WCAG AA</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khai thác 100% không gian màu Display P3</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">METRIC: ΔEOK &lt; 0.02 (Pure Precision)</text>
-            </g>
-
-            <!-- PILLAR 2: DIVISION OF LABOR (Dual Core Monolith - FOCAL) -->
-            <g id="nodePillar2" class="interactive-node" tabindex="0" role="button" aria-label="Truth 2: Division of Labor" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">TRUTH 02 • BRAIN &amp; BODY [FOCAL]</text>
-
-              <circle cx="564" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="564" cy="165" r="7" fill="var(--text-primary)"/>
-
-              <text x="596" y="162" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Division of Labor</text>
-              <text x="596" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Reasoning Brain vs UI Kernel</text>
-
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Host AI: Suy luận Persona, IA &amp; Component Tree</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• UI Kernel: Đóng gói DTCG Tokens &amp; Toán học màu</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tách bạch tuyệt đối giữa Ý Niệm và Thực Thi</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Không ảo giác token, không phụ thuộc may rủi</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">CONTRACT: Zero Stochastic Code</text>
-            </g>
-
-            <!-- PILLAR 3: MACHINE QUALITY FLOOR (14-Plank Grid) -->
-            <g id="nodePillar3" class="interactive-node" tabindex="0" role="button" aria-label="Truth 3: Deterministic Machine Floor" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TRUTH 03 • QUALITY FLOOR</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="1044" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <rect x="1038" y="159" width="12" height="12" fill="var(--text-primary)"/>
-
-              <text x="1076" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Deterministic Floor</text>
-              <text x="1076" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">14 Hard Machine Linters</text>
-
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui validate-layout: Bắt tràn màn hình &amp; soup &gt; 2</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui taste-lint: Sàn thẩm mỹ 6 trục (Taste Floor)</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ui a11y-lint: Kiểm thử tĩnh chuẩn tiếp cận Tier-1</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Lỗi bất kỳ = Chặn merge Pull Request (Exit 1)</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">GATE: 14 Linters 100% Pass</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-2">
-              <span class="readout-badge">FOUNDATIONS TRIAD: ACTIVE</span>
-              <span class="readout-text" id="readout-text-slide-2">Click any Pillar node or trigger button to inspect architectural contract parameters.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">14</div>
+              <div class="radiant-hero-label">Machine Floor Linters</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Operating Manual • Core Philosophy</div><div>02 / 28</div></footer>
-        <div data-speaker-notes="3 chân lý tối thượng là kim chỉ nam: biến sự hỗn loạn của LLM thành kết quả tất định."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>02 / 28</div>
+        </footer>
+        <div data-speaker-notes="The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."></div>
       </article>
 
 <article class="slide-item" id="slide-3" data-index="3">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Kiến Trúc Phân Quyền</span></div>
-          <div>Hồi 1 • 02 • Architecture Split</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Architecture Split</span>
+          </div>
+          <div>03 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Kiến Trúc Phân Quyền</span>
-            <h2 class="slide-title-h1 gsap-reveal">Division of Labor: AI Reasoning vs UI Kernel</h2>
-            <p class="slide-subtitle gsap-reveal">Host AI Agent handles creative reasoning, while the deterministic UI Kernel executes color mathematics and strict compliance verification.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚙</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">2 Minds</div>
+              <div class="orb-label-main">Human & Host Agent</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Kernel</div>
+              <div class="orb-label-secondary">Deterministic Engine</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Leaks</div>
+              <div class="orb-label-tertiary">Stochastic Free</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableArchTitle fableArchDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="kernelChamber"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableArchTitle">The Division of Labor: From Human Beacon to Neural Prism and Monolithic Kernel Gate</title>
-            <desc id="fableArchDesc">Aerodynamic structural diagram illustrating the living transformation of human intent through neural reasoning into deterministic, mathematically verified UI code.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DIVISION<br>OF LABOR</h1>
+              <p class="radiant-body-text">The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.</p>
+            </div>
 
-            <defs>
-              <!-- Luminous Waveguide Gradients -->
-              <linearGradient id="beamGradient1" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-muted)" stop-opacity="0.2"/>
-                <stop offset="50%" stop-color="var(--text-primary)" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="1"/>
-              </linearGradient>
-              <linearGradient id="beamGradient2" x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stop-color="var(--text-primary)" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="var(--text-primary)" stop-opacity="1"/>
-              </linearGradient>
-              <filter id="glowFable" x="-20%" y="-20%" width="140%" height="140%">
-                <feGaussianBlur stdDeviation="6" result="blur" />
-                <feComposite in="SourceGraphic" in2="blur" operator="over" />
-              </filter>
-            </defs>
-
-            <!-- Background Atmospheric Energy Field -->
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--text-inverse)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE LIVING STREAM • BRAIN &amp; BODY DUALITY PIPELINE</text>
-
-            <!-- 1. Waveguide Conduit 1 (Human -> AI) -->
-            <path id="waveguide1" d="M 360 250 C 420 250, 440 250, 500 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 360 250 C 420 250, 440 250, 500 250" fill="none" stroke="url(#beamGradient1)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <!-- 2. Waveguide Conduit 2 (AI -> Kernel) -->
-            <path id="waveguide2" d="M 900 250 C 960 250, 980 250, 1040 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 900 250 C 960 250, 980 250, 1040 250" fill="none" stroke="url(#beamGradient2)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <!-- Photonic Packets (Data flow pulse) -->
-
-            <!-- Conduit Flow Status Badges -->
-            <rect x="395" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="430" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PROMPT</text>
-
-            <rect x="935" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="970" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">AST / DTCG</text>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 1: THE HUMAN BEACON (Intent Transmitter)        -->
-            <!-- ======================================================== -->
-            <g id="nodeUser" class="interactive-node" tabindex="0" role="button" aria-label="Organism 1: Human Intent Beacon" style="cursor: pointer;">
-              <!-- Outer Resonance Rings -->
-              <circle cx="200" cy="250" r="145" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-              <circle cx="200" cy="250" r="130" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              
-              <!-- Core Capsule -->
-              <rect x="80" y="150" width="240" height="200" rx="16" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              
-              <!-- Glowing Beacon Emitter -->
-              <circle cx="200" cy="180" r="22" fill="var(--text-inverse)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="200" cy="180" r="8" fill="var(--text-primary)"/>
-
-              <text x="200" y="228" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.1em" text-anchor="middle">ORGAN 01 • TRANSMITTER</text>
-              <text x="200" y="255" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Human Intent</text>
-              <text x="200" y="278" font-family="var(--font-mono)" font-size="12" fill="var(--text-secondary)" text-anchor="middle">Natural Language Brief</text>
-
-              <!-- Parametric Readout -->
-              <rect x="96" y="298" width="208" height="34" rx="8" fill="var(--bg-surface)" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="200" y="320" font-family="var(--font-mono)" font-size="11" font-weight="600" fill="var(--text-primary)" text-anchor="middle">INPUT: Brand • Mood • Target</text>
-            </g>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 2: THE NEURAL PRISM (Creative Reasoning Brain)  -->
-            <!-- ======================================================== -->
-            <g id="nodeAgent" class="interactive-node" tabindex="0" role="button" aria-label="Organism 2: Neural Synthesis Prism" style="cursor: pointer;">
-              <!-- Outer Prism Geometry (Hexagonal Resonator) -->
-              <polygon points="700,70 880,160 880,340 700,430 520,340 520,160" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              
-              <!-- Inner Refraction Core -->
-              <polygon points="700,100 850,175 850,325 700,400 550,325 550,175" fill="var(--bg-surface-raised)" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <!-- Central Synthesis Engine -->
-              <circle cx="700" cy="200" r="36" fill="var(--text-inverse)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <text x="700" y="195" font-family="'Inter'" font-size="22" font-weight="900" fill="var(--text-primary)" text-anchor="middle">AI</text>
-              <text x="700" y="215" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-muted)" text-anchor="middle">BRAIN</text>
-
-              <text x="700" y="260" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.1em" text-anchor="middle">ORGAN 02 • NEURAL PRISM</text>
-              <text x="700" y="285" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Host AI Agent</text>
-              <text x="700" y="308" font-family="var(--font-mono)" font-size="12" fill="var(--text-secondary)" text-anchor="middle">Creative Synthesis &amp; Persona</text>
-
-              <!-- Refraction Beams (Persona spectrum) -->
-              <line x1="600" y1="330" x2="800" y2="330" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="700" y="352" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Resolves Persona Family</text>
-              <text x="700" y="374" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Crafts Semantic DOM Tree</text>
-
-              <rect x="570" y="390" width="260" height="28" rx="6" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="700" y="408" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-primary)" text-anchor="middle">ROLE: Creative Reasoning</text>
-            </g>
-
-            <!-- ======================================================== -->
-            <!-- ORGANISM 3: THE MONOLITHIC KERNEL GATE (Deterministic)   -->
-            <!-- ======================================================== -->
-            <g id="nodeKernel" class="interactive-node" tabindex="0" role="button" aria-label="Organism 3: Monolithic Kernel Gate" style="cursor: pointer;">
-              <!-- Outer Monolith Boundary (Heavy Structural Armor) -->
-              <rect x="1040" y="70" width="350" height="360" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              
-              <!-- Top Gate Header -->
-              <rect x="1040" y="70" width="350" height="50" rx="16" fill="var(--text-primary)"/>
-              <text x="1215" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">ORGAN 03 • MONOLITHIC GATE [FOCAL]</text>
-
-              <!-- Core Identity -->
-              <text x="1215" y="155" font-family="var(--font-sans)" font-size="22" font-weight="800" fill="var(--text-primary)" text-anchor="middle">UI Kernel Engine</text>
-              <text x="1215" y="178" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)" text-anchor="middle">Deterministic Color &amp; 14 Linters Floor</text>
-              <line x1="1070" y1="195" x2="1360" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <!-- 3 Gate Valves (The 3 Hard Machine Checks) -->
-              <g transform="translate(1065, 210)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">1. OKLCH / P3 Color Math</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">ΔEOK PASS</text>
-              </g>
-
-              <g transform="translate(1065, 256)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">2. DTCG Token Compiler</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">100% BOUND</text>
-              </g>
-
-              <g transform="translate(1065, 302)">
-                <rect width="300" height="36" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-                <circle cx="20" cy="18" r="5" fill="var(--text-primary)"/>
-                <text x="36" y="22" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)">3. 14 Deterministic Linters</text>
-                <text x="270" y="22" font-family="var(--font-mono)" font-size="10" font-weight="700" fill="var(--text-muted)" text-anchor="end">EXIT 0</text>
-              </g>
-
-              <!-- Qualified Delivery Seal -->
-              <rect x="1065" y="355" width="300" height="50" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1215" y="385" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.06em" text-anchor="middle">✓ ZERO-STOCHASTIC RELEASE</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-3">
-              <span class="readout-badge">PIPELINE: ACTIVE</span>
-              <span class="readout-text" id="readout-text-slide-3">Click any node or press 'Simulate Data Flow' to watch the prompt-to-kernel deterministic validation run.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Deterministic Compile</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Architecture • System Division of Labor</div><div>03 / 28</div></footer>
-        <div data-speaker-notes="AI Agent suy luận, UI Kernel kiểm định. Hai bán cầu kết hợp thành vòng lặp tự sửa lỗi hoàn hảo."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>03 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."></div>
       </article>
 
 <article class="slide-item" id="slide-4" data-index="4">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Optional Hands</span></div>
-          <div>Hồi 1 • 03 • Specialized Modules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 1 • Hands Ecosystem</span>
+          </div>
+          <div>04 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Module Mở Rộng</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 6 Specialized Optional Hands Ecosystem</h2>
-            <p class="slide-subtitle gsap-reveal">Specialized modular hands extend multi-dimensional design capabilities, gracefully degrading when unconfigured.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">✋</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Hands</div>
+              <div class="orb-label-main">Specialized Engines</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 CLI</div>
+              <div class="orb-label-secondary">Unified Toolchain</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 ms</div>
+              <div class="orb-label-tertiary">Runtime Bloat</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. FIGMA 1:1 MIRROR</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">figma-agent</div>
-              <p class="stat-desc">Connects to Figma Desktop via port 9410. Synthesizes precise auto-layout, swaps component instances, and syncs tokens bi-directionally.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">OPTIONAL<br>HANDS</h1>
+              <p class="radiant-body-text">Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. SEMANTIC MEMORY</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">recall (mind)</div>
-              <p class="stat-desc">Local vector memory powered by ONNX embeddings. Recalls historical lessons at task start and distills insights upon completion.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. 3D &amp; SCROLL CINEMA</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">gflow &amp; scrub</div>
-              <p class="stat-desc">Điều khiển camera 3D và cuộn video không vết cắt (Seam Physics) thông qua Google Flow (Veo/Imagen).</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">4. VISUAL REGRESSION</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">page-shot &amp; vr</div>
-              <p class="stat-desc">Chụp render thực tế và so sánh pixel-level diff cho từng component (vr-matrix), ngăn chặn layout shift ngoài ý muốn.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">5. RENDERED A11Y</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">a11y-audit</div>
-              <p class="stat-desc">Thực thi axe-core trên Chrome headless để kiểm tra độ tương phản thực tế và cây ngữ nghĩa ARIA ở trạng thái render thật.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">6. CANVAS &amp; SHADERS</span>
-              <div class="stat-label" style="font-size: 20px; margin-top: 8px;">canvas-ui (T6)</div>
-              <p class="stat-desc">Mô phỏng chất liệu Liquid Glass, hạt 3D và WebGL shaders với hợp đồng dọn dẹp bộ nhớ (Teardown Contract).</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6</div>
+              <div class="radiant-hero-label">Multi-Runtime Engines</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Toolchain • Optional Hands Ecosystem</div><div>04 / 28</div></footer>
-        <div data-speaker-notes="6 cánh tay này biến DESIGN:OS thành hệ điều hành thiết kế toàn năng từ giao diện web phẳng đến không gian 3D và canvas Figma."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>04 / 28</div>
+        </footer>
+        <div data-speaker-notes="The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."></div>
       </article>
 
 <article class="slide-item" id="slide-5" data-index="5">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Bản Sắc Thiết Kế</span></div>
-          <div>Hồi 1 • 04 • Design Soul Architecture</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Design Soul</span>
+          </div>
+          <div>05 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bản Sắc Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">3-Tier Design Soul Hierarchy (Never / Always / Voice)</h2>
-            <p class="slide-subtitle gsap-reveal">Establishing aesthetic stances and consistent design vocabulary from Studio level down to specific projects.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏛</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">WT 75</div>
+              <div class="orb-label-main">Project Overrides</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">WT 50</div>
+              <div class="orb-label-secondary">Studio Shared</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">WT 0</div>
+              <div class="orb-label-tertiary">Factory Invariant</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableSoulTitle fableSoulDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ttb"
-            data-focal-id="soulProject"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableSoulTitle">Design Soul: The 3 Tiers of Sovereignty &amp; Precedence Cascade</title>
-            <desc id="fableSoulDesc">Hierarchical cascade diagram showing the three tiers of design truth: Factory Invariants, Studio Standards, and Project Soul.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">CASCADE OF<br>SOVEREIGNTY</h1>
+              <p class="radiant-body-text">Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE SOVEREIGNTY CASCADE • THREE TIERS OF DESIGN TRUTH</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- TIER 0: FACTORY INVARIANTS -->
-            <g id="soulFactory" class="interactive-node" tabindex="0" role="button" aria-label="Tier 0: Factory Invariants" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TIER 0 • FACTORY (WEIGHT 0)</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="104" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <rect x="96" y="157" width="16" height="16" fill="var(--text-primary)"/>
-
-              <text x="136" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Factory Invariants</text>
-              <text x="136" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Immutable Architectural Laws</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu Purple-on-Dark &amp; Glow Borders</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cấm container lồng nhau quá 2 cấp (Soup)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chuẩn tiếp cận WCAG 2.2 AA bắt buộc</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Luật cứng: Không thể bị ghi đè (Immutable)</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SOVEREIGNTY: Absolute Floor</text>
-            </g>
-
-            <!-- TIER 1: STUDIO STANDARDS -->
-            <g id="soulStudio" class="interactive-node" tabindex="0" role="button" aria-label="Tier 1: Studio Standards" style="cursor: pointer;">
-              <rect x="520" y="80" width="400" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="520" y="80" width="400" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="544" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">TIER 1 • STUDIO (WEIGHT 50)</text>
-              <circle cx="890" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <circle cx="564" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1.5"/>
-              <polygon points="564,152 576,172 552,172" fill="var(--text-primary)"/>
-
-              <text x="596" y="162" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Studio Standards</text>
-              <text x="596" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Workspace Shared Conventions</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chuẩn nhịp 8px Spacing Grid toàn team</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Thư viện Icon mặc định: Phosphor Icons</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Font typography mặc định theo phân khúc</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Định hình phong cách chung cả tổ chức</text>
-
-              <rect x="544" y="350" width="352" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="720" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">WORKSPACE: Shared Stance</text>
-            </g>
-
-            <!-- TIER 2: PROJECT SOUL -->
-            <g id="soulProject" class="interactive-node" tabindex="0" role="button" aria-label="Tier 2: Project Soul" style="cursor: pointer;">
-              <rect x="1000" y="70" width="380" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1000" y="70" width="380" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="1190" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">TIER 2 • PROJECT SOUL [FOCAL]</text>
-
-              <circle cx="1044" cy="165" r="18" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <circle cx="1044" cy="165" r="8" fill="var(--text-primary)"/>
-
-              <text x="1076" y="162" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Project Soul</text>
-              <text x="1076" y="182" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Bespoke Brand Persona</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Persona gia đình: Aurora Minimal / Brutalist</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bảng màu thương hiệu OKLCH độc bản</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ cao thang chuyển động (Motion Cap T5)</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Ghi đè Studio Stance khi Brief yêu cầu</text>
-
-              <rect x="1024" y="350" width="332" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1190" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">PRECEDENCE: Project Brief Wins</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-5">
-              <span class="readout-badge">PRECEDENCE: HIERARCHICAL</span>
-              <span class="readout-text" id="readout-text-slide-5">Click tiers to test rule resolution: Explicit User Brief (100) > Project Soul (75) > Studio Standards (50) > Factory Invariants (0).</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3 Tiers</div>
+              <div class="radiant-hero-label">Precedence Hierarchy</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 75%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Architecture • Soul Precedence</div><div>05 / 28</div></footer>
-        <div data-speaker-notes="Soul thiết lập lập trường thẩm mỹ. Explicit Brief từ user luôn có quyền ghi đè cao nhất."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>05 / 28</div>
+        </footer>
+        <div data-speaker-notes="Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."></div>
       </article>
 
 <article class="slide-item" id="slide-6" data-index="6">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Onboarding Router</span></div>
-          <div>Hồi 2 • 05 • The 6 Entry Roads</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Onboarding</span>
+          </div>
+          <div>06 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Onboarding</span>
-            <h2 class="slide-title-h1 gsap-reveal">6 Entry Roads for Project Onboarding (E1–E6)</h2>
-            <p class="slide-subtitle gsap-reveal">Chạy <code>ui scan --json</code> để tự động nhận diện tình trạng dự án và chọn đúng lộ trình khởi tạo.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🛣</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Roads</div>
+              <div class="orb-label-main">E1 to E6 Pathways</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Scan</div>
+              <div class="orb-label-secondary">Auto Diagnostics</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Guess</div>
+              <div class="orb-label-tertiary">Instant Setup</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E1 • GREENFIELD</span>
-              <div class="stat-label" style="margin-top: 10px;">Dự án mới hoàn toàn</div>
-              <p class="stat-desc">Khởi tạo Design System từ 1 trong 26 Personas có sẵn.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui ds init app --persona aurora-minimal</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">6 ENTRY<br>ROADS</h1>
+              <p class="radiant-body-text">Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E2 • BROWNFIELD</span>
-              <div class="stat-label" style="margin-top: 10px;">Codebase có sẵn</div>
-              <p class="stat-desc">Quét mã nguồn hiện tại và biên dịch thành Design System.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui scan --cwd . → /ui:learn</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E3 • LIVE URL</span>
-              <div class="stat-label" style="margin-top: 10px;">Bóc tách từ URL</div>
-              <p class="stat-desc">Trích xuất màu sắc, typography từ website bạn thích.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>/ui:from-url https://linear.app</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E4 • FIGMA LIBRARY</span>
-              <div class="stat-label" style="margin-top: 10px;">Thư viện Figma</div>
-              <p class="stat-desc">Quét Figma file và chuyển thành bundle tokens + registry.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>design-os figma scan → ui ingest-figma-ds</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E5 • DTCG TOKENS</span>
-              <div class="stat-label" style="margin-top: 10px;">Token shadcn / DTCG</div>
-              <p class="stat-desc">Nạp file token JSON có sẵn vào kho Design System.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>ui ds import tokens.json --name my-app</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">E6 • MOODBOARD</span>
-              <div class="stat-label" style="margin-top: 10px;">Ảnh mẫu &amp; Shots</div>
-              <p class="stat-desc">Nạp ảnh chụp màn hình để trích xuất hạt giống Persona.</p>
-              <div class="code-terminal" style="padding: 12px; margin-top: 14px; font-size: 13px;">
-                <code>design-os reference add ./shot.png</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">E1-E6</div>
+              <div class="radiant-hero-label">Deterministic Gateways</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 60%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Onboarding • Entry Roads E1-E6</div><div>06 / 28</div></footer>
-        <div data-speaker-notes="6 cổng vào này đảm bảo DESIGN:OS hòa nhập vào bất kỳ quy trình làm việc nào của team dù là vẽ Figma trước hay code trước."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>06 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."></div>
       </article>
 
 <article class="slide-item" id="slide-7" data-index="7">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Onboarding Checklist</span></div>
-          <div>Hồi 2 • 06 • Setup &amp; Stop-Gates</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Setup Protocol</span>
+          </div>
+          <div>07 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Onboarding</span>
-            <h2 class="slide-title-h1 gsap-reveal">5-Step Setup Protocol &amp; Mandatory STOP-Gates</h2>
-            <p class="slide-subtitle gsap-reveal">Tuân thủ thứ tự thiết lập để không bao giờ gặp lỗi lệch mã băm hoặc sai danh tính Agent.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🔒</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <div class="stat-label">5 Bước Khởi Tạo Chuẩn Xác</div>
-              <ol style="padding-left: 24px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 16px;">
-                <li><strong>Bước 0:</strong> Chạy <code>ui onboard</code> xem checklist và <code>ui scan</code>.</li>
-                <li><strong>Bước 1:</strong> Chọn cổng (E1–E6) để seal kho <code>design/</code>.</li>
-                <li><strong>Bước 2:</strong> Chạy cả 2 lệnh Doctor: <code>ui doctor</code> và <code>design-os doctor --versions</code>.</li>
-                <li><strong>Bước 3:</strong> Điền Never/Always/Voice vào <code>design/soul.md</code> rồi chạy <code>ui ds soul check</code>.</li>
-                <li><strong>Bước 4:</strong> Khởi tạo đội ngũ Agent: <code>ui agents init</code>.</li>
-              </ol>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">5 Steps</div>
+              <div class="orb-label-main">Ordered Setup</div>
             </div>
 
-            <div style="display: flex; flex-direction: column; gap: 24px;">
-              <div class="slide-card gsap-card" style="border-top-color: var(--text-primary);">
-                <span class="matrix-badge">⚠️ STOP-GATE 1: NAMING HYGIENE</span>
-                <div class="stat-label" style="margin-top: 8px;">Luôn truyền --name khi import token</div>
-                <p class="stat-desc">Nếu bỏ qua <code>--name &lt;slug&gt;</code>, hệ thống mặc định đặt tên là <code>imported-ds</code> và sau này toàn bộ AI Agent sẽ bị đặt tên là <code>designer-imported-ds</code>.</p>
-              </div>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Protocol Bound</div>
+            </div>
 
-              <div class="slide-card gsap-card" style="border-top-color: var(--text-primary);">
-                <span class="matrix-badge">🛑 STOP-GATE 2: GIT PREREQUISITE</span>
-                <div class="stat-label" style="margin-top: 8px;">Bắt buộc phải là Git Repository</div>
-                <p class="stat-desc">Dự án phải có <code>.git</code> (chạy <code>git init</code>). Nếu không có git, các lỗi lệch hash registry sau này sẽ không thể diff và truy vết.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Drift</div>
+              <div class="orb-label-tertiary">Token Hash Sync</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">SETUP<br>PROTOCOL</h1>
+              <p class="radiant-body-text">Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">5 / 5</div>
+              <div class="radiant-hero-label">STOP-Gates Cleared</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Onboarding • Verification &amp; Stop-Gates</div><div>07 / 28</div></footer>
-        <div data-speaker-notes="Hai bác sĩ kiểm tra 2 việc khác nhau: ui doctor kiểm tra kernel, còn design-os doctor kiểm tra các optional hands."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>07 / 28</div>
+        </footer>
+        <div data-speaker-notes="Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."></div>
       </article>
 
 <article class="slide-item" id="slide-8" data-index="8">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Agent Staff</span></div>
-          <div>Hồi 2 • 07 • Virtual Design Staff</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 2 • Virtual Staff</span>
+          </div>
+          <div>08 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đội Ngũ Agent</span>
-            <h2 class="slide-title-h1 gsap-reveal">Virtual Design Staff &amp; Periodic Heartbeat</h2>
-            <p class="slide-subtitle gsap-reveal">Một lệnh <code>ui agents init</code> cấp cho dự án một đội ngũ 3 chuyên gia AI với ranh giới trách nhiệm nghiêm ngặt.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">👥</div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">AI DESIGNER</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">designer-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Sinh giao diện, tinh chỉnh code HTML/CSS theo đúng Design Tokens.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ được tự chấm điểm bài làm của chính mình.</p>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Agents</div>
+              <div class="orb-label-main">Specialized Roles</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">AI CURATOR</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">curator-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Thanh tra độc lập, phê bình thẩm mỹ 6+1 trục, đối chiếu spec và đưa ra phán quyết.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ được trực tiếp sửa code.</p>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Heart</div>
+              <div class="orb-label-secondary">Cron Heartbeat</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FIGMA HAND</span>
-              <div class="stat-label" style="font-size: var(--font-size-base); margin-top: 8px;">figma-&lt;studio&gt;-&lt;project&gt;</div>
-              <p class="stat-desc" style="margin-top: 14px;"><strong>Vai trò:</strong> Thao tác trực tiếp trên canvas Figma qua broker port 9410.<br><br><strong style="color: var(--text-primary);">Ranh giới cấm:</strong> Không bao giờ giả lập thao tác khi plugin Figma đang tắt.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">24 / 7</div>
+              <div class="orb-label-tertiary">Active Governance</div>
             </div>
           </div>
 
-          <div class="slide-card gsap-card" style="margin-top: 24px; padding: 20px 28px; flex-direction: row; align-items: center; justify-content: space-between;">
-            <div>
-              <strong style="font-size: var(--font-size-base);">❤️ Recurring Heartbeat (<code>design-os heartbeat</code>)</strong>
-              <p style="font-size: var(--font-size-sm); color: var(--text-muted); margin-top: 4px;">Tự động quét định kỳ: <code>nightly-a11y</code>, <code>weekly-specimen</code>, <code>preview-pages</code>, <code>figma-hygiene</code>.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VIRTUAL<br>STAFF</h1>
+              <p class="radiant-body-text">A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.</p>
             </div>
-            <span class="matrix-badge">HEALTH CHECK CỤC BỘ</span>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3</div>
+              <div class="radiant-hero-label">Specialized AI Roles</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
+            </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Agents • Specialized Roles</div><div>08 / 28</div></footer>
-        <div data-speaker-notes="Designer không bao giờ tự chấm điểm, Curator không bao giờ tự sửa code. Ranh giới trách nhiệm bảo đảm chất lượng khách quan."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>08 / 28</div>
+        </footer>
+        <div data-speaker-notes="Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."></div>
       </article>
 
 <article class="slide-item" id="slide-9" data-index="9">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Daily Verbs</span></div>
-          <div>Hồi 2 • 08 • Everyday Workflow</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Daily Operations</span>
+          </div>
+          <div>09 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Công Việc Hàng Ngày</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 6 Core Daily Verbs (/ui:* Commands)</h2>
-            <p class="slide-subtitle gsap-reveal">Tương tác bằng ngôn ngữ tự nhiên trong CLI. AI tự chuyển hóa thành kế hoạch và code chuẩn mực.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Verbs</div>
+              <div class="orb-label-main">Natural CLI Verbs</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Self-Healing</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 UI Lag</div>
+              <div class="orb-label-tertiary">Instant Output</div>
+            </div>
           </div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. TẠO GIAO DIỆN MỚI</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:generate</span> landing page for an AI developer tool, brutalist-editorial, dark theme
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
-              <p class="stat-desc" style="margin-top: 10px;">Biến yêu cầu sơ khai thành brief chuẩn, dựng layout gắn token, kiểm tra qua 6 linter.</p>
+              <h1 class="radiant-display-title">6 CORE<br>DAILY VERBS</h1>
+              <p class="radiant-body-text">High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. CHỈNH SỬA VI MÔ</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:iterate</span> make the hero headline larger and the CTA button warmer
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6</div>
+              <div class="radiant-hero-label">Core Operating Verbs</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
               </div>
-              <p class="stat-desc" style="margin-top: 10px;">Chỉnh sửa phẫu thuật từng dòng (line-diff) mà không làm vỡ cấu trúc của Design System.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. DỰNG LÊN FIGMA CANVAS</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:to-figma</span> 3-tier pricing card component with toggle
-              </div>
-              <p class="stat-desc" style="margin-top: 10px;">Vẽ trực tiếp lên Figma với cấu trúc auto-layout, instance component thật và biến màu token.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">4. TRUY VẤN BỘ NHỚ</span>
-              <div class="code-terminal" style="margin-top: 10px;">
-                <span class="code-prompt">&gt; </span><span class="code-keyword">/ui:why</span> why did we choose oklch(0.65 0.24 260) for primary CTA?
-              </div>
-              <p class="stat-desc" style="margin-top: 10px;">Truy vết nguồn gốc mọi quyết định thiết kế trong quá khứ từ Design Memory.</p>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • Core Verbs</div><div>09 / 28</div></footer>
-        <div data-speaker-notes="6 động từ thường nhật biến CLI thành bảng điều khiển trực quan cho designer và developer."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>09 / 28</div>
+        </footer>
+        <div data-speaker-notes="Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."></div>
       </article>
 
 <article class="slide-item" id="slide-10" data-index="10">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Figma Agent Hand</span></div>
-          <div>Hồi 3 • 09 • Real-Time Bridge</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Figma Bridge</span>
+          </div>
+          <div>10 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Cầu Nối Hai Chiều</span>
-            <h2 class="slide-title-h1 gsap-reveal">Figma Desktop Bridge: Broker Port 9410</h2>
-            <p class="slide-subtitle gsap-reveal">AI Agents and Designers collaborate on a real-time Figma file with secure conflict locking.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌉</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">9410</div>
+              <div class="orb-label-main">WebSocket Broker</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">127.0.0.1</div>
+              <div class="orb-label-secondary">Local Loopback</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Conflict</div>
+              <div class="orb-label-tertiary">Atomic Mutex</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableFigmaTitle fableFigmaDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="figmaNodeBroker"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableFigmaTitle">The Two-Way Bridge: Code Tokens to Live Figma Desktop Canvas</title>
-            <desc id="fableFigmaDesc">Bi-directional suspension bridge diagram connecting Code AST Tokens and Figma Desktop Canvas via Port 9410 Broker.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">FIGMA LIVE<br>DESKTOP BRIDGE</h1>
+              <p class="radiant-body-text">Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE TWO-WAY BRIDGE • PORT 9410 BI-DIRECTIONAL REAL-TIME SYNCHRONIZATION</text>
-
-            <path d="M 380 250 C 440 250, 460 250, 520 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 380 250 C 440 250, 460 250, 520 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <path d="M 920 250 C 980 250, 1000 250, 1060 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 920 250 C 980 250, 1000 250, 1060 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="10 8" />
-
-            <rect x="415" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="450" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PUSH DTCG</text>
-
-            <rect x="955" y="210" width="70" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="990" y="225" font-family="var(--font-mono)" font-size="9" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PULL AST</text>
-
-            <!-- WEST BANK: CODE -->
-            <g id="figmaNodeCode" class="interactive-node" tabindex="0" role="button" aria-label="West Bank: Code Token Matrix" style="cursor: pointer;">
-              <rect x="60" y="80" width="320" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="320" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">WEST BANK • CODE</text>
-              <circle cx="350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Code Repository</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">design/tokens.json (DTCG)</text>
-              <line x1="84" y1="205" x2="356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chân lý màu: design/tokens.json</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Lệnh biên dịch: ui tokens export</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khung mã AST ngữ nghĩa HTML/CSS</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động sinh Pull Request AST diff</text>
-
-              <rect x="84" y="350" width="272" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="220" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SOURCE: Canonical DTCG</text>
-            </g>
-
-            <!-- CENTER ARCH: BROKER (FOCAL) -->
-            <g id="figmaNodeBroker" class="interactive-node" tabindex="0" role="button" aria-label="Center Arch: Port 9410 Rotary Commutator" style="cursor: pointer;">
-              <polygon points="720,60 900,155 900,345 720,440 540,345 540,155" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              
-              <rect x="580" y="80" width="280" height="36" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="103" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.08em" text-anchor="middle">WS BROKER : 9410 [FOCAL]</text>
-
-              <circle cx="720" cy="200" r="45" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <circle cx="720" cy="200" r="8" fill="var(--text-primary)"/>
-              <line x1="720" y1="160" x2="720" y2="240" stroke="var(--text-primary)" stroke-width="3" stroke-linecap="round"/>
-              <line x1="680" y1="200" x2="760" y2="200" stroke="var(--text-primary)" stroke-width="3" stroke-linecap="round"/>
-
-              <text x="720" y="270" font-family="var(--font-sans)" font-size="20" font-weight="900" fill="var(--text-primary)" text-anchor="middle">figma-agent Broker</text>
-              <text x="720" y="292" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)" text-anchor="middle">127.0.0.1:9410 WebSocket Engine</text>
-
-              <line x1="600" y1="315" x2="840" y2="315" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="720" y="338" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Atomic Token Serialization</text>
-              <text x="720" y="360" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)" text-anchor="middle">• Mutex Conflict-Lock Protocol</text>
-
-              <rect x="580" y="380" width="280" height="36" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="403" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STATUS: Port 9410 Connected</text>
-            </g>
-
-            <!-- EAST BANK: CANVAS -->
-            <g id="figmaNodeCanvas" class="interactive-node" tabindex="0" role="button" aria-label="East Bank: Live Figma Desktop Canvas" style="cursor: pointer;">
-              <rect x="1060" y="80" width="320" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1060" y="80" width="320" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1084" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">EAST BANK • CANVAS</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1084" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Figma Desktop Canvas</text>
-              <text x="1084" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Live Variables &amp; Auto-Layout</text>
-              <line x1="1084" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1084" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Liên kết trực tiếp Figma Variables</text>
-              <text x="1084" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Auto-Layout tương thích 1:1 Flexbox</text>
-              <text x="1084" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Designer chỉnh sửa = Gửi event WebSocket</text>
-              <text x="1084" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động bắt sự kiện qua Plugin manifest</text>
-
-              <rect x="1084" y="350" width="272" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1220" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">SURFACE: Live Native Canvas</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-10">
-              <span class="readout-badge">BROKER: PORT 9410 READY</span>
-              <span class="readout-text" id="readout-text-slide-10">Click nodes or simulation button to inspect bi-directional Code-to-Canvas push and Canvas-to-Code pull mechanics.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">9410</div>
+              <div class="radiant-hero-label">Local Broker Port</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Figma Hand • Real-Time Bridge Architecture</div><div>10 / 28</div></footer>
-        <div data-speaker-notes="Broker port 9410 kết nối trực tiếp với Figma Desktop Plugin, cho phép AI dựng layout và gán token tự động."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>10 / 28</div>
+        </footer>
+        <div data-speaker-notes="The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."></div>
       </article>
 
 <article class="slide-item" id="slide-11" data-index="11">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Figma Craft</span></div>
-          <div>Hồi 3 • 10 • Auto-Layout &amp; Token Binding</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 3 • Token Pipeline</span>
+          </div>
+          <div>11 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Chuẩn Mực Figma</span>
-            <h2 class="slide-title-h1 gsap-reveal">Crafting Canvas Art: Auto-Layout &amp; Variables</h2>
-            <p class="slide-subtitle gsap-reveal">Không bao giờ vẽ hình chữ nhật tự do vô nghĩa. Mọi khung vẽ đều phải tuân thủ nghiêm ngặt Auto-Layout và Token Variables.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🪙</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 Source</div>
+              <div class="orb-label-main">design/tokens.json</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">W3C DTCG Standard</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Stale</div>
+              <div class="orb-label-tertiary">Synchronized AST</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. AUTO-LAYOUT SÂU</span>
-              <div class="stat-label" style="margin-top: 8px;">Auto-Layout 100%</div>
-              <p class="stat-desc" style="margin-top: 10px;">100% frame đều có layoutMode (HORIZONTAL / VERTICAL), padding và itemSpacing chuẩn token 4/8px.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>node.layoutMode = 'VERTICAL';</code><br>
-                <code>node.itemSpacing = 16;</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">CANONICAL<br>TOKENS</h1>
+              <p class="radiant-body-text">Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. INSTANCE SWAPPING</span>
-              <div class="stat-label" style="margin-top: 8px;">Tái Dùng Component</div>
-              <p class="stat-desc" style="margin-top: 10px;">Không vẽ lại Button hay Input. Trỏ tìm Component trong Library và gọi <code>createInstance()</code> chuẩn xác.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>const inst = comp.createInstance();</code><br>
-                <code>parent.appendChild(inst);</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. VARIABLE BINDING</span>
-              <div class="stat-label" style="margin-top: 8px;">Gắn Token Variables</div>
-              <p class="stat-desc" style="margin-top: 10px;">Màu sắc không tô raw hex. Ánh xạ trực tiếp sang Figma Variable Collection đã nhập từ DTCG tokens.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>node.setBoundVariable('fills', vId);</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Token AST Binding</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Figma Craft • Canonical Canvas Rules</div><div>11 / 28</div></footer>
-        <div data-speaker-notes="Canvas trên Figma được tạo ra có cấu trúc như mã nguồn thực tế: có auto-layout, instance component và variable tokens."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>11 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."></div>
       </article>
 
 <article class="slide-item" id="slide-12" data-index="12">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Audit Surfaces</span></div>
-          <div>Hồi 3 • 11 • Audit Disambiguation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Quality Audit</span>
+          </div>
+          <div>12 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bề Mặt Kiểm Định</span>
-            <h2 class="slide-title-h1 gsap-reveal">Dissecting the 4 'Audit' Surfaces</h2>
-            <p class="slide-subtitle gsap-reveal">4 công cụ khác nhau cùng mang từ khóa "Audit". Chọn đúng công cụ theo đúng đối tượng kiểm tra.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🔬</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">4 Surfaces</div>
+              <div class="orb-label-main">Chamber Sieve</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">6 Axes</div>
+              <div class="orb-label-secondary">Taste Rubric</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≤ 2</div>
+              <div class="orb-label-tertiary">Max Container Soup</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableAuditTitle fableAuditDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="auditQuad1"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableAuditTitle">The 4 Registered Audit Surfaces Matrix</title>
-            <desc id="fableAuditDesc">Quadrant architecture matrix showing the four deterministic verification surfaces: taste-lint, validate-layout, a11y-lint, and full-stack vr-gate release suites.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">4 QUALITY<br>SURFACES</h1>
+              <p class="radiant-body-text">The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE 4-CHAMBER QUALITY SIEVE • DETERMINISTIC VERIFICATION MATRIX</text>
-
-            <!-- Quad 1: Taste Lint -->
-            <g id="auditQuad1" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 1: ui taste-lint" style="cursor: pointer;">
-              <rect x="60" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="2.5"/>
-              <rect x="60" y="80" width="310" height="44" rx="16" fill="var(--text-primary)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.08em">SURFACE 01 • TASTE LINT [FOCAL]</text>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui taste-lint</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">6-Axis Aesthetic Rubric Floor</text>
-              <line x1="84" y1="205" x2="346" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét tĩnh HTML/CSS không cần render</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• 14 Luật cấm (Anti-Patterns)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kiểm tra Tracking &amp; Bo góc token</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tốc độ: &lt; 20ms thực thi</text>
-
-              <rect x="84" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="1.5"/>
-              <text x="215" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EXIT: Floor Score &ge; 8.0</text>
-            </g>
-
-            <!-- Quad 2: Validate Layout -->
-            <g id="auditQuad2" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 2: ui validate-layout" style="cursor: pointer;">
-              <rect x="400" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="400" y="80" width="310" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="424" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 02 • LAYOUT</text>
-
-              <text x="424" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui validate-layout</text>
-              <text x="424" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Container Soup &amp; Overflow</text>
-              <line x1="424" y1="205" x2="686" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="424" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bắt container lồng nhau &gt; 2 cấp</text>
-              <text x="424" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét tràn nội dung trục ngang</text>
-              <text x="424" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Phát hiện đứt gãy Grid / Flexbox</text>
-              <text x="424" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khắc phục tự động qua autofix</text>
-
-              <rect x="424" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="555" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">CHECK: Nesting &le; 2 Levels</text>
-            </g>
-
-            <!-- Quad 3: A11y Lint -->
-            <g id="auditQuad3" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 3: ui a11y-lint" style="cursor: pointer;">
-              <rect x="740" y="80" width="310" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="740" y="80" width="310" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="764" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 03 • ACCESSIBILITY</text>
-
-              <text x="764" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ui a11y-lint</text>
-              <text x="764" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Tier-1 Static Accessibility Floor</text>
-              <line x1="764" y1="205" x2="1026" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="764" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tương phản WCAG 2.2 AA (4.5:1)</text>
-              <text x="764" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Bắt buộc role, title, aria-labels</text>
-              <text x="764" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kiểm tra thứ tự Focus bàn phím</text>
-              <text x="764" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cấm thẻ img thiếu alt, button rỗng</text>
-
-              <rect x="764" y="350" width="262" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="895" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">LEVEL: WCAG 2.2 AA Static</text>
-            </g>
-
-            <!-- Quad 4: Full Audit -->
-            <g id="auditQuad4" class="interactive-node" tabindex="0" role="button" aria-label="Quadrant 4: design-os audit" style="cursor: pointer;">
-              <rect x="1080" y="80" width="300" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1080" y="80" width="300" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1104" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SURFACE 04 • FULL SUITE</text>
-
-              <text x="1104" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">design-os audit</text>
-              <text x="1104" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">10-Tool Release Suite &amp; VR</text>
-              <line x1="1104" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1104" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kết hợp 10 công cụ kiểm định toàn diện</text>
-              <text x="1104" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét Visual Regression 3 Viewports</text>
-              <text x="1104" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đồng bộ Dark/Light Paired Tokens</text>
-              <text x="1104" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Điều kiện tiên quyết để tạo PR merge</text>
-
-              <rect x="1104" y="350" width="252" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1230" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">GATE: 0 Errors Required</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-12">
-              <span class="readout-badge">SURFACES: 4 REGISTERED</span>
-              <span class="readout-text" id="readout-text-slide-12">Click any of the 4 quadrants to inspect its exact CLI command, verification scope, and execution order.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0</div>
+              <div class="radiant-hero-label">Errors Allowed to Ship</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • The 4 Audit Surfaces</div><div>12 / 28</div></footer>
-        <div data-speaker-notes="Ma trận 2x2 giúp phân biệt rõ 4 loại lệnh audit để không bao giờ chạy nhầm đối tượng quét."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>12 / 28</div>
+        </footer>
+        <div data-speaker-notes="Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."></div>
       </article>
 
 <article class="slide-item" id="slide-13" data-index="13">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Finding Triage</span></div>
-          <div>Hồi 3 • 12 • Triage &amp; Core Rules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Triage Protocol</span>
+          </div>
+          <div>13 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Xử Lý Lỗi</span>
-            <h2 class="slide-title-h1 gsap-reveal">Finding Triage Workflow &amp; 2 Golden Rules</h2>
-            <p class="slide-subtitle gsap-reveal">Đọc kết quả linter một cách khoa học để đưa ra quyết định Iterate hay Escalate.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚖</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <div class="stat-label">Quy Trình Triage 3 Bước</div>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 16px;">
-                <li><strong>1. Luôn đọc cờ --json:</strong> Exit code <code>1</code> có thể do gọi sai flag (<code>BAD_ARG</code>) hoặc lỗi thiết kế thực sự. Xem envelope trước khi sửa code.</li>
-                <li><strong>2. Exit 0:</strong> Không có lỗi severity error → Sẵn sàng phát hành (Ship).</li>
-                <li><strong>3. Exit 1:</strong> Có lỗi nghiêm trọng → Chọn <strong>Iterate</strong> (sửa code và quét lại) hoặc <strong>Escalate</strong> (báo cáo mâu thuẫn yêu cầu).</li>
-              </ul>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Turns</div>
+              <div class="orb-label-main">Max Iteration Loop</div>
             </div>
 
-            <div style="display: flex; flex-direction: column; gap: 24px;">
-              <div class="slide-card gsap-card">
-                <span class="matrix-badge">NGUYÊN TẮC VÀNG 1</span>
-                <div class="stat-label" style="margin-top: 8px;">Xác Minh Trước Khi Sửa (Verify Before Fix)</div>
-                <p class="stat-desc">Kiểm tra xem cặp màu hoặc class bị linter bắt lỗi có thực sự được render trên màn hình không trước khi vội vàng sửa đổi file token gốc.</p>
-              </div>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 Verify</div>
+              <div class="orb-label-secondary">Confirm Real Bug</div>
+            </div>
 
-              <div class="slide-card gsap-card">
-                <span class="matrix-badge">NGUYÊN TẮC VÀNG 2</span>
-                <div class="stat-label" style="margin-top: 8px;">A11y Luôn Thắng Phong Cách (A11y Always Wins)</div>
-                <p class="stat-desc">Nếu màu sắc từ yêu cầu của người dùng vi phạm độ tương phản WCAG AA, bắt buộc phải ưu tiên sửa màu A11y và báo cáo minh bạch cho người dùng.</p>
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Guess</div>
+              <div class="orb-label-tertiary">Evidence Grounded</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">TRIAGE &<br>AUTODETECT</h1>
+              <p class="radiant-body-text">Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">≤ 3</div>
+              <div class="radiant-hero-label">Turns to Convergence</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 90%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Daily Workflow • Finding Triage</div><div>13 / 28</div></footer>
-        <div data-speaker-notes="A11y luôn là tiêu chuẩn cứng không thể thỏa hiệp trong DESIGN:OS."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>13 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."></div>
       </article>
 
 <article class="slide-item" id="slide-14" data-index="14">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Design Memory</span></div>
-          <div>Hồi 4 • 13 • Recall &amp; Reflect Loop</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Vector Memory</span>
+          </div>
+          <div>14 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Bộ Nhớ Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">Design Memory Loop (Recall &amp; Reflect)</h2>
-            <p class="slide-subtitle gsap-reveal">DESIGN:OS ghi nhớ mọi kinh nghiệm thành công và bài học thất bại để AI ngày càng hoàn thiện sau mỗi phiên làm việc.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🧠</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">0.85</div>
+              <div class="orb-label-main">Cosine Similarity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">ONNX</div>
+              <div class="orb-label-secondary">Local Vector Space</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">On-Device Privacy</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableMemTitle fableMemDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="memReflect"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableMemTitle">Design Vector Memory: The Recall &amp; Reflection Distillation Loop</title>
-            <desc id="fableMemDesc">Vector manifold diagram showing the three phases of continuous design learning.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VECTOR<br>MEMORY LOOP</h1>
+              <p class="radiant-body-text">Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE RESONANT VECTOR MANIFOLD • PERSISTENT DISTILLATION LOOP</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- STEP 1: RECALL -->
-            <g id="memRecall" class="interactive-node" tabindex="0" role="button" aria-label="Step 1: Vector Recall Manifold" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">STEP 01 • VECTOR RECALL</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Recall Embedding Query</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Local ONNX Latent Space</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Quét Brief qua mô hình Vector ONNX cục bộ</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đo độ tương đồng Cosine (Cosine Similarity &ge; 0.85)</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Truy hồi 2 bài học kinh nghiệm sát nhất</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Nạp trực tiếp vào ngữ cảnh Host AI Agent</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">LATENT: Cosine Match &ge; 0.85</text>
-            </g>
-
-            <!-- STEP 2: WORK EXECUTION -->
-            <g id="memWork" class="interactive-node" tabindex="0" role="button" aria-label="Step 2: Primed Work Execution" style="cursor: pointer;">
-              <rect x="520" y="80" width="400" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="520" y="80" width="400" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="544" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">STEP 02 • WORK EXECUTION</text>
-              <circle cx="890" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Primed Synthesis</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Grounded Generation Pass</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Sinh mã giao diện với bối cảnh đã tôi luyện</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tuyệt đối không lặp lại lỗi thiết kế cũ</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Áp dụng Persona và Token chuẩn xác</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tiết kiệm hàng triệu token context window</text>
-
-              <rect x="544" y="350" width="352" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="720" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EXECUTION: Zero Regression</text>
-            </g>
-
-            <!-- STEP 3: REFLECT -->
-            <g id="memReflect" class="interactive-node" tabindex="0" role="button" aria-label="Step 3: Reflection &amp; Distillation" style="cursor: pointer;">
-              <rect x="1000" y="70" width="380" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1000" y="70" width="380" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="1190" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">STEP 03 • REFLECT &amp; DISTILL [FOCAL]</text>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Crucible Distillation</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">.design/memory.json Repository</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đúc kết bài học sau mỗi lượt giao diện thành công</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đóng băng kinh nghiệm thành JSON có cấu trúc</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cập nhật kho tri thức vĩnh cửu .design/memory.json</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khép kín chu trình tự học vô hạn của Agent</text>
-
-              <rect x="1024" y="350" width="332" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1190" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">STORAGE: .design/memory.json</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-14">
-              <span class="readout-badge">VECTOR MEMORY: ONNX READY</span>
-              <span class="readout-text" id="readout-text-slide-14">Click steps to test Recall query embedding, execution context priming, and post-task lesson distillation.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0.85</div>
+              <div class="radiant-hero-label">Recall Cosine Threshold</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Memory • Living Learning Loop</div><div>14 / 28</div></footer>
-        <div data-speaker-notes="Vòng lặp bộ nhớ đảm bảo AI không bao giờ lặp lại sai lầm trong quá khứ."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>14 / 28</div>
+        </footer>
+        <div data-speaker-notes="Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."></div>
       </article>
 
 <article class="slide-item" id="slide-15" data-index="15">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Taste Voting</span></div>
-          <div>Hồi 4 • 14 • Elo Rating &amp; Corpus Curation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 4 • Crucible</span>
+          </div>
+          <div>15 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tiến Hóa Thẩm Mỹ</span>
-            <h2 class="slide-title-h1 gsap-reveal">Taste Elo Rating &amp; Sample Curation</h2>
-            <p class="slide-subtitle gsap-reveal">Cơ chế đấu cặp Blind A/B Comparison chấm điểm Elo giúp hệ thống tự động lọc ra các biến thể thiết kế xuất sắc nhất.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🧪</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Hooks</div>
+              <div class="orb-label-main">Capture Triggers</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">1 File</div>
+              <div class="orb-label-secondary">.design/memory.json</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Dups</div>
+              <div class="orb-label-tertiary">Deduplicated Lessons</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. BLIND A/B PAIRING</span>
-              <div class="stat-label" style="margin-top: 8px;">Đấu Cặp Ẩn Danh</div>
-              <p class="stat-desc" style="margin-top: 10px;">Hệ thống bốc ngẫu nhiên 2 biến thể ứng cử viên (Candidate A vs B) được sinh cùng một đề bài.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui taste next --domain landing</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">CRUCIBLE<br>DISTILLATION</h1>
+              <p class="radiant-body-text">Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. TASTE VOTING</span>
-              <div class="stat-label" style="margin-top: 8px;">Ghi Nhận Phán Quyết</div>
-              <p class="stat-desc" style="margin-top: 10px;">Designer hoặc Curator bình chọn biến thể chiến thắng dựa trên 6+1 trục thẩm mỹ.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui taste record --winner a</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. CORPUS ADMISSION</span>
-              <div class="stat-label" style="margin-top: 8px;">Nạp Kho Mẫu Vàng</div>
-              <p class="stat-desc" style="margin-top: 10px;">Các biến thể đạt Elo rating &gt; 1200 được tự động nạp vào corpus mẫu để huấn luyện và nạp prior cho AI.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui corpus promote --id cand-09</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">100 %</div>
+              <div class="radiant-hero-label">Local Privacy Capture</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Taste Evolution • Elo Rating Matrix</div><div>15 / 28</div></footer>
-        <div data-speaker-notes="Hệ thống Elo định lượng hóa gu thẩm mỹ, giúp kho mẫu thiết kế ngày càng tinh hoa."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>15 / 28</div>
+        </footer>
+        <div data-speaker-notes="Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."></div>
       </article>
 
 <article class="slide-item" id="slide-16" data-index="16">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Color Science</span></div>
-          <div>Hồi 5 • 15 • OKLCH &amp; Perceptual Uniformity</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Color Science</span>
+          </div>
+          <div>16 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Khoa Học Màu Sắc</span>
-            <h2 class="slide-title-h1 gsap-reveal">OKLCH Mathematics, P3 Gamut &amp; Delta EOK</h2>
-            <p class="slide-subtitle gsap-reveal">Why DESIGN:OS deprecates legacy HSL/Hex in favor of the perceptually uniform OKLCH color space.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌈</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">360°</div>
+              <div class="orb-label-main">Perceptual Uniformity</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">P3</div>
+              <div class="orb-label-secondary">Wide Color Gamut</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≤ 0.02</div>
+              <div class="orb-label-tertiary">Patch Semver Limit</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableColorTitle fableColorDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="ltr"
-            data-focal-id="colorOKLCH"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableColorTitle">Color Science: OKLCH &amp; Display P3 Perceptual Uniformity</title>
-            <desc id="fableColorDesc">Color gamut architecture diagram illustrating legacy HSL non-linear brightness distortion, uniform OKLCH perceived lightness across all 360-degree hues, and mathematical Semver breaking changes via Delta EOK calipers.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">OKLCH COLOR<br>SCIENCE</h1>
+              <p class="radiant-body-text">Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE POLARIZED OPTICAL CHAMBER • OKLCH COLOR SCIENCE &amp; DELTA E PRECISION</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="5" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="2.5" stroke-dasharray="8 6" />
-
-            <!-- CHAMBER 1: HSL -->
-            <g id="colorHSL" class="interactive-node" tabindex="0" role="button" aria-label="Legacy HSL Flaw" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-muted)" letter-spacing="0.08em">LEGACY COLOR • HSL / sRGB</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-muted)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">HSL Perceptual Flaw</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Non-Linear Human Optical Perception</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Vàng L=50% sáng gấp 3 lần Xanh L=50%</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đổi tông màu (Hue) làm vỡ độ tương phản</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Chỉ bao phủ không gian màu hẹp sRGB</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Ảo giác toán học không đáng tin cậy</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-muted)" text-anchor="middle">FLAW: Inconsistent Luminance</text>
-            </g>
-
-            <!-- CHAMBER 2: OKLCH -->
-            <g id="colorOKLCH" class="interactive-node" tabindex="0" role="button" aria-label="OKLCH Color Science" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">OKLCH SCIENCE • DISPLAY P3 [FOCAL]</text>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">OKLCH Uniformity</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Perceptually Constant Lightness L</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Độ sáng cảm nhận L=0.7 đồng đều mọi góc Hue</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động bảo đảm chuẩn tương phản WCAG 2.2</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Khai thác 100% dải màu siêu rộng Display P3</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tích hợp trực tiếp lệnh CLI: ui color scale</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">STANDARD: 100% P3 Color Gamut</text>
-            </g>
-
-            <!-- CHAMBER 3: SEMVER DELTA -->
-            <g id="colorDelta" class="interactive-node" tabindex="0" role="button" aria-label="Delta EOK Semver Precision" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">SEMVER DELTA • ΔEOK</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">ΔEOK Precision Meter</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Mathematical Semver Versioning</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ΔEOK &gt; 0.05: Thay đổi lớn (MAJOR Breaking)</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• 0.02 &lt; ΔEOK &le; 0.05: Bổ sung (MINOR Additive)</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• ΔEOK &le; 0.02: Vi chỉnh không lệch mắt (PATCH)</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đánh giá khách quan, loại bỏ tranh cãi cảm tính</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">CALIPER: Precise Semver Gate</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-16">
-              <span class="readout-badge">COLOR MATH: OKLCH / P3</span>
-              <span class="readout-text" id="readout-text-slide-16">Inspect why OKLCH delivers uniform perceptual lightness L across all hues and how ΔEOK enforces Semver breaking color changes.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">ΔE 0.02</div>
+              <div class="radiant-hero-label">Semver Patch Precision</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Color Science • OKLCH Space &amp; Delta EOK</div><div>16 / 28</div></footer>
-        <div data-speaker-notes="OKLCH Color Mathematics bảo đảm mọi thang bậc sáng đều có cùng độ tương phản mắt thấy."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>16 / 28</div>
+        </footer>
+        <div data-speaker-notes="Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."></div>
       </article>
 
 <article class="slide-item" id="slide-17" data-index="17">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Taste Rubric</span></div>
-          <div>Hồi 5 • 16 • 6+1 Craft Axes</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Taste Rubric</span>
+          </div>
+          <div>17 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tiêu Chuẩn Thẩm Mỹ</span>
-            <h2 class="slide-title-h1 gsap-reveal">6+1 Aesthetic Axes (Taste Rubric)</h2>
-            <p class="slide-subtitle gsap-reveal">Scoring every axis from 0 to 10. AI synthesizes layouts against these principles, and Curator enforces compliance.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎯</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6+1</div>
+              <div class="orb-label-main">Heptagonal Axes</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">Core 0</div>
+              <div class="orb-label-secondary">Consistency Mandate</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">≥ 8.0</div>
+              <div class="orb-label-tertiary">Release Quality Floor</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableTasteTitle fableTasteDesc"
-            data-diagram-grammar="architecture"
-            data-reading-order="hub"
-            data-focal-id="tasteCore7"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableTasteTitle">The 6+1 Taste Rubric Craft Radar Matrix</title>
-            <desc id="fableTasteDesc">Heptagonal craft resonator radar diagram evaluating generated UI against Consistency Core 7 and the 6 aesthetic axes.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">6+1 TASTE<br>RUBRIC RADAR</h1>
+              <p class="radiant-body-text">Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE HEPTAGONAL CRAFT RESONATOR • 6+1 TASTE RUBRIC FLOOR (ui taste-lint)</text>
-
-            <circle cx="720" cy="260" r="160" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-            <circle cx="720" cy="260" r="110" fill="none" stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4 4"/>
-            <circle cx="720" cy="260" r="60" fill="none" stroke="var(--border-strong)" stroke-width="1.5"/>
-
-            <line x1="720" y1="260" x2="720" y2="80" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="880" y2="170" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="880" y2="350" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="720" y2="440" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="560" y2="350" stroke="var(--border-strong)" stroke-width="1.5"/>
-            <line x1="720" y1="260" x2="560" y2="170" stroke="var(--border-strong)" stroke-width="1.5"/>
-
-            <!-- CENTER CORE -->
-            <g id="tasteCore7" class="interactive-node" tabindex="0" role="button" aria-label="Core Axis: Consistency" style="cursor: pointer;">
-              <circle cx="720" cy="260" r="54" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <circle cx="720" cy="260" r="46" fill="var(--text-primary)"/>
-              <text x="720" y="254" font-family="var(--font-mono)" font-size="11" font-weight="900" fill="var(--text-inverse)" text-anchor="middle">CORE 0</text>
-              <text x="720" y="272" font-family="var(--font-sans)" font-size="12" font-weight="800" fill="var(--text-inverse)" text-anchor="middle">Consistency</text>
-            </g>
-
-            <!-- AXES -->
-            <g id="tasteAxis1" class="interactive-node" tabindex="0" role="button" aria-label="Axis 1: Layout &amp; Hierarchy" style="cursor: pointer;">
-              <rect x="620" y="70" width="200" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="720" y="96" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">01 • LAYOUT &amp; HIERARCHY</text>
-              <text x="720" y="118" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Reading Order (Score: 9.0)</text>
-            </g>
-
-            <g id="tasteAxis2" class="interactive-node" tabindex="0" role="button" aria-label="Axis 2: Typography &amp; Rhythm" style="cursor: pointer;">
-              <rect x="910" y="140" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="1015" y="166" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">02 • TYPOGRAPHY</text>
-              <text x="1015" y="188" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Modular Scale (Score: 8.8)</text>
-            </g>
-
-            <g id="tasteAxis3" class="interactive-node" tabindex="0" role="button" aria-label="Axis 3: Spacing &amp; Geometry" style="cursor: pointer;">
-              <rect x="910" y="320" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="1015" y="346" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">03 • SPACING</text>
-              <text x="1015" y="368" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">8px Rhythm (Score: 9.2)</text>
-            </g>
-
-            <g id="tasteAxis4" class="interactive-node" tabindex="0" role="button" aria-label="Axis 4: Iconography &amp; Badges" style="cursor: pointer;">
-              <rect x="620" y="410" width="200" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="720" y="436" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">04 • ICONOGRAPHY</text>
-              <text x="720" y="458" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Single Family (Score: 9.5)</text>
-            </g>
-
-            <g id="tasteAxis5" class="interactive-node" tabindex="0" role="button" aria-label="Axis 5: Motion Ladder" style="cursor: pointer;">
-              <rect x="320" y="320" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="425" y="346" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">05 • MOTION LADDER</text>
-              <text x="425" y="368" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">T5 Choreography (Score: 9.0)</text>
-            </g>
-
-            <g id="tasteAxis6" class="interactive-node" tabindex="0" role="button" aria-label="Axis 6: Depth &amp; Surfaces" style="cursor: pointer;">
-              <rect x="320" y="140" width="210" height="60" rx="12" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <text x="425" y="166" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" text-anchor="middle">06 • DEPTH &amp; SURFACES</text>
-              <text x="425" y="188" font-family="var(--font-sans)" font-size="14" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Tonal Elevation (Score: 9.0)</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-17">
-              <span class="readout-badge">RADAR SCAN: 6+1 AXES</span>
-              <span class="readout-text" id="readout-text-slide-17">Click axes or press Scan to inspect individual craft score thresholds (Consistency 10/10, Layout & Typo >= 8.0).</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">8.0 +</div>
+              <div class="radiant-hero-label">Minimum Score to Ship</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 80%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Quality Floor • The 6+1 Taste Rubric</div><div>17 / 28</div></footer>
-        <div data-speaker-notes="Mô hình 6+1 trục thẩm mỹ: Consistency là lõi bất biến, 6 trục vệ tinh định hình vẻ đẹp thị giác."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>17 / 28</div>
+        </footer>
+        <div data-speaker-notes="A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."></div>
       </article>
 
 <article class="slide-item" id="slide-18" data-index="18">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Machine Floor</span></div>
-          <div>Hồi 5 • 17 • 14 Hard Linter Rules</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • UX Laws</span>
+          </div>
+          <div>18 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Sàn Chất Lượng Tất Định</span>
-            <h2 class="slide-title-h1 gsap-reveal">14 Hard Machine Floor Linters</h2>
-            <p class="slide-subtitle gsap-reveal">Các linter <code>taste-lint</code>, <code>validate-layout</code>, <code>content-lint</code> tự động phát hiện và chặn đứng các lỗi AI code rác.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📐</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">CHUYỂN ĐỘNG &amp; LAYOUT SAFETY</span>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 14px;">
-                <li><code>no-transition-all</code>: Cấm dùng transition: all gây drop FPS.</li>
-                <li><code>no-layout-keyframes</code>: Cấm animate top, left, width, height.</li>
-                <li><code>require-reduced-motion</code>: Bắt buộc có media query giảm chuyển động.</li>
-                <li><code>no-100vw-scroll</code>: Cấm w-[100vw] gây thanh cuộn ngang khó chịu.</li>
-                <li><code>no-root-overflow-hidden</code>: Cấm overflow-x: hidden ở thẻ html/body làm liệt sticky.</li>
-              </ul>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">12 Laws</div>
+              <div class="orb-label-main">Cognitive Standards</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">TYPOGRAPHY &amp; NỘI DUNG UX</span>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.8; margin-top: 14px;">
-                <li><code>min-body-font</code>: Cấm font chữ body nhỏ hơn 16px.</li>
-                <li><code>no-font-scale-sprawl</code>: Cảnh báo &gt; 7 cỡ font tự chế, chặn khi &gt; 10 cỡ.</li>
-                <li><code>no-italic-headings</code>: Cấm tiêu đề display dùng font chữ nghiêng.</li>
-                <li><code>no-pure-black-shadow</code>: Cấm bóng đổ đen tuyệt đối rgba(0,0,0,...).</li>
-                <li><code>no-placeholder-copy</code>: Cấm văn bản rác vô nghĩa, tên giả vô định, link rỗng.</li>
-              </ul>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">≥ 44px</div>
+              <div class="orb-label-secondary">Fitts Law Tap Target</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">7 ± 2</div>
+              <div class="orb-label-tertiary">Miller Chunking Limit</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">12 COGNITIVE<br>UX LAWS</h1>
+              <p class="radiant-body-text">Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">12</div>
+              <div class="radiant-hero-label">Enforced Ergonomic Laws</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Quality Floor • 14 Machine Rules</div><div>18 / 28</div></footer>
-        <div data-speaker-notes="14 luật máy là sàn an toàn tuyệt đối, ngăn chặn hoàn toàn code rác từ LLM."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>18 / 28</div>
+        </footer>
+        <div data-speaker-notes="UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."></div>
       </article>
 
 <article class="slide-item" id="slide-19" data-index="19">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>UX Psychology</span></div>
-          <div>Hồi 5 • 18 • 12 Cognitive Laws</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 5 • Personas</span>
+          </div>
+          <div>19 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tâm Lý Học Thiết Kế</span>
-            <h2 class="slide-title-h1 gsap-reveal">12 Classical Cognitive UX Laws</h2>
-            <p class="slide-subtitle gsap-reveal">Giao diện đẹp phải đi đôi với sự thuận tự nhiên của não bộ. DESIGN:OS tích hợp trực tiếp các định luật nhận thức.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎭</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">11 Personas</div>
+              <div class="orb-label-main">Curated Families</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">5 Slugs</div>
+              <div class="orb-label-secondary">Contrasting Stances</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Cliché</div>
+              <div class="orb-label-tertiary">Banned Tropes</div>
+            </div>
           </div>
 
-          <div class="slide-grid-4">
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">FITTS'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Mục Tiêu &amp; Khoảng Cách</div>
-              <p class="stat-desc" style="font-size: 14px;">Touch target tối thiểu 44px; nút CTA chính đặt ở vị trí ngón tay chạm nhanh nhất.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DESIGN<br>PERSONAS</h1>
+              <p class="radiant-body-text">11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.</p>
             </div>
 
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">HICK'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Thời Gian Ra Quyết Định</div>
-              <p class="stat-desc" style="font-size: 14px;">Giảm bớt tùy chọn để tăng tốc độ chọn lựa; gom nhóm hành vi theo từng cấp bậc.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">MILLER'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Giới Hạn 7±2 Khối Nhớ</div>
-              <p class="stat-desc" style="font-size: 14px;">Phân đoạn thông tin thành các cụm (chunking) từ 5 đến 9 phần tử trong một tầm nhìn.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">DOHERTY THRESHOLD</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Ngưỡng Phản Hồi 400ms</div>
-              <p class="stat-desc" style="font-size: 14px;">Mọi tương tác click/hover phải phản hồi thị giác trong vòng dưới 400ms để giữ sự tập trung.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">ZEIGARNIK EFFECT</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Thanh Tiến Trình Dang Dở</div>
-              <p class="stat-desc" style="font-size: 14px;">Bộ não luôn bị thôi thúc hoàn thành các tác vụ dở dang; áp dụng cho onboarding steps.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">JAKOB'S LAW</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Kỳ Vọng Thói Quen Cũ</div>
-              <p class="stat-desc" style="font-size: 14px;">Người dùng dành phần lớn thời gian trên web khác; giữ nguyên các quy ước điều hướng quen thuộc.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">VON RESTORFF</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Hiệu Ứng Nổi Bật Độc Bản</div>
-              <p class="stat-desc" style="font-size: 14px;">Phần tử có hình dáng khác biệt nhất (như thẻ Pricing Recommended) sẽ được ghi nhớ sâu nhất.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="padding: 20px;">
-              <span class="matrix-badge">SERIAL POSITION</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 6px;">Hiệu Ứng Đầu &amp; Cuối</div>
-              <p class="stat-desc" style="font-size: 14px;">Người dùng nhớ nhất mục đầu tiên và mục cuối cùng của thanh menu hay danh sách tính năng.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">11</div>
+              <div class="radiant-hero-label">Bespoke Design Personas</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 90%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS UX Psychology • Cognitive Design Laws</div><div>19 / 28</div></footer>
-        <div data-speaker-notes="12 định luật UX định hình cách tổ chức giao diện thuận theo tự nhiên của nhận thức con người."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>19 / 28</div>
+        </footer>
+        <div data-speaker-notes="Explicit persona declarations prevent generic corporate dashboard syndrome."></div>
       </article>
 
 <article class="slide-item" id="slide-20" data-index="20">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Motion Ladder</span></div>
-          <div>Hồi 6 • 19 • The 6 Motion Tiers</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Motion Ladder</span>
+          </div>
+          <div>20 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">The Motion Ladder</span>
-            <h2 class="slide-title-h1 gsap-reveal">6-Tier Motion Ladder (T1–T6)</h2>
-            <p class="slide-subtitle gsap-reveal">Chỉ nâng lên bậc chuyển động cao hơn khi câu chuyện thiết kế thực sự đòi hỏi và ngân sách hiệu năng cho phép.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">⚡</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Tiers</div>
+              <div class="orb-label-main">T1 to T6 Standards</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">60 FPS</div>
+              <div class="orb-label-secondary">Frame Budget</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">Reduced Motion Safe</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T1 • MICRO-FEEDBACK</span>
-              <div class="stat-label" style="margin-top: 8px;">Hover &amp; Active States</div>
-              <p class="stat-desc">CSS transition 150-200ms trên <code>transform</code> và <code>opacity</code>. Phản hồi bấm nút, hover thẻ. Zero bundle cost.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">THE MOTION<br>LADDER</h1>
+              <p class="radiant-body-text">Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T2 • STATE TRANSITION</span>
-              <div class="stat-label" style="margin-top: 8px;">Chuyển Đổi Trạng Thái</div>
-              <p class="stat-desc">Mở Modal, bung Accordion, hoán đổi Tabs. Sử dụng CSS transitions kết hợp ARIA expanded.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T3 • ENTRANCE REVEAL</span>
-              <div class="stat-label" style="margin-top: 8px;">Scroll-Driven CSS</div>
-              <p class="stat-desc">Hiệu ứng xuất hiện khi cuộn trang bằng native CSS <code>animation-timeline: view()</code>. Không tốn Javascript.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T4 • LAYOUT CHOREO</span>
-              <div class="stat-label" style="margin-top: 8px;">FLIP Layout Animation</div>
-              <p class="stat-desc">Tái sắp xếp lưới sản phẩm, mở rộng thẻ chi tiết bằng kỹ thuật FLIP không gây giật khung hình.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T5 • GSAP SCROLLTRIGGER</span>
-              <div class="stat-label" style="margin-top: 8px;">Biên Đạo Thời Gian</div>
-              <p class="stat-desc">Ghim khung hình (Pinning), scrub tiến trình cuộn, phối hợp timeline đa tầng phức tạp cho landing page.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">T6 • AUTHORING &amp; 3D</span>
-              <div class="stat-label" style="margin-top: 8px;">Scroll-Cinema &amp; WebGL</div>
-              <p class="stat-desc">Cuộn phim 3D không gian, WebGL shaders, camera flight đa phân đoạn qua GFlow hand.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">60 FPS</div>
+              <div class="radiant-hero-label">Locked Kinetic Budget</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Motion Ladder • Tiered Kinetic Standards</div><div>20 / 28</div></footer>
-        <div data-speaker-notes="Thang bậc chuyển động giúp kiểm soát hiệu năng: chỉ leo lên T6 khi thực sự cần trải nghiệm điện ảnh."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>20 / 28</div>
+        </footer>
+        <div data-speaker-notes="Animations must serve narrative purpose. Decorative motion without function is classified as code debt."></div>
       </article>
 
 <article class="slide-item" id="slide-21" data-index="21">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Scroll-Cinema</span></div>
-          <div>Hồi 6 • 20 • Seam Physics &amp; Continuous Take</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Scroll Cinema</span>
+          </div>
+          <div>21 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Điện Ảnh Cuộn Trang</span>
-            <h2 class="slide-title-h1 gsap-reveal">Scroll-Cinema: The Art of Seamless Camera Flight</h2>
-            <p class="slide-subtitle gsap-reveal">Chaining separately rendered video clips into a single continuous take driven directly by scroll gestures.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🎬</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Legs</div>
+              <div class="orb-label-main">Camera Waypoints</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">2 Seams</div>
+              <div class="orb-label-secondary">Kinetic Joint Locks</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Stutter</div>
+              <div class="orb-label-tertiary">Zero Rewind Match</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fableCinemaTitle fableCinemaDesc"
-            data-diagram-grammar="sequence"
-            data-reading-order="ltr"
-            data-focal-id="cinemaLeg2"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fableCinemaTitle">Scroll-Cinema: The 3-Leg Continuous Camera Flight with Kinetic Seam Physics</title>
-            <desc id="fableCinemaDesc">Continuous camera flight sequence diagram showing Leg 1 Hero Orbit, Leg 2 Exploded View, and Leg 3 Macro Core connected via frame-locked velocity seams guaranteeing zero-rewind stutter.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">SCROLL-CINEMA<br>FLIGHT</h1>
+              <p class="radiant-body-text">Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE CONTINUOUS FLIGHT PATH • ZERO-REWIND SCROLL-CINEMA SEAM PHYSICS</text>
-
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 440 250 L 520 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="8 6" />
-
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--border-strong)" stroke-width="6" stroke-linecap="round"/>
-            <path d="M 920 250 L 1000 250" fill="none" stroke="var(--text-primary)" stroke-width="3" stroke-dasharray="8 6" />
-
-            <rect x="440" y="210" width="80" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="480" y="225" font-family="var(--font-mono)" font-size="9" font-weight="800" fill="var(--text-primary)" text-anchor="middle">SEAM 1: LOCK</text>
-
-            <rect x="920" y="210" width="80" height="22" rx="11" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-            <text x="960" y="225" font-family="var(--font-mono)" font-size="9" font-weight="800" fill="var(--text-primary)" text-anchor="middle">SEAM 2: LOCK</text>
-
-            <!-- LEG 1 -->
-            <g id="cinemaLeg1" class="interactive-node" tabindex="0" role="button" aria-label="Leg 1: Hero Orbit" style="cursor: pointer;">
-              <rect x="60" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="60" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="84" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">LEG 01 • SPATIAL ORBIT</text>
-              <circle cx="410" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="84" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Hero Spatial Orbit</text>
-              <text x="84" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">360&deg; Camera Spatial Path</text>
-              <line x1="84" y1="205" x2="416" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="84" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Camera quay quanh vật thể 3D sản phẩm</text>
-              <text x="84" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tốc độ cuộn Scrub đồng bộ 60fps mượt mà</text>
-              <text x="84" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tọa độ đích: Khóa vị trí Seam 1 (Delta = 0)</text>
-              <text x="84" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Kết thúc tại góc nhìn trực diện chuẩn bị nổ</text>
-
-              <rect x="84" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="250" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PHYSICS: 60 FPS Interpolation</text>
-            </g>
-
-            <!-- LEG 2 (FOCAL) -->
-            <g id="cinemaLeg2" class="interactive-node" tabindex="0" role="button" aria-label="Leg 2: Exploded View" style="cursor: pointer;">
-              <rect x="520" y="70" width="400" height="360" rx="18" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="520" y="70" width="400" height="48" rx="18" fill="var(--text-primary)"/>
-              <text x="720" y="100" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-inverse)" letter-spacing="0.1em" text-anchor="middle">LEG 02 • EXPLODED VIEW [FOCAL]</text>
-
-              <text x="544" y="160" font-family="var(--font-sans)" font-size="22" font-weight="900" fill="var(--text-primary)">Exploded Z-Disassembly</text>
-              <text x="544" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Internal Component Separation</text>
-              <line x1="544" y1="205" x2="896" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="544" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tách lớp linh kiện dọc theo trục sâu Z-axis</text>
-              <text x="544" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Seam 1 &rarr; Seam 2: Vận tốc vector khớp 100%</text>
-              <text x="544" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Triệt tiêu hoàn toàn hiện tượng giật cục (Stutter)</text>
-              <text x="544" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Cảm giác cinematic điện ảnh đẳng cấp cao</text>
-
-              <rect x="544" y="350" width="352" height="46" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="720" y="378" font-family="var(--font-mono)" font-size="13" font-weight="800" fill="var(--text-primary)" letter-spacing="0.04em" text-anchor="middle">SEAM QUALITY: Zero-Rewind Lock</text>
-            </g>
-
-            <!-- LEG 3 -->
-            <g id="cinemaLeg3" class="interactive-node" tabindex="0" role="button" aria-label="Leg 3: Macro 2K Core" style="cursor: pointer;">
-              <rect x="1000" y="80" width="380" height="340" rx="16" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="1000" y="80" width="380" height="44" rx="16" fill="var(--bg-surface-raised)"/>
-              <text x="1024" y="108" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" letter-spacing="0.08em">LEG 03 • MACRO 2K ZOOM</text>
-              <circle cx="1350" cy="102" r="6" fill="var(--text-primary)"/>
-
-              <text x="1024" y="160" font-family="var(--font-sans)" font-size="20" font-weight="800" fill="var(--text-primary)">Macro Core 2K Flight</text>
-              <text x="1024" y="180" font-family="var(--font-mono)" font-size="12" fill="var(--text-muted)">Sub-Pixel Micro-Texture Dive</text>
-              <line x1="1024" y1="205" x2="1356" y2="205" stroke="var(--border-subtle)" stroke-width="1"/>
-
-              <text x="1024" y="235" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Camera lao sâu vào bề mặt vi cấu trúc chip</text>
-              <text x="1024" y="265" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Hiển thị vân kim loại và chi tiết máy cực nét</text>
-              <text x="1024" y="295" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Đáp an toàn xuống vị trí CTA chuyển đổi</text>
-              <text x="1024" y="325" font-family="var(--font-sans)" font-size="14" fill="var(--text-secondary)">• Tự động dừng mượt mà khi người dùng ngừng cuộn</text>
-
-              <rect x="1024" y="350" width="332" height="42" rx="8" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1190" y="376" font-family="var(--font-mono)" font-size="12" font-weight="700" fill="var(--text-primary)" text-anchor="middle">RESOLUTION: 2K Sub-Pixel Flight</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-21">
-              <span class="readout-badge">SEAM PHYSICS: VERIFIED</span>
-              <span class="readout-text" id="readout-text-slide-21">Test 3-leg continuous camera flight: Seam 1 (Position match) and Seam 2 (Velocity vector lock) zero-rewind guarantee.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">0 ms</div>
+              <div class="radiant-hero-label">Seam Handoff Stutter</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Scroll-Cinema • The Seam Physics Contract</div><div>21 / 28</div></footer>
-        <div data-speaker-notes="Mối nối (Seam) là sản phẩm: đảm bảo tính liên tục về vị trí và vận tốc để người xem cảm nhận như 1 cú máy one-take duy nhất."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>21 / 28</div>
+        </footer>
+        <div data-speaker-notes="Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."></div>
       </article>
 
 <article class="slide-item" id="slide-22" data-index="22">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>GFlow Hand</span></div>
-          <div>Hồi 6 • 21 • Google Flow Automation</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • 3D GFlow</span>
+          </div>
+          <div>22 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tự Động Hóa Video AI</span>
-            <h2 class="slide-title-h1 gsap-reveal">GFlow Hand: Google Flow Automation (Veo / Imagen)</h2>
-            <p class="slide-subtitle gsap-reveal">Điều khiển Google Flow qua Playwright với cơ chế an toàn <strong>Verify-then-Spend</strong> bảo vệ số dư tài khoản.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌐</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 Canvas</div>
+              <div class="orb-label-main">Hardware Accelerated</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">2K Texture</div>
+              <div class="orb-label-secondary">Subpixel Detail</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Memory</div>
+              <div class="orb-label-tertiary">Lifecycle Teardown</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. THE GOLDEN PATH</span>
-              <div class="stat-label" style="margin-top: 8px;">ui gflow i2v</div>
-              <p class="stat-desc" style="margin-top: 10px;">Lệnh an toàn duy nhất: sinh video từ ảnh, kiểm tra tải file MP4 thật, tự trích xuất last frame qua ffmpeg.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ui gflow i2v "flight..." --initial-frame seed.png</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">3D SPATIAL<br>GFLOW</h1>
+              <p class="radiant-body-text">Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. VERIFY-THEN-SPEND</span>
-              <div class="stat-label" style="margin-top: 8px;">Chống Rơi Render</div>
-              <p class="stat-desc" style="margin-top: 10px;">Không bao giờ gọi lệnh <code>chain</code> mù quáng. Mỗi phân đoạn phải tải về thành công trước khi sinh đoạn tiếp theo.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>DOWNLOAD_MISSING → Recovery Plan</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. WEBP CONVERSION</span>
-              <div class="stat-label" style="margin-top: 8px;">Trích Xuất Khung Hình</div>
-              <p class="stat-desc" style="margin-top: 10px;">Chuyển đổi MP4 thành chuỗi WebP nén chất lượng cao sẵn sàng cho Canvas Scrubbing mượt mà trên mobile.</p>
-              <div class="code-terminal" style="padding: 10px; margin-top: 12px; font-size: 13px;">
-                <code>ffmpeg -i clip.mp4 frame_%04d.webp</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">2 K</div>
+              <div class="radiant-hero-label">Subpixel Texture Resolution</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 85%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS GFlow Hand • Automated Video Pipeline</div><div>22 / 28</div></footer>
-        <div data-speaker-notes="GFlow Hand tự động hóa quy trình sinh video phức tạp bằng phương pháp verify-then-spend an toàn."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>22 / 28</div>
+        </footer>
+        <div data-speaker-notes="All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."></div>
       </article>
 
 <article class="slide-item" id="slide-23" data-index="23">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Canvas UI</span></div>
-          <div>Hồi 6 • 22 • Shaders &amp; Teardown Contract</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Visual Regression</span>
+          </div>
+          <div>23 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đồ Họa Bậc Cao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Canvas T6 &amp; WebGL Shaders: Liquid Glass &amp; Teardown Contract</h2>
-            <p class="slide-subtitle gsap-reveal">Hiệu ứng bề mặt chất liệu cao cấp nhưng tuyệt đối tuân thủ ngân sách hiệu năng 60 FPS và dọn dẹp bộ nhớ.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📸</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Screens</div>
+              <div class="orb-label-main">Desktop / Laptop / Mobile</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Drift</div>
+              <div class="orb-label-secondary">Pixel Hash Match</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">CI Headless Test</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">1. ONE-EFFECT CAP</span>
-              <div class="stat-label" style="margin-top: 8px;">Giới Hạn 1 Hiệu Ứng</div>
-              <p class="stat-desc" style="margin-top: 10px;">Chỉ được phép có duy nhất 1 hiệu ứng Canvas T6 trên toàn trang (ví dụ: Liquid Glass hoặc Particle Mesh).</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">VISUAL<br>REGRESSION</h1>
+              <p class="radiant-body-text">Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">2. TEARDOWN CONTRACT</span>
-              <div class="stat-label" style="margin-top: 8px;">Hợp Đồng Dọn Dẹp</div>
-              <p class="stat-desc" style="margin-top: 10px;">Bắt buộc phải hủy <code>cancelAnimationFrame</code>, giải phóng WebGL contexts và dọn sạch Event Listeners khi unmount.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">3. 60 FPS PERFORMANCE FLOOR</span>
-              <div class="stat-label" style="margin-top: 8px;">Sàn Hiệu Năng 60 FPS</div>
-              <p class="stat-desc" style="margin-top: 10px;">Giới hạn kích thước render buffer theo DPR tối đa 2; tự động hạ cấp xuống ảnh tĩnh trên thiết bị yếu.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">3 / 3</div>
+              <div class="radiant-hero-label">Viewports Verified</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Canvas UI • T6 Engineering Standard</div><div>23 / 28</div></footer>
-        <div data-speaker-notes="Canvas T6 chỉ được kích hoạt khi có lý do chính đáng và bắt buộc phải có teardown function để tránh rò rỉ bộ nhớ."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>23 / 28</div>
+        </footer>
+        <div data-speaker-notes="Automated headless Playwright sweeps catch subtle overflow and clipping before human review."></div>
       </article>
 
 <article class="slide-item" id="slide-24" data-index="24">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Qualified Delivery</span></div>
-          <div>Hồi 7 • 23 • Release Verification</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 6 • Taste Voting</span>
+          </div>
+          <div>24 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Qualified Delivery Contract v2</h2>
-            <p class="slide-subtitle gsap-reveal">Biến việc sinh UI thành quy trình phát hành có bằng chứng kiểm định rõ ràng (Evidence-based release).</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏆</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">100%</div>
+              <div class="orb-label-main">Compounded Taste</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">N Variants</div>
+              <div class="orb-label-secondary">Parallel Generation</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">1 Winner</div>
+              <div class="orb-label-tertiary">Highest Scoring PR</div>
+            </div>
           </div>
 
-          <div class="slide-grid-4">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 1 • BRIEF</span>
-              <div class="stat-label" style="margin-top: 10px;">design-brief.json</div>
-              <p class="stat-desc">Biến yêu cầu sơ khai thành hợp đồng nghiệp vụ: đối tượng, mục tiêu, tuyên bố bị cấm.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">COMPOUNDED<br>CRAFT REFLECTION</h1>
+              <p class="radiant-body-text">Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 2 • CONTRACT</span>
-              <div class="stat-label" style="margin-top: 10px;">generation-contract.json</div>
-              <p class="stat-desc">Khai báo 3 hướng cấu trúc, nhiệm vụ từng vùng, hình ảnh và icon Phosphor bắt buộc.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 3 • EVIDENCE</span>
-              <div class="stat-label" style="margin-top: 10px;">Renders 1440 / 768 / 390</div>
-              <p class="stat-desc">Sinh candidate và chụp ảnh render thực tế ở cả 3 kích thước Desktop, Tablet và Mobile.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 4 • VERDICT</span>
-              <div class="stat-label" style="margin-top: 10px;">QUALIFIED</div>
-              <p class="stat-desc">Curator đối chiếu bằng chứng. Đạt 100% gates → Phát hành; Thiếu sót → DRAFT_WITH_CONCERNS.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">10 X</div>
+              <div class="radiant-hero-label">Design Team Velocity</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 95%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Qualified Delivery v2</div><div>24 / 28</div></footer>
-        <div data-speaker-notes="Trạng thái QUALIFIED bắt buộc phải có bằng chứng render thực tế cả 3 viewport, không thể nói suông."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>24 / 28</div>
+        </footer>
+        <div data-speaker-notes="Compounding craft transforms single-use generations into permanent organizational capability."></div>
       </article>
 
 <article class="slide-item" id="slide-25" data-index="25">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Full-Stack Audit</span></div>
-          <div>Hồi 7 • 24 • The 6-Step Audit Pipeline</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Delivery Pipeline</span>
+          </div>
+          <div>25 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Quy Trình Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">The Mandatory 6-Step Full-Stack Audit Pipeline</h2>
-            <p class="slide-subtitle gsap-reveal">Thứ tự thực thi mang tính quyết định: chạy sai thứ tự sẽ dẫn đến kết quả kiểm định sai lệch.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🚀</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">6 Stages</div>
+              <div class="orb-label-main">Ordered Pipeline</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">100%</div>
+              <div class="orb-label-secondary">Static & Rendered</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">0 Bypass</div>
+              <div class="orb-label-tertiary">Strict CI Gates</div>
+            </div>
           </div>
 
-          <div class="diagram-container gsap-card">
-          <svg viewBox="0 0 1440 500" width="100%" height="100%" class="diagram-svg"
-            role="img" aria-labelledby="fablePipeTitle fablePipeDesc"
-            data-diagram-grammar="sequence"
-            data-reading-order="ltr"
-            data-focal-id="pipeStep6"
-            data-source-kind="brief"
-            data-token-fallback="false"
-            xmlns="http://www.w3.org/2000/svg">
-            <title id="fablePipeTitle">The 6-Step Full-Stack Delivery Pipeline</title>
-            <desc id="fablePipeDesc">Sequential delivery pipeline diagram executing verification gates in exact defect-catching order.</desc>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">DELIVERY<br>PIPELINE</h1>
+              <p class="radiant-body-text">The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.</p>
+            </div>
 
-            <rect x="20" y="20" width="1400" height="460" rx="20" fill="var(--bg-base)" stroke="var(--border-subtle)" stroke-width="1.5" stroke-dasharray="8 8"/>
-            <text x="50" y="52" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-muted)" letter-spacing="0.14em">THE 6-STAGE FRACTIONAL REFINERY • ORDERED QUALITY GATES</text>
-
-            <!-- Step 1 -->
-            <g id="pipeStep1" class="interactive-node" tabindex="0" role="button" aria-label="Step 1: Flow Lint" style="cursor: pointer;">
-              <rect x="40" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="40" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="145" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 01 • FLOW</text>
-              <text x="145" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Flow Lint</text>
-              <text x="145" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui flow lint</text>
-              <line x1="56" y1="195" x2="234" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="56" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Bắt lỗi cụt (dead-end)</text>
-              <text x="56" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét unreachable</text>
-              <text x="56" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Đủ trạng thái error</text>
-              <rect x="56" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="145" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">FLOW PASS</text>
-            </g>
-
-            <!-- Step 2 -->
-            <g id="pipeStep2" class="interactive-node" tabindex="0" role="button" aria-label="Step 2: User Evidence" style="cursor: pointer;">
-              <rect x="270" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="270" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="375" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 02 • EVIDENCE</text>
-              <text x="375" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">User Evidence</text>
-              <text x="375" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui evidence</text>
-              <line x1="286" y1="195" x2="464" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="286" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Khảo sát người dùng</text>
-              <text x="286" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Dữ liệu định tính</text>
-              <text x="286" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Trọng số chuyển đổi</text>
-              <rect x="286" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="375" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">EVIDENCE OK</text>
-            </g>
-
-            <!-- Step 3 -->
-            <g id="pipeStep3" class="interactive-node" tabindex="0" role="button" aria-label="Step 3: VR Baseline" style="cursor: pointer;">
-              <rect x="500" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="500" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="605" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 03 • VR GATE</text>
-              <text x="605" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">VR Baseline</text>
-              <text x="605" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui vr gate</text>
-              <line x1="516" y1="195" x2="694" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="516" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét ảnh 3 Viewports</text>
-              <text x="516" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• 1920 Desktop, Mobile</text>
-              <text x="516" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• So sánh pixel diff</text>
-              <rect x="516" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="605" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">VR MATCH 100%</text>
-            </g>
-
-            <!-- Step 4 -->
-            <g id="pipeStep4" class="interactive-node" tabindex="0" role="button" aria-label="Step 4: Paired Tokens" style="cursor: pointer;">
-              <rect x="730" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="730" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="835" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 04 • PAIRS</text>
-              <text x="835" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">Paired Tokens</text>
-              <text x="835" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui paired-tokens</text>
-              <line x1="746" y1="195" x2="924" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="746" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Đối soát Dark / Light</text>
-              <text x="746" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Không lạc mất cặp màu</text>
-              <text x="746" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Giữ độ sâu quang học</text>
-              <rect x="746" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="835" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">PAIRS CLEAN</text>
-            </g>
-
-            <!-- Step 5 -->
-            <g id="pipeStep5" class="interactive-node" tabindex="0" role="button" aria-label="Step 5: A11y Lint" style="cursor: pointer;">
-              <rect x="960" y="80" width="210" height="340" rx="14" fill="var(--bg-surface)" stroke="var(--border-strong)" stroke-width="2"/>
-              <rect x="960" y="80" width="210" height="40" rx="14" fill="var(--bg-surface-raised)"/>
-              <text x="1065" y="106" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-primary)" text-anchor="middle">STAGE 05 • A11Y</text>
-              <text x="1065" y="155" font-family="var(--font-sans)" font-size="17" font-weight="800" fill="var(--text-primary)" text-anchor="middle">A11y Lint</text>
-              <text x="1065" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">ui a11y-lint</text>
-              <line x1="976" y1="195" x2="1154" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="976" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Quét Axe Core máy cứng</text>
-              <text x="976" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Tương phản WCAG AA</text>
-              <text x="976" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• Khả năng đọc màn hình</text>
-              <rect x="976" y="350" width="178" height="38" rx="6" fill="var(--bg-surface-raised)" stroke="var(--border-strong)" stroke-width="1"/>
-              <text x="1065" y="374" font-family="var(--font-mono)" font-size="11" font-weight="700" fill="var(--text-primary)" text-anchor="middle">AXE PASS</text>
-            </g>
-
-            <!-- Step 6 -->
-            <g id="pipeStep6" class="interactive-node" tabindex="0" role="button" aria-label="Step 6: Full Audit" style="cursor: pointer;">
-              <rect x="1190" y="70" width="220" height="360" rx="16" fill="var(--bg-surface)" stroke="var(--text-primary)" stroke-width="3"/>
-              <rect x="1190" y="70" width="220" height="46" rx="16" fill="var(--text-primary)"/>
-              <text x="1300" y="98" font-family="var(--font-mono)" font-size="11" font-weight="800" fill="var(--text-inverse)" text-anchor="middle">STAGE 06 • FULL AUDIT [FOCAL]</text>
-              <text x="1300" y="155" font-family="var(--font-sans)" font-size="18" font-weight="900" fill="var(--text-primary)" text-anchor="middle">Full Audit</text>
-              <text x="1300" y="175" font-family="var(--font-mono)" font-size="11" fill="var(--text-muted)" text-anchor="middle">design-os audit</text>
-              <line x1="1206" y1="195" x2="1394" y2="195" stroke="var(--border-subtle)" stroke-width="1"/>
-              <text x="1206" y="230" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• taste-lint 6+1 trục</text>
-              <text x="1206" y="260" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• validate-layout tĩnh</text>
-              <text x="1206" y="290" font-family="var(--font-sans)" font-size="13" fill="var(--text-secondary)">• 10 công cụ xuất xưởng</text>
-              <rect x="1206" y="350" width="188" height="44" rx="8" fill="var(--bg-surface-raised)" stroke="var(--text-primary)" stroke-width="2"/>
-              <text x="1300" y="378" font-family="var(--font-mono)" font-size="12" font-weight="800" fill="var(--text-primary)" text-anchor="middle">0 ERRORS &rarr; SHIP</text>
-            </g>
-          </svg>
-          <div class="diagram-readout-panel" id="readout-slide-25">
-              <span class="readout-badge">DELIVERY PIPELINE: 6 STEPS</span>
-              <span class="readout-text" id="readout-text-slide-25">Run simulation to watch linters execute in the exact defect-catching order: Flow -> Evidence -> VR -> Paired -> A11y -> Audit.</span>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">6 / 6</div>
+              <div class="radiant-hero-label">Pipeline Stages Passed</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Ordered 6-Step Audit</div><div>25 / 28</div></footer>
-        <div data-speaker-notes="Pipeline 6 bước bắt buộc chạy đúng thứ tự: Flow -> Evidence -> VR -> Pairs -> Rendered A11y -> Full Audit."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>25 / 28</div>
+        </footer>
+        <div data-speaker-notes="Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."></div>
       </article>
 
 <article class="slide-item" id="slide-26" data-index="26">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Release &amp; Semver</span></div>
-          <div>Hồi 7 • 25 • Checklist &amp; PR Review</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Semver Matrix</span>
+          </div>
+          <div>26 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Đóng Gói Bàn Giao</span>
-            <h2 class="slide-title-h1 gsap-reveal">Delivery Checklist &amp; PR Semver Matrix</h2>
-            <p class="slide-subtitle gsap-reveal">Tạo tài liệu component tự động, trang specimen độc lập và tự động tính toán mức độ breaking change cho Pull Request.</p>
-          </div>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🏷</div>
 
-          <div class="slide-grid-2">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">5 LỆNH TRONG DELIVERY CHECKLIST</span>
-              <div class="code-terminal" style="font-size: 13px; margin-top: 12px; line-height: 1.6;">
-                <span class="code-comment"># 1. Kiểm tra thiếu trạng thái component</span><br>
-                <code>ui ds specimen --dir . --strict --json</code><br><br>
-                <span class="code-comment"># 2. Tái tạo tài liệu component từ Registry</span><br>
-                <code>ui ds docs --dir . --out docs/components.md</code><br><br>
-                <span class="code-comment"># 3. Tạo trang specimen HTML độc lập</span><br>
-                <code>ui ds preview --dir . --out preview.html</code><br><br>
-                <span class="code-comment"># 4. Quét Visual Regression component kit</span><br>
-                <code>design-os vr-matrix --project .</code><br><br>
-                <span class="code-comment"># 5. Xuất Changelog lịch sử thay đổi</span><br>
-                <code>ui changelog --dir . --format markdown</code>
-              </div>
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">3 Releases</div>
+              <div class="orb-label-main">Patch / Minor / Major</div>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">PHÂN LOẠI SEMVER (ui ds diff)</span>
-              <div class="code-terminal" style="font-size: 13px; margin-top: 12px;">
-                <code>ui ds diff base head --format pr-comment</code>
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">≤ 0.02</div>
+              <div class="orb-label-secondary">Patch Delta EOK</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">> 0.05</div>
+              <div class="orb-label-tertiary">Major Breaking</div>
+            </div>
+          </div>
+
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
-              <ul style="padding-left: 20px; font-size: var(--font-size-sm); color: var(--text-secondary); line-height: 1.7; margin-top: 14px;">
-                <li><strong>MAJOR (Breaking):</strong> Xóa token/component đang dùng; hoặc thay đổi màu sắc vượt ngưỡng Delta EOK.</li>
-                <li><strong>MINOR (Additive):</strong> Thêm mới token/component hoặc thêm variant mà không ảnh hưởng code cũ.</li>
-                <li><strong>PATCH:</strong> Sửa lỗi chính tả token, vi chỉnh không gây lệch thị giác.</li>
-              </ul>
+              <h1 class="radiant-display-title">SEMVER PR<br>MATRIX</h1>
+              <p class="radiant-body-text">Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.</p>
+            </div>
+
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">v1.0.0</div>
+              <div class="radiant-hero-label">Production Semver Bound</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Delivery • Semver &amp; Handoff</div><div>26 / 28</div></footer>
-        <div data-speaker-notes="Checklist 5 bước và Semver Diff đảm bảo việc bàn giao sang cho đội ngũ Engineering diễn ra êm đẹp."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>26 / 28</div>
+        </footer>
+        <div data-speaker-notes="Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."></div>
       </article>
 
 <article class="slide-item" id="slide-27" data-index="27">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Fable Thinking</span></div>
-          <div>Hồi 7 • 26 • The 5 Design Fables</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • The 5 Fables</span>
+          </div>
+          <div>27 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tư Duy Ngụ Ngôn</span>
-            <h2 class="slide-title-h1 gsap-reveal">The 5 Design Fables: Philosophy Behind Master Craft</h2>
-            <p class="slide-subtitle gsap-reveal">Distilling complex engineering mechanisms into intuitive allegorical archetypes.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">📖</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">5 Fables</div>
+              <div class="orb-label-main">Spatial Mechanisms</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Generic</div>
+              <div class="orb-label-secondary">Meaningful Living UI</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">100%</div>
+              <div class="orb-label-tertiary">Metaphor Grounded</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 1 • THE SEAMLESS FLIGHT</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Seamless Flight</div>
-              <p class="stat-desc">"Một đường rách nhỏ làm tan biến cả giấc mơ". Vận tốc và vị trí tại mối nối clip phải tuyệt đối liên tục, không bao giờ được phép lùi bước.</p>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+              </div>
+              <h1 class="radiant-display-title">THE 5 DESIGN<br>FABLES</h1>
+              <p class="radiant-body-text">Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 2 • THE TWO-WAY BRIDGE</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Two-Way Bridge</div>
-              <p class="stat-desc">"Sự thật không thuộc về riêng Mã hay Tranh". figma-agent nối nhịp hai bờ, biến Canvas thành thực thể sống động gắn liền với Token.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 3 • THE 14-PLANK FLOOR</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The 14-Plank Floor</div>
-              <p class="stat-desc">"Đừng bao giờ tin vào lời hứa của AI". Hãy để 14 lưỡi cưa linter kiểm tra từng mối hàn code để bảo vệ chất lượng không tì vết.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 4 • THE MOTION LADDER</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Motion Ladder</div>
-              <p class="stat-desc">"Leo cao mà thiếu chân đế thì rơi". Chỉ leo từ T1 đến T6 khi câu chuyện đòi hỏi và người dùng cho phép qua reduced-motion.</p>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">FABLE 5 • MEMORY DISTILLATION</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">The Sol Memory Distillation</div>
-              <p class="stat-desc">"Sau mỗi chuyến đi, hãy đúc kết vào đá tảng". Recall lưu giữ bài học và giải phóng context để tiếp tục bay xa mà không tốn triệu token.</p>
-            </div>
-
-            <div class="slide-card gsap-card" style="background: var(--bg-surface-raised);">
-              <span class="matrix-badge">CORE TAKEAWAY</span>
-              <div class="stat-label" style="font-size: 18px; margin-top: 8px;">Discipline Breeds Master Craft</div>
-              <p class="stat-desc">DESIGN:OS không biến bạn thành nô lệ của công cụ, mà trao cho bạn sức mạnh của một xưởng thiết kế công nghiệp tự vận hành.</p>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">5</div>
+              <div class="radiant-hero-label">Living Design Fables</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
+              </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Philosophy • Fable Thinking</div><div>27 / 28</div></footer>
-        <div data-speaker-notes="5 câu chuyện ngụ ngôn là tổng kết triết lý sâu sắc nhất đằng sau toàn bộ công nghệ của DESIGN:OS."></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>27 / 28</div>
+        </footer>
+        <div data-speaker-notes="Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."></div>
       </article>
 
 <article class="slide-item" id="slide-28" data-index="28">
         <div class="chrome-accent-strip"></div>
         <header class="chrome-header">
-          <div class="chrome-brand"><span class="chrome-brand-badge">DESIGN:OS</span><span>Summary</span></div>
-          <div>Hồi 7 • 27 • Start Designing</div>
+          <div class="chrome-brand">
+            <span class="chrome-brand-badge">DESIGN:OS</span>
+            <span>Act 7 • Production Ready</span>
+          </div>
+          <div>28 / 28 • RADIANT</div>
         </header>
 
-        <section class="slide-content-zone" style="justify-content: center;">
-          <div class="slide-heading-group">
-            <span class="slide-eyebrow gsap-reveal">Tổng Kết &amp; Thực Hành</span>
-            <h2 class="slide-title-display gsap-reveal">Start in 60 Seconds: Production Ready</h2>
-            <p class="slide-subtitle gsap-reveal">Toàn bộ hệ sinh thái DESIGN:OS đã được cấu hình và kiểm định hoàn chỉnh trong môi trường của bạn.</p>
+        <section class="radiant-stage-grid">
+          <!-- Left Column: Tactile Metric Orbs Cluster -->
+          <div class="radiant-left-cluster">
+            <div class="orb-badge-icon" aria-hidden="true">🌟</div>
+
+            <!-- Primary Luminous Lime Orb -->
+            <div class="orb-primary-lime">
+              <div class="orb-arrow">→</div>
+              <div class="orb-stat-huge">1 CLI</div>
+              <div class="orb-label-main">ui / design-os</div>
+            </div>
+
+            <!-- Secondary Dark Glass Orb -->
+            <div class="orb-secondary-dark">
+              <div class="orb-stat-secondary">0 Guess</div>
+              <div class="orb-label-secondary">Total Determinism</div>
+            </div>
+
+            <!-- Tertiary Dark Glass Orb -->
+            <div class="orb-tertiary-dark">
+              <div class="orb-stat-tertiary">Ready</div>
+              <div class="orb-label-tertiary">Production Grade</div>
+            </div>
           </div>
 
-          <div class="slide-grid-3" style="margin-top: 20px;">
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 1</span>
-              <div class="stat-label" style="margin-top: 10px;">Khám Sức Khỏe</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>ui onboard &amp;&amp; ui doctor</code>
+          <!-- Right Column: Luminous Master Card -->
+          <div class="radiant-master-card">
+            <div class="radiant-card-top">
+              <div class="radiant-dots" aria-hidden="true">
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
+                <span class="radiant-dot"></span>
               </div>
+              <h1 class="radiant-display-title">READY FOR<br>PRODUCTION</h1>
+              <p class="radiant-body-text">Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.</p>
             </div>
 
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 2</span>
-              <div class="stat-label" style="margin-top: 10px;">Khởi Tạo Dự Án</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>ui ds init my-app --persona aurora-minimal</code>
-              </div>
-            </div>
-
-            <div class="slide-card gsap-card">
-              <span class="matrix-badge">BƯỚC 3</span>
-              <div class="stat-label" style="margin-top: 10px;">Sinh Giao Diện</div>
-              <div class="code-terminal" style="margin-top: 12px; font-size: 13px;">
-                <code>/ui:generate landing page for my next idea</code>
+            <div class="radiant-card-bottom">
+              <div class="radiant-hero-number">SHIP</div>
+              <div class="radiant-hero-label">Qualified Delivery Floor</div>
+              <div class="radiant-progress-track" aria-hidden="true">
+                <div class="radiant-progress-fill" style="width: 100%;"></div>
               </div>
             </div>
           </div>
         </section>
 
-        <footer class="chrome-footer"><div>DESIGN:OS Operating Manual • Ready for Production</div><div>28 / 28</div></footer>
-        <div data-speaker-notes="Cảm ơn bạn đã hoàn thành khóa Masterclass 28 slide. Chúc bạn tạo nên những giao diện đỉnh cao cùng DESIGN:OS!"></div>
+        <footer class="chrome-footer">
+          <div>DESIGN:OS Operating Manual • Radiant Big Number Editorial</div>
+          <div>28 / 28</div>
+        </footer>
+        <div data-speaker-notes="Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"></div>
       </article>
 
     </div>

--- a/site/translations.js
+++ b/site/translations.js
@@ -1,5 +1,4 @@
-// DESIGN:OS 28-Slide Masterclass Internationalization System (i18n)
-// Supported languages: English (Default), Tiếng Việt, 한국어, 日本語, Español, Français, 中文
+// DESIGN:OS 28-Slide Radiant Editorial Internationalization Dictionary
 const DECK_I18N = {
   "languages": [
     {
@@ -41,1234 +40,1430 @@ const DECK_I18N = {
   "slides": {
     "1": {
       "en": {
-        "eyebrow": "Multi-Runtime Design CLI • Production Operating Manual",
-        "title": "Mastering DESIGN:OS<br>From AI Reasoning to Scroll-Cinema &amp; Figma.",
-        "subtitle": "7 Strategic Acts: AI vs Kernel Division, 6 Onboarding Roads, Live Figma Bridge 9410, Recall Vector Memory, OKLCH Color Science, 3D GFlow &amp; 2K Scroll-Cinema, and Qualified Delivery Floor.",
-        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. This manual covers everything from core mathematical foundations, Figma live sync, vector memory, to 3D scroll-cinema flights and Fable thinking."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "vi": {
-        "eyebrow": "Multi-Runtime Design CLI • Cẩm Nang Vận Hành Sản Xuất",
-        "title": "Làm chủ Toàn Năng DESIGN:OS<br>Từ AI Reasoning Đến Scroll-Cinema &amp; Figma.",
-        "subtitle": "7 Hồi Chiến Lược: Kiến trúc phân quyền AI vs Kernel, 6 Cổng Onboard, Figma Live Bridge 9410, Vòng lặp Học tập Recall, Khoa học màu OKLCH, 3D GFlow &amp; Scroll-Cinema 2K, và Sàn Qualified Delivery.",
-        "notes": "Chào mừng đến với DESIGN:OS Masterclass 28 slide. Bộ cẩm nang bao quát từ lõi toán học, cầu nối Figma, bộ nhớ vector đến điện ảnh cuộn trang 3D và 5 câu chuyện ngụ ngôn triết lý thiết kế."
+        "title": "LÀM CHỦ<br>DESIGN:OS",
+        "body": "Cẩm nang vận hành đa runtime cho thiết kế AI hiện đại. Chuyển đổi từ sự may rủi của LLM sang toán học màu tất định, đồng bộ trực tiếp Figma Desktop, truy hồi bộ nhớ vector và sàn kiểm định xuất xưởng.",
+        "heroNum": "0 %",
+        "heroLabel": "Không Dựa May Rủi",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "ko": {
-        "eyebrow": "멀티 런타임 디자인 CLI • 프로덕션 운영 매뉴얼",
-        "title": "DESIGN:OS 마스터하기<br>AI 추론부터 스크롤 시네마 &amp; Figma까지.",
-        "subtitle": "7개 전략적 장: AI와 커널 분권 구조, 6개 온보딩 경로, 피그마 브릿지 9410, 벡터 메모리 리콜, OKLCH 색채 과학, 3D GFlow 및 2K 스크롤 시네마, 품질 보증 납품 기준.",
-        "notes": "DESIGN:OS 28개 슬라이드 마스터클래스에 오신 것을 환영합니다. 핵심 수학 기초부터 피그마 실시간 연동, 벡터 메모리, 3D 스크롤 시네마까지 완벽하게 다룹니다."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "ja": {
-        "eyebrow": "マルチランタイム デザインCLI • 本番運用マニュアル",
-        "title": "DESIGN:OS を完全マスター<br>AI推論からスクロールシネマ＆Figmaまで.",
-        "subtitle": "7つの戦略的幕: AI対カーネル分権構造、6つのオンボーディング経路、Figmaブリッジ9410、ベクトルメモリRecall、OKLCH色彩科学、3D GFlow＆2Kスクロールシネマ、品質保証デリバリー基準。",
-        "notes": "DESIGN:OS 28スライド マスタークラスへようこそ。数学的基礎からFigmaリアルタイム連携、ベクトルメモリ、3Dスクロールシネマまで網羅しています。"
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "es": {
-        "eyebrow": "CLI de Diseño Multi-Runtime • Manual de Operación en Producción",
-        "title": "Dominando DESIGN:OS<br>Desde el Razonamiento AI hasta Scroll-Cinema y Figma.",
-        "subtitle": "7 Actos Estratégicos: División AI vs Kernel, 6 Vías de Onboarding, Figma Live Bridge 9410, Memoria Vectorial Recall, Ciencia del Color OKLCH, GFlow 3D y Scroll-Cinema 2K, y Entrega Calificada.",
-        "notes": "Bienvenidos a la Masterclass Completa de DESIGN:OS en 28 Diapositivas. Abarca desde fundamentos matemáticos hasta sincronización con Figma, memoria vectorial y vuelos 3D."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "fr": {
-        "eyebrow": "CLI de Design Multi-Runtime • Manuel d'Exploitation Production",
-        "title": "Maîtriser DESIGN:OS<br>Du Raisonnement IA au Scroll-Cinéma &amp; Figma.",
-        "subtitle": "7 Actes Stratégiques: Séparation IA vs Noyau, 6 Voies d'Intégration, Pont Figma 9410, Mémoire Vectorielle Recall, Science des Couleurs OKLCH, GFlow 3D &amp; Scroll-Cinéma 2K, et Livraison Qualifiée.",
-        "notes": "Bienvenue dans la Masterclass DESIGN:OS en 28 diapositives. Ce guide couvre des fondations mathématiques à la synchronisation Figma en direct, la mémoire vectorielle et le cinéma 3D."
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       },
       "zh": {
-        "eyebrow": "多运行时设计CLI • 生产级系统操作手册",
-        "title": "全面掌握 DESIGN:OS<br>从 AI 推理到滚动电影与 Figma 实时画布.",
-        "subtitle": "7大核心篇章: AI与确定性内核分权架构、6大Onboarding入口、Figma桌面桥接9410、Recall向量记忆、OKLCH色彩科学、3D GFlow与2K滚动电影、Qualified Delivery交付底线。",
-        "notes": "欢迎来到 DESIGN:OS 28页大师课。涵盖从底层色彩数学、Figma实时桥接、向量记忆、到3D空间镜头控制与Design Fables哲学的全部核心体系。"
+        "title": "MASTERING<br>DESIGN:OS",
+        "body": "The definitive multi-runtime operating manual for modern AI design. Transition from stochastic LLM luck to deterministic color mathematics, live Figma desktop synchronization, vector memory recall, and qualified delivery pipelines.",
+        "heroNum": "0 %",
+        "heroLabel": "LLM Luck Required",
+        "notes": "Welcome to the DESIGN:OS 28-Slide Complete Masterclass. Today we establish the complete operating manual for deterministic AI UI generation."
       }
     },
     "2": {
       "en": {
-        "eyebrow": "Core Philosophy",
-        "title": "The 3 Supreme Truths of DESIGN:OS",
-        "subtitle": "Eliminating reliance on LLM luck. Enforcing quality through color science and deterministic machine floors.",
-        "notes": "The 3 core truths form our compass: converting stochastic LLM chaos into reliable, deterministic code."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "vi": {
-        "eyebrow": "Triết Lý Cốt Lõi",
-        "title": "3 Chân Lý Tối Thượng Của DESIGN:OS",
-        "subtitle": "Không dựa vào sự may rủi của mô hình LLM. Ép chất lượng bằng toán học màu sắc và sàn kiểm định tất định.",
-        "notes": "3 chân lý tối thượng là kim chỉ nam: biến sự hỗn loạn của LLM thành kết quả tất định."
+        "title": "3 CHÂN LÝ<br>TỐI THƯỢNG",
+        "body": "Xóa bỏ sự phụ thuộc vào sự may rủi của AI. Mọi token hình ảnh đều bắt nguồn từ khoa học màu sắc OKLCH, phân định rõ ràng giữa AI reasoning và UI kernel, cùng sàn 14 linter kiểm định tất định.",
+        "heroNum": "14",
+        "heroLabel": "Linter Kiểm Định Máy",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "ko": {
-        "eyebrow": "핵심 원칙",
-        "title": "DESIGN:OS의 3대 핵심 공리",
-        "subtitle": "LLM의 운에 의존하지 않고, 색채 과학과 결정론적 검증 바닥을 통해 품질을 강제합니다.",
-        "notes": "3대 핵심 공리는 LLM의 무작위성을 결정론적 결과물로 전환하는 기준입니다."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "ja": {
-        "eyebrow": "コア哲学",
-        "title": "DESIGN:OS 3つの至高の真理",
-        "subtitle": "LLMの偶然性に頼らず、色彩科学と決定論的検証フロアによって品質を担保します。",
-        "notes": "3つの至高の真理は、LLMの不確実性を決定論的なコードへと変換するための羅針盤です。"
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "es": {
-        "eyebrow": "Fundamentos Clave",
-        "title": "Las 3 Verdades Supremas de DESIGN:OS",
-        "subtitle": "Eliminando la suerte de los LLM. Garantizando calidad mediante ciencia del color y pisos deterministas.",
-        "notes": "Las 3 verdades supremas convierten el caos estocástico en código confiable y determinista."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "fr": {
-        "eyebrow": "Fondations Essentielles",
-        "title": "Les 3 Vérités Suprêmes de DESIGN:OS",
-        "subtitle": "Éliminer l'aléatoire des LLM. Forcer la qualité par la science des couleurs et des contrôles déterministes.",
-        "notes": "Ces 3 vérités transforment le chaos stochastique en code déterministe et fiable."
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       },
       "zh": {
-        "eyebrow": "核心设计公理",
-        "title": "DESIGN:OS 的三大至高公理",
-        "subtitle": "告别对大模型运气的依赖，通过严密色彩数学与确定性机器底线死守品质。",
-        "notes": "三大公理是核心指南针：将大模型的随机混乱转化为确定性的工业级代码。"
+        "title": "3 SUPREME<br>TRUTHS",
+        "body": "Eliminating reliance on stochastic generative luck. Every visual token is derived from perceptual OKLCH color science, strict division of labor between AI reasoning and the UI kernel, and an immutable 14-linter machine floor.",
+        "heroNum": "14",
+        "heroLabel": "Machine Floor Linters",
+        "notes": "The 3 core truths form our engineering compass: converting stochastic LLM chaos into reliable, deterministic release code."
       }
     },
     "3": {
       "en": {
-        "eyebrow": "Architecture Split",
-        "title": "Division of Labor: AI Reasoning vs UI Kernel",
-        "subtitle": "Host AI Agent handles creative reasoning, while the deterministic UI Kernel handles color mathematics, tokens compilation, and lint enforcement.",
-        "notes": "AI agents reason and generate; UI Kernel verifies and enforces. Together they create an error-free self-repairing loop."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "vi": {
-        "eyebrow": "Kiến Trúc Phân Quyền",
-        "title": "Sơ Đồ Phân Quyền: AI Reasoning vs UI Kernel",
-        "subtitle": "Host AI Agent đóng vai trò sáng tạo (Reasoning), trong khi UI Kernel làm nhiệm vụ tính toán toán học và kiểm tra tuân thủ (Verification).",
-        "notes": "AI Agent suy luận, UI Kernel kiểm định. Hai bán cầu kết hợp thành vòng lặp tự sửa lỗi hoàn hảo."
+        "title": "PHÂN QUYỀN<br>KIẾN TRÚC",
+        "body": "Host AI Agent phụ trách tư duy sáng tạo bậc cao, giải quyết persona và cấu trúc DOM ngữ nghĩa. UI Kernel đảm bảo biên dịch DTCG, toán học màu và các cửa ải xuất xưởng không lỗi.",
+        "heroNum": "100 %",
+        "heroLabel": "Biên Dịch Tất Định",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "ko": {
-        "eyebrow": "역할 분권 아키텍처",
-        "title": "분권 구조: AI 추론 vs UI 커널",
-        "subtitle": "호스트 AI 에이전트는 창의적 추론을 담당하고, 결정론적 UI 커널은 색채 수학, 토큰 컴파일 및 린트 검증을 수행합니다.",
-        "notes": "AI 에이전트의 추론과 UI 커널의 결정론적 검증이 결합되어 완벽한 자동 복구 루프를 형성합니다."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "ja": {
-        "eyebrow": "分権アーキテクチャ",
-        "title": "役割分担: AI推論 vs UIカーネル",
-        "subtitle": "ホストAIエージェントが創造的推論を担い、決定論的UIカーネルが色彩数学、トークン変換、Lint検証を実行します。",
-        "notes": "AIの柔軟な推論とカーネルの厳格な検証が組み合わさり、自動修復ループを実現します。"
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "es": {
-        "eyebrow": "División de Arquitectura",
-        "title": "División de Trabajo: Razonamiento AI vs UI Kernel",
-        "subtitle": "El agente AI maneja el razonamiento creativo, mientras que el Kernel UI ejecuta las matemáticas de color y las verificaciones.",
-        "notes": "El agente AI razona y el Kernel UI verifica, creando un bucle perfecto de auto-reparación."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "fr": {
-        "eyebrow": "Séparation d'Architecture",
-        "title": "Division du Travail: Raisonnement IA vs Noyau UI",
-        "subtitle": "L'agent IA gère le raisonnement créatif, tandis que le Noyau UI déterministe assure les calculs mathématiques et la conformité.",
-        "notes": "L'IA raisonne et le Noyau vérifie, créant une boucle d'auto-correction robuste."
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       },
       "zh": {
-        "eyebrow": "分权架构设计",
-        "title": "分权体系: AI 空间推理 vs UI 确定性内核",
-        "subtitle": "Host AI Agent 负责美学推演与结构生成，UI Kernel 负责 OKLCH 色彩数学计算、Token 编译与 14 大机器红线裁决。",
-        "notes": "AI 大脑负责发散推理，UI 机器内核负责确定性判决，构成闭环的自愈修复系统。"
+        "title": "DIVISION<br>OF LABOR",
+        "body": "The Host AI Agent handles high-level creative synthesis, persona resolution, and semantic DOM structuring. The UI Kernel strictly enforces DTCG compilation, color science math, and zero-error release gates.",
+        "heroNum": "100 %",
+        "heroLabel": "Deterministic Compile",
+        "notes": "Never allow the LLM to guess hex colors or calculate contrast math. The UI Kernel guarantees mathematically provable output."
       }
     },
     "4": {
       "en": {
-        "eyebrow": "Specialized Modules",
-        "title": "The 6 Specialized Optional Hands Ecosystem",
-        "subtitle": "Specialized modular hands extend multi-dimensional design capabilities, gracefully degrading when unconfigured.",
-        "notes": "These 6 optional hands transform DESIGN:OS into a complete design operating system from flat web to 3D and Figma."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "vi": {
-        "eyebrow": "Module Mở Rộng",
-        "title": "Hệ Sinh Thái 6 \"Cánh Tay\" Chuyên Trách (Optional Hands)",
-        "subtitle": "Các module chuyên trách mở rộng năng lực thiết kế đa chiều, tự suy giảm nhẹ nhàng khi vắng mặt (Graceful Degradation).",
-        "notes": "6 cánh tay này biến DESIGN:OS thành hệ điều hành thiết kế toàn năng từ giao diện web phẳng đến không gian 3D và canvas Figma."
+        "title": "6 ĐÔI TAY<br>MỞ RỘNG",
+        "body": "Hệ sinh thái tay chuyên biệt—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall và color science—tự động suy giảm nhẹ nhàng khi không cấu hình, giữ bundle siêu nhẹ.",
+        "heroNum": "6",
+        "heroLabel": "Module Đa Runtime",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "ko": {
-        "eyebrow": "특화 모듈",
-        "title": "6대 전문 옵셔널 핸즈(Optional Hands) 생태계",
-        "subtitle": "다차원 디자인 역량을 확장하며, 모듈 부재 시 우아한 기능 저하(Graceful Degradation)를 제공합니다.",
-        "notes": "이 6개의 핸즈는 DESIGN:OS를 평면 웹부터 3D, 피그마 캔버스까지 아우르는 완벽한 OS로 만듭니다."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "ja": {
-        "eyebrow": "専門モジュール",
-        "title": "6つの特化型オプショナル・ハンズ（Optional Hands）エコシステム",
-        "subtitle": "多次元のデザイン能力を拡張し、未設定時も安全にフォールバック（Graceful Degradation）します。",
-        "notes": "これら6つの拡張機能により、Webから3D、Figmaまで統一されたデザイン体験を提供します。"
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "es": {
-        "eyebrow": "Módulos Especializados",
-        "title": "Ecosistema de 6 Manos Opcionales Especializadas",
-        "subtitle": "Módulos que expanden capacidades de diseño multidimensional, degradándose suavemente si no están presentes.",
-        "notes": "Estas 6 manos transforman a DESIGN:OS en un sistema operativo de diseño completo."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "fr": {
-        "eyebrow": "Modules Spécialisés",
-        "title": "L'Écosystème des 6 Mains Optionnelles Spécialisées",
-        "subtitle": "Des modules qui étendent les capacités de design multidimensionnel avec une dégradation élégante en cas d'absence.",
-        "notes": "Ces 6 modules font de DESIGN:OS un véritable système d'exploitation de design global."
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       },
       "zh": {
-        "eyebrow": "扩展手柄体系",
-        "title": "6 大专业特化手柄生态 (Optional Hands)",
-        "subtitle": "高内聚的专业功能模块，拓展从矢量画布到 3D 电影的全部能力，缺失时自动优雅降级。",
-        "notes": "这 6 大专业手柄将 DESIGN:OS 从简单的代码生成器升维为全场景设计操作系统。"
+        "title": "OPTIONAL<br>HANDS",
+        "body": "Specialized modular capabilities—Figma live sync, GSAP timelines, 3D GFlow, vector memory recall, and color science—gracefully degrade when unconfigured, keeping the core bundle ultra-light.",
+        "heroNum": "6",
+        "heroLabel": "Multi-Runtime Engines",
+        "notes": "The optional hands architecture ensures zero bloat for simple web projects while providing industrial power when invoked."
       }
     },
     "5": {
       "en": {
-        "eyebrow": "Design Identity",
-        "title": "3-Tier Design Soul Hierarchy (Never / Always / Voice)",
-        "subtitle": "Establishing aesthetic stances and consistent design vocabulary from Studio level down to specific projects.",
-        "notes": "Design Soul defines aesthetic identity. The user's explicit brief always holds the highest precedence."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "vi": {
-        "eyebrow": "Bản Sắc Thiết Kế",
-        "title": "Hệ Thống 3 Tầng Design Soul (Never / Always / Voice)",
-        "subtitle": "Định hình lập trường thẩm mỹ và ngôn ngữ thiết kế nhất quán từ cấp Studio đến từng dự án cụ thể.",
-        "notes": "Soul thiết lập lập trường thẩm mỹ. Explicit Brief từ user luôn có quyền ghi đè cao nhất."
+        "title": "THỨ BẬC<br>LINH HỒN",
+        "body": "Quy tắc ưu tiên 3 tầng bảo vệ bản sắc thẩm mỹ: Bất biến Factory làm nền tảng, quy ước Studio duy trì đồng bộ, và Linh hồn Project giữ quyền quyết định tối cao.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Cấp Độ Quyền Lực",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "ko": {
-        "eyebrow": "디자인 아이덴티티",
-        "title": "3계층 디자인 소울(Design Soul) 아키텍처",
-        "subtitle": "스튜디오 레벨부터 개별 프로젝트까지 일관된 미학적 입장과 디자인 어휘를 수립합니다.",
-        "notes": "디자인 소울은 미학적 기준을 세우며, 사용자의 명시적 지시가 항상 최우선 순위를 갖습니다."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "ja": {
-        "eyebrow": "デザイン・アイデンティティ",
-        "title": "3層のデザインソウル（Design Soul）構造",
-        "subtitle": "スタジオ全体から個別プロジェクトに至るまで、一貫した美学方針と語彙を定義します。",
-        "notes": "ソウルは美学の規範を定義します。ユーザーの明示的な要求が常に最優先されます。"
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "es": {
-        "eyebrow": "Identidad de Diseño",
-        "title": "Jerarquía de 3 Niveles de Design Soul",
-        "subtitle": "Establece posturas estéticas y vocabulario consistente desde el estudio hasta proyectos individuales.",
-        "notes": "Soul define la postura estética. Las instrucciones explícitas del usuario siempre tienen máxima prioridad."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "fr": {
-        "eyebrow": "Identité Visuelle",
-        "title": "Hiérarchie à 3 Niveaux du Design Soul",
-        "subtitle": "Établit les partis pris esthétiques et le vocabulaire de design du studio jusqu'au projet.",
-        "notes": "Le Soul définit l'identité visuelle. Les directives explicites priment toujours."
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       },
       "zh": {
-        "eyebrow": "设计美学灵魂",
-        "title": "3 级 Design Soul 美学灵魂体系",
-        "subtitle": "通过 Never / Always / Voice 规则建立从工作室全局到具体项目的统一美学立场。",
-        "notes": "Soul 定义团队的美学红线与设计语调，用户的 Explicit Brief 永远拥有最高覆盖权。"
+        "title": "CASCADE OF<br>SOVEREIGNTY",
+        "body": "Strict 3-tier precedence guarantees aesthetic identity. Factory invariants establish the unbreakable floor, Studio conventions enforce consistency across workspaces, and Project Soul holds ultimate veto power.",
+        "heroNum": "3 Tiers",
+        "heroLabel": "Precedence Hierarchy",
+        "notes": "Project briefs win over Studio conventions, but Factory anti-pattern bans are mathematically immutable."
       }
     },
     "6": {
       "en": {
-        "eyebrow": "Onboarding Matrix",
-        "title": "6 Entry Roads for Project Onboarding (E1–E6)",
-        "subtitle": "Seamlessly onboarding any project state: from zero codebase, existing repos, reference URLs, to Figma frames.",
-        "notes": "E1 to E6 provide deterministic routes for every project starting state."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "vi": {
-        "eyebrow": "Ma Trận Tiếp Nhận",
-        "title": "Router 6 Cổng Vào Onboarding (E1–E6)",
-        "subtitle": "Tiếp nhận mọi hiện trạng dự án: từ con số 0, codebase có sẵn, URL tham chiếu, đến file Figma thực tế.",
-        "notes": "E1 đến E6 mở đường cho mọi trạng thái dự án bắt đầu với DESIGN:OS một cách tất định."
+        "title": "6 LỘ TRÌNH<br>ONBOARDING",
+        "body": "Lệnh ui scan tự động quét và phân tích trạng thái dự án để điều hướng vào đường băng tối ưu—từ dự án mới (E1), codebase có sẵn (E2), bóc tách URL (E3) hay Figma tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Cổng Khởi Tạo Chuẩn",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "ko": {
-        "eyebrow": "온보딩 라우터",
-        "title": "프로젝트 온보딩을 위한 6가지 진입 경로 (E1–E6)",
-        "subtitle": "완전한 제로 베이스, 기존 코드베이스, 참조 URL, 피그마 프레임까지 모든 프로젝트 상태를 원활하게 수용합니다.",
-        "notes": "E1부터 E6까지의 경로는 프로젝트의 시작 상태에 맞춰 최적의 온보딩 워크플로우를 제공합니다."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "ja": {
-        "eyebrow": "オンボーディング・ルーター",
-        "title": "プロジェクト受入の6つの進入路 (E1–E6)",
-        "subtitle": "新規プロジェクト、既存コード、参照URL、Figmaフレームまで、あらゆる状態から即座に導入可能です。",
-        "notes": "E1からE6のルートにより、どのような初期状態のプロジェクトでも決定論的に統合できます。"
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "es": {
-        "eyebrow": "Matriz de Incorporación",
-        "title": "6 Vías de Entrada para Onboarding (E1–E6)",
-        "subtitle": "Integración fluida para cualquier estado: proyectos nuevos, código existente, URLs o Figma.",
-        "notes": "E1 a E6 proporcionan rutas deterministas para cada estado inicial."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "fr": {
-        "eyebrow": "Matrice d'Intégration",
-        "title": "6 Voies d'Entrée pour l'Intégration (E1–E6)",
-        "subtitle": "Intégration sans couture pour tout projet: nouveau, existant, URL de référence ou Figma.",
-        "notes": "E1 à E6 assurent une transition fluide quel que soit le point de départ."
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       },
       "zh": {
-        "eyebrow": "Onboarding 路由体系",
-        "title": "6 大项目接入路由通道 (E1–E6)",
-        "subtitle": "无缝适配从零冷启动、已有工程改建、线上站点逆向、到 Figma 实时画板等任意初始状态。",
-        "notes": "E1 至 E6 构筑了覆盖全场景的精准接入流水线。"
+        "title": "6 ENTRY<br>ROADS",
+        "body": "Running ui scan inspects project state to route you into the optimal onboarding runway—whether starting from scratch (E1), existing codebase (E2), live URL extraction (E3), or Figma design tokens (E4).",
+        "heroNum": "E1-E6",
+        "heroLabel": "Deterministic Gateways",
+        "notes": "Never guess project initialization. The scan command detects framework, design tokens, and existing style files automatically."
       }
     },
     "7": {
       "en": {
-        "eyebrow": "Workflow Discipline",
-        "title": "5-Step Setup Protocol &amp; Mandatory STOP-Gates",
-        "subtitle": "Strict discipline: never generate UI code without passing the prerequisite configuration gates.",
-        "notes": "STOP-Gates prevent premature code generation before tokens and design soul are compiled."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "vi": {
-        "eyebrow": "Kỷ Luật Quy Trình",
-        "title": "Quy Trình 5 Bước &amp; Các STOP-Gates Bắt Buộc",
-        "subtitle": "Kỷ luật thép: không bao giờ sinh mã HTML/CSS khi chưa vượt qua các cổng kiểm tra cấu hình tiên quyết.",
-        "notes": "STOP-Gates ngăn chặn tình trạng sinh mã vô tội vạ khi chưa có token và design soul."
+        "title": "QUY TRÌNH<br>5 BƯỚC THIẾT LẬP",
+        "body": "Vòng đời thiết lập 5 bước tuần tự được bảo vệ bởi các cổng STOP bắt buộc: Kiểm tra Doctor, biên dịch Design System, khai báo Soul, kết nối AI staff và khởi tạo cầu nối Figma.",
+        "heroNum": "5 / 5",
+        "heroLabel": "Cửa Ải STOP Vượt Qua",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "ko": {
-        "eyebrow": "워크플로우 규율",
-        "title": "5단계 셋업 프로토콜 및 필수 STOP-Gates",
-        "subtitle": "철저한 규율: 선행 구성 게이트를 통과하기 전에는 절대 UI 코드를 생성하지 않습니다.",
-        "notes": "STOP-Gates는 토큰과 디자인 소울이 컴파일되기 전 불완전한 코드 생성을 엄격히 차단합니다."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "ja": {
-        "eyebrow": "ワークフロー規律",
-        "title": "5段階セットアップ手順と必須 STOP-Gates",
-        "subtitle": "厳格な規律: 前提となる構成ゲートを通過するまで、UIコードの生成を行ってはなりません。",
-        "notes": "STOP-Gatesはトークンやデザインソウルが準備される前の早まったコード生成を防止します。"
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "es": {
-        "eyebrow": "Disciplina de Trabajo",
-        "title": "Protocolo de 5 Pasos y STOP-Gates Obligatorios",
-        "subtitle": "Disciplina estricta: nunca generar código UI sin superar las puertas de configuración previas.",
-        "notes": "Los STOP-Gates evitan la generación prematura de código sin tokens validados."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "fr": {
-        "eyebrow": "Discipline de Flux",
-        "title": "Protocole en 5 Étapes &amp; STOP-Gates Obligatoires",
-        "subtitle": "Discipline stricte: ne jamais générer de code UI sans valider les étapes de configuration préalables.",
-        "notes": "Les STOP-Gates empêchent toute génération de code avant la validation des tokens."
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       },
       "zh": {
-        "eyebrow": "初始化铁律",
-        "title": "5 步初始化规程与强制 STOP-Gates 红线",
-        "subtitle": "绝对纪律：在未完成环境诊断、Token 编译与 Soul 声明前，严禁越级直接生成 UI 代码。",
-        "notes": "STOP-Gates 坚决杜绝在缺少设计地基时的盲目瞎写。"
+        "title": "SETUP<br>PROTOCOL",
+        "body": "Sequential 5-step onboarding lifecycle guarded by mandatory STOP gates: Doctor verification, design system compilation, soul declaration, virtual staff wiring, and Figma bridge initialization.",
+        "heroNum": "5 / 5",
+        "heroLabel": "STOP-Gates Cleared",
+        "notes": "Following the sequential order eliminates hash drift, broken token pointers, and misconfigured agent personas."
       }
     },
     "8": {
       "en": {
-        "eyebrow": "Autonomous Collaboration",
-        "title": "Virtual Design Staff &amp; Periodic Heartbeat",
-        "subtitle": "Self-coordinating virtual agent team executing continuous tasks through the deterministic heartbeat daemon.",
-        "notes": "Designer, Curator, and Figma Hand work together under heartbeat supervision."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "vi": {
-        "eyebrow": "Cộng Tác Tự Trị",
-        "title": "Đội Ngũ Subagents Ảo &amp; Heartbeat Định Kỳ",
-        "subtitle": "Bộ 3 nhân sự ảo tự phối hợp, chạy các tác vụ định kỳ qua cơ chế Heartbeat độc lập.",
-        "notes": "Designer, Curator, và Figma Hand phối hợp nhịp nhàng dưới sự điều phối của Heartbeat."
+        "title": "ĐỘI NGŨ<br>VIRTUAL STAFF",
+        "body": "Một lệnh ui agents init cấp cho dự án đội ngũ 3 chuyên gia: System Architect phụ trách cấu trúc, Craft Stylist trau chuốt thẩm mỹ và Release Auditor kiểm soát chất lượng.",
+        "heroNum": "3",
+        "heroLabel": "Vai Trò AI Chuyên Biệt",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "ko": {
-        "eyebrow": "자율 협업 팀",
-        "title": "가상 디자인 스태프 및 주기적 하트비트(Heartbeat)",
-        "subtitle": "결정론적 하트비트 데몬을 통해 지속적인 유지보수 작업을 수행하는 자율 협업 가상 에이전트 팀.",
-        "notes": "디자이너, 큐레이터, 피그마 핸드가 하트비트 감시 하에 완벽한 분업을 이룹니다."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "ja": {
-        "eyebrow": "自律協調スタッフ",
-        "title": "仮想デザインチームと周期的ハートビート",
-        "subtitle": "決定論的ハートビートデーモンにより継続的なタスクを実行する自律型仮想エージェントチーム。",
-        "notes": "Designer、Curator、Figma Handがハートビート管理下で有機的に連携します。"
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "es": {
-        "eyebrow": "Colaboración Autónoma",
-        "title": "Equipo de Diseño Virtual y Heartbeat Periódico",
-        "subtitle": "Equipo de agentes virtuales autónomos que ejecutan tareas continuas mediante el demonio de heartbeat.",
-        "notes": "Designer, Curator y Figma Hand colaboran bajo la supervisión de Heartbeat."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "fr": {
-        "eyebrow": "Collaboration Autonome",
-        "title": "Équipe de Design Virtuelle &amp; Heartbeat Périodique",
-        "subtitle": "Équipe d'agents virtuels autonomes exécutant des tâches continues via le démon heartbeat déterministe.",
-        "notes": "Le Designer, le Curateur et Figma Hand collaborent sous la régulation du heartbeat."
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       },
       "zh": {
-        "eyebrow": "自主协同体系",
-        "title": "虚拟设计班组与周期性 Heartbeat 心跳守护",
-        "subtitle": "Designer、Curator 与 Figma Hand 虚拟专员协同作业，通过确定性心跳守护实现无人值守维护。",
-        "notes": "三大虚拟角色各司其职，在 Heartbeat 的精确节拍下完成资产巡检与自动优化。"
+        "title": "VIRTUAL<br>STAFF",
+        "body": "A single ui agents init command provisions a dedicated 3-expert team: System Architect for structural layout, Craft Stylist for aesthetic polish, and Release Auditor for quality gate enforcement.",
+        "heroNum": "3",
+        "heroLabel": "Specialized AI Roles",
+        "notes": "Clear separation of duties prevents cognitive confusion. The Auditor never writes code; the Architect never polishes colors."
       }
     },
     "9": {
       "en": {
-        "eyebrow": "Daily Operations",
-        "title": "The 6 Core Daily Verbs (/ui:* Commands)",
-        "subtitle": "Standardized slash commands covering every day-to-day design requirement with absolute determinism.",
-        "notes": "From generate to iterate and to-figma, these 6 verbs structure every agent workflow."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "vi": {
-        "eyebrow": "Thao Tác Thường Nhật",
-        "title": "6 Động Từ Thường Nhật (Daily Verbs)",
-        "subtitle": "Bộ lệnh slash command chuẩn hóa đáp ứng mọi nhu cầu thiết kế hàng ngày với độ tất định tuyệt đối.",
-        "notes": "Từ generate đến iterate và to-figma, 6 động từ này định hình toàn bộ luồng làm việc của agent."
+        "title": "6 ĐỘNG TỪ<br>VẬN HÀNH CLI",
+        "body": "Trải nghiệm CLI mượt mà với các lệnh tự nhiên: /ui:generate tạo màn hình mới, /ui:iterate tinh chỉnh, /ui:audit kiểm tra tiêu chuẩn và /ui:design khám phá biến thể.",
+        "heroNum": "6",
+        "heroLabel": "Động Từ Thao Tác Cốt Lõi",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "ko": {
-        "eyebrow": "일일 운영 커맨드",
-        "title": "6대 일상 동사 커맨드 (Daily Verbs)",
-        "subtitle": "절대적인 결정론을 기반으로 매일의 디자인 요구사항을 완벽히 충족하는 표준 슬래시 명령어 세트.",
-        "notes": "생성부터 반복 개선, 피그마 전송까지 6개 명령어가 모든 워크플로우를 주도합니다."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "ja": {
-        "eyebrow": "日常オペレーション",
-        "title": "6つの日常コマンド（Daily Verbs）",
-        "subtitle": "決定論的な品質を維持しながら、日々のデザイン作業を網羅する標準スラッシュコマンド群。",
-        "notes": "generateからiterate、to-figmaまで、6つのコマンドがエージェントの作業を定義します。"
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "es": {
-        "eyebrow": "Operaciones Diarias",
-        "title": "Los 6 Verbos Clave de Operación Diaria",
-        "subtitle": "Comandos slash estandarizados que cubren cada necesidad de diseño con total determinismo.",
-        "notes": "Desde generate hasta iterate y to-figma, estos 6 verbos estructuran todo el flujo de trabajo."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "fr": {
-        "eyebrow": "Opérations Quotidiennes",
-        "title": "Les 6 Verbes Quotidiens Essentiels",
-        "subtitle": "Commandes slash standardisées couvrant tous les besoins de conception avec un déterminisme absolu.",
-        "notes": "De generate à iterate et to-figma, ces 6 verbes structurent le travail des agents."
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       },
       "zh": {
-        "eyebrow": "日常操作动词",
-        "title": "6 大日常核心设计动词 (/ui:* 指令集)",
-        "subtitle": "标准化的斜杠指令集，以高度确定性的协议覆盖从草图生成、局部迭代到画布推送的全部场景。",
-        "notes": "6 大日常指令是驱动 DESIGN:OS 运转的核心交互接口。"
+        "title": "6 CORE<br>DAILY VERBS",
+        "body": "High-velocity CLI ergonomics powered by natural language slash verbs: /ui:generate for net-new views, /ui:iterate for targeted refinements, /ui:audit for compliance checks, and /ui:design for exploratory variant synthesis.",
+        "heroNum": "6",
+        "heroLabel": "Core Operating Verbs",
+        "notes": "Agents translate user intent into structured DTCG tokens and semantic HTML without manual boilerplate overhead."
       }
     },
     "10": {
       "en": {
-        "eyebrow": "Bi-directional Bridge",
-        "title": "Figma Desktop Bridge: Broker Port 9410",
-        "subtitle": "AI Agents and Designers collaborate on a real-time Figma file with secure conflict locking.",
-        "notes": "The local broker on port 9410 connects directly to the Figma Desktop plugin for live layout synthesis and token binding."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "vi": {
-        "eyebrow": "Cầu Nối Hai Chiều",
-        "title": "Cây Cầu Figma Desktop: Broker Port 9410",
-        "subtitle": "AI Agent và Designer cùng làm việc trên một file Figma thời gian thực với cơ chế khóa xung đột an toàn.",
-        "notes": "Broker port 9410 kết nối trực tiếp với Figma Desktop Plugin, cho phép AI dựng layout và gán token tự động."
+        "title": "CẦU NỐI TRỰC TIẾP<br>FIGMA DESKTOP",
+        "body": "Đồng bộ WebSocket cục bộ hai chiều giữa Git code và canvas Figma Desktop thời gian thực. Đẩy tokens DTCG thành Figma Variables và kéo Auto-Layout frames thành mã AST.",
+        "heroNum": "9410",
+        "heroLabel": "Cổng Broker Cục Bộ",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "ko": {
-        "eyebrow": "양방향 실시간 브릿지",
-        "title": "피그마 데스크톱 브릿지: 브로커 포트 9410",
-        "subtitle": "AI 에이전트와 디자이너가 안전한 충돌 방지 락을 통해 실시간 피그마 파일에서 협업합니다.",
-        "notes": "포트 9410 브로커를 통해 피그마 플러그인과 연결하여 오토레이아웃과 토큰을 실시간 동기화합니다."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "ja": {
-        "eyebrow": "双方向ブリッジ",
-        "title": "Figma デスクトップブリッジ: Broker Port 9410",
-        "subtitle": "AIエージェントとデザイナーが衝突防止ロック付きでリアルタイムにFigmaファイルを共同編集します。",
-        "notes": "ポート9410のローカルブローカーを介して、Figmaプラグインとトークンを双方向同期します。"
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "es": {
-        "eyebrow": "Puente Bidireccional",
-        "title": "Puente Figma Desktop: Broker Port 9410",
-        "subtitle": "Los agentes AI y diseñadores colaboran en tiempo real en Figma con bloqueo de conflictos.",
-        "notes": "El broker en el puerto 9410 permite la síntesis de layouts y la vinculación de tokens en vivo."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "fr": {
-        "eyebrow": "Pont Bidirectionnel",
-        "title": "Pont Figma Desktop: Broker Port 9410",
-        "subtitle": "Les agents IA et les designers collaborent en temps réel sur Figma avec verrouillage sécurisé.",
-        "notes": "Le broker sur le port 9410 connecte directement le plugin Figma pour la synchronisation des tokens."
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       },
       "zh": {
-        "eyebrow": "双向实时桥接",
-        "title": "Figma 桌面级桥接体系: Broker 端口 9410",
-        "subtitle": "AI Agent 与设计师在 Figma 画布上实时协同，具备安全无锁的冲突避让与断线保护机制。",
-        "notes": "9410 端口本地 Broker 直连官方 Plugin，实现代码 Tokens 与 Figma Variables 的 1:1 双向映射。"
-      }
-    },
-    "16": {
-      "en": {
-        "eyebrow": "Color Science",
-        "title": "OKLCH Mathematics, P3 Gamut &amp; Delta EOK",
-        "subtitle": "Why DESIGN:OS deprecates legacy HSL/Hex in favor of the perceptually uniform OKLCH color space.",
-        "notes": "OKLCH ensures uniform perceived lightness across all hues, guaranteeing true accessibility."
-      },
-      "vi": {
-        "eyebrow": "Khoa Học Màu Sắc",
-        "title": "Toán Học Màu OKLCH, Gamut P3 &amp; Delta EOK",
-        "subtitle": "Tại sao DESIGN:OS cấm hoàn toàn HSL và sRGB cổ điển để chuyển sang không gian cảm nhận đồng đều OKLCH.",
-        "notes": "Toán học màu OKLCH bảo đảm mọi thang bậc sáng đều có cùng độ tương phản mắt thấy."
-      },
-      "ko": {
-        "eyebrow": "색채 과학",
-        "title": "OKLCH 수학, P3 색역 및 델타 EOK",
-        "subtitle": "DESIGN:OS가 기존 HSL/Hex를 완전히 배제하고 지각적 균일 공간인 OKLCH를 선택한 이유입니다.",
-        "notes": "OKLCH는 모든 색상에서 인간의 눈이 느끼는 균일한 밝기를 제공하여 완벽한 웹 접근성을 보장합니다."
-      },
-      "ja": {
-        "eyebrow": "色彩科学",
-        "title": "OKLCH 色彩数学、P3色域、Delta EOK",
-        "subtitle": "従来のHSLやHexを廃止し、知覚的に均一なOKLCH色空間を採用する理由を解説します。",
-        "notes": "OKLCH数学により、あらゆる色相で視覚的に均一な明度とコントラスト比を保証します。"
-      },
-      "es": {
-        "eyebrow": "Ciencia del Color",
-        "title": "Matemáticas OKLCH, Gama P3 y Delta EOK",
-        "subtitle": "Por qué DESIGN:OS abandona HSL/Hex en favor del espacio perceptualmente uniforme OKLCH.",
-        "notes": "OKLCH garantiza una luminosidad percibida uniforme, asegurando verdadera accesibilidad."
-      },
-      "fr": {
-        "eyebrow": "Science des Couleurs",
-        "title": "Mathématiques OKLCH, Espace P3 &amp; Delta EOK",
-        "subtitle": "Pourquoi DESIGN:OS abandonne HSL/Hex au profit de l'espace perceptuellement uniforme OKLCH.",
-        "notes": "OKLCH assure une luminosité perçue constante sur toutes les teintes pour une accessibilité parfaite."
-      },
-      "zh": {
-        "eyebrow": "色彩科学与数学",
-        "title": "OKLCH 感知均匀色彩空间、P3 广色域与 ΔEOK",
-        "subtitle": "揭秘为何 DESIGN:OS 全面废黜传统 HSL/RGB，转向视觉感知一致的现代 OKLCH 色彩体系。",
-        "notes": "OKLCH 严格保证感知亮度 L 的物理一致性，结合 ΔEOK 实现 Semver 破坏性颜色变更的自动判定。"
-      }
-    },
-    "21": {
-      "en": {
-        "eyebrow": "Scroll-Driven Cinema",
-        "title": "Scroll-Cinema: The Art of Seamless Camera Flight",
-        "subtitle": "Chaining separately rendered video clips into a single continuous take driven directly by scroll gestures.",
-        "notes": "The seam is the product: position and velocity continuity must hold perfectly so the flight feels like one unbroken take."
-      },
-      "vi": {
-        "eyebrow": "Điện Ảnh Cuộn Trang",
-        "title": "Scroll-Cinema: Nghệ Thuật Cuộn Phim Không Vết Cắt",
-        "subtitle": "Kỹ thuật ráp nối các đoạn clip riêng lẻ thành một cú máy one-take duy nhất điều khiển trực tiếp bằng ngón tay cuộn chuột.",
-        "notes": "Mối nối (Seam) là sản phẩm: đảm bảo tính liên tục về vị trí và vận tốc để người xem cảm nhận như 1 cú máy one-take duy nhất."
-      },
-      "ko": {
-        "eyebrow": "스크롤 시네마",
-        "title": "스크롤 시네마: 이음새 없는 카메라 비행의 미학",
-        "subtitle": "개별 렌더링된 클립들을 스크롤 제스처로 직접 제어하는 하나의 연속적인 원테이크로 결합합니다.",
-        "notes": "이음새(Seam)가 곧 제품입니다. 위치와 속도의 연속성이 유지되어야 단절 없는 비행 경험이 완성됩니다."
-      },
-      "ja": {
-        "eyebrow": "スクロール・シネマ",
-        "title": "スクロールシネマ: 継ぎ目のないカメラ飛行の美学",
-        "subtitle": "個別にレンダリングされた映像を、スクロール操作で操る1つの連続ワンテイクへと結合します。",
-        "notes": "シーム（継ぎ目）こそが品質の核心です。位置と速度の連続性を厳格に保持します。"
-      },
-      "es": {
-        "eyebrow": "Cine Guiado por Scroll",
-        "title": "Scroll-Cinema: El Arte del Vuelo de Cámara Continuo",
-        "subtitle": "Uniendo clips independientes en una toma continua impulsada directamente por el desplazamiento.",
-        "notes": "La costura es el producto: la continuidad de posición y velocidad debe mantenerse intacta."
-      },
-      "fr": {
-        "eyebrow": "Cinéma au Défilement",
-        "title": "Scroll-Cinéma: L'Art du Vol de Caméra Continu",
-        "subtitle": "Assembler des clips distincts en un plan-séquence unique contrôlé par le défilement.",
-        "notes": "La jointure est le produit: la continuité de position et de vitesse doit être absolue."
-      },
-      "zh": {
-        "eyebrow": "滚动电影工程",
-        "title": "Scroll-Cinema: 无缝一镜到底的滚动电影艺术",
-        "subtitle": "通过接缝物理定律（Seam Physics），将多段 AI 生成的视频切片拼接为单手指掌控的超高清一镜到底体验。",
-        "notes": "接缝即产品：严格遵循位置连续性与速度矢量锁定，绝不允许在接缝处产生任何倒车眩晕卡顿。"
-      }
-    },
-    "27": {
-      "en": {
-        "eyebrow": "Fable Thinking",
-        "title": "The 5 Design Fables: Philosophy Behind Master Craft",
-        "subtitle": "Distilling complex engineering mechanisms into intuitive allegorical archetypes.",
-        "notes": "These 5 fables embody the deep design engineering philosophy behind DESIGN:OS."
-      },
-      "vi": {
-        "eyebrow": "Tư Duy Ngụ Ngôn",
-        "title": "5 Ngụ Ngôn Triết Lý Thiết Kế (Design Fables)",
-        "subtitle": "Đúc kết những cơ chế kỹ thuật phức tạp thành các hình tượng ngụ ngôn trực quan dễ ghi nhớ.",
-        "notes": "5 câu chuyện ngụ ngôn là tổng kết triết lý sâu sắc nhất đằng sau toàn bộ công nghệ của DESIGN:OS."
-      },
-      "ko": {
-        "eyebrow": "우화적 사고 모델",
-        "title": "5가지 디자인 우화: 마스터 크래프트 뒤에 숨겨진 철학",
-        "subtitle": "복잡한 엔지니어링 메커니즘을 직관적인 우화적 아키타입으로 압축하여 전달합니다.",
-        "notes": "이 5가지 우화는 DESIGN:OS 기술 전반에 흐르는 깊은 디자인 철학을 상징합니다."
-      },
-      "ja": {
-        "eyebrow": "寓話的思考法",
-        "title": "5つのデザイン寓話: 卓越したクラフトを支える哲学",
-        "subtitle": "複雑なエンジニアリング構造を、記憶に残りやすい直感的な寓話モデルへと昇華します。",
-        "notes": "これら5つの寓話は、DESIGN:OSの設計思想の真髄を端的に物語っています。"
-      },
-      "es": {
-        "eyebrow": "Pensamiento de Fábulas",
-        "title": "Las 5 Fábulas de Diseño: Filosofía Detrás del Diseño Maestro",
-        "subtitle": "Sintetizando mecanismos complejos en arquetipos alegóricos memorables.",
-        "notes": "Estas 5 fábulas representan la filosofía fundamental de ingeniería de DESIGN:OS."
-      },
-      "fr": {
-        "eyebrow": "Pensée par Fables",
-        "title": "Les 5 Fables de Design: La Philosophie du Grand Design",
-        "subtitle": "Transformer des mécanismes complexes en archétypes allégoriques mémorables.",
-        "notes": "Ces 5 fables incarnent la philosophie profonde d'ingénierie qui anime DESIGN:OS."
-      },
-      "zh": {
-        "eyebrow": "AK 寓言式思维",
-        "title": "5 大设计寓言: 卓越工程背后的系统哲学",
-        "subtitle": "将极其精密复杂的软件架构与美学规范，提炼为直指人心的 5 大直觉寓言模型。",
-        "notes": "5 大寓言是 DESIGN:OS 最深层的灵魂沉淀：用无缝飞行、双向之桥与14块坚硬踏板构筑工业级奇迹。"
-      }
-    },
-    "28": {
-      "en": {
-        "eyebrow": "Quickstart Guide",
-        "title": "Start in 60 Seconds: Production Ready",
-        "subtitle": "Install toolchain, compile design tokens, and launch your first AI agent with deterministic quality guarantees.",
-        "notes": "You are now fully equipped to build production-grade web interfaces and Figma canvases with DESIGN:OS."
-      },
-      "vi": {
-        "eyebrow": "Khởi Động Nhanh",
-        "title": "Bắt Đầu Ngay Trong 60 Giây",
-        "subtitle": "Cài đặt bộ công cụ, biên dịch design tokens và khởi chạy agent đầu tiên với bảo chứng chất lượng tuyệt đối.",
-        "notes": "Bạn đã sẵn sàng để xây dựng các sản phẩm web và canvas Figma đẳng cấp thế giới cùng DESIGN:OS."
-      },
-      "ko": {
-        "eyebrow": "빠른 시작 가이드",
-        "title": "60초 안에 시작하기: 프로덕션 준비 완료",
-        "subtitle": "툴체인을 설치하고, 디자인 토큰을 컴파일하며, 결정론적 품질 보증을 갖춘 첫 AI 에이전트를 실행하세요.",
-        "notes": "이제 DESIGN:OS와 함께 최고 수준의 웹 및 피그마 캔버스를 구축할 준비가 완료되었습니다."
-      },
-      "ja": {
-        "eyebrow": "クイックスタート",
-        "title": "60秒で始める: 本番対応",
-        "subtitle": "ツールチェーンをインストールし、トークンをコンパイルして、決定論的な品質保証のもとで最初のAIを起動します。",
-        "notes": "これでDESIGN:OSを活用して、最高品質のWebとFigmaを制作する準備が整いました。"
-      },
-      "es": {
-        "eyebrow": "Inicio Rápido",
-        "title": "Comienza en 60 Segundos: Listo para Producción",
-        "subtitle": "Instala la suite de herramientas, compila tus tokens y lanza tu primer agente AI con calidad garantizada.",
-        "notes": "Ahora estás listo para construir interfaces web y lienzos de Figma de clase mundial con DESIGN:OS."
-      },
-      "fr": {
-        "eyebrow": "Démarrage Rapide",
-        "title": "Démarrer en 60 Secondes: Prêt pour la Production",
-        "subtitle": "Installez les outils, compilez les tokens et lancez votre premier agent IA avec une garantie totale de qualité.",
-        "notes": "Vous êtes désormais équipé pour créer des interfaces web et des maquettes Figma de niveau mondial."
-      },
-      "zh": {
-        "eyebrow": "快速上手",
-        "title": "60 秒极速起步: 生产级就绪",
-        "subtitle": "安装全局工具链，编译 DTCG 设计令牌，以完全确定性的质量保障启动您的第一个 AI 设计智能体。",
-        "notes": "恭喜！您已全面掌握 DESIGN:OS 的全套精髓，开启确定性工业级设计之旅。"
+        "title": "FIGMA LIVE<br>DESKTOP BRIDGE",
+        "body": "Direct local WebSocket synchronization between the code repository and live Figma Desktop canvas. Pushes DTCG design tokens as native Figma Variables and pulls Auto-Layout frames as parsed AST.",
+        "heroNum": "9410",
+        "heroLabel": "Local Broker Port",
+        "notes": "The 2-way bridge guarantees seamless collaboration between developers in IDE and designers in Figma Desktop."
       }
     },
     "11": {
       "en": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Slide 11 architectural overview."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "vi": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Tổng quan kiến trúc slide 11."
+        "title": "TOKEN CHÂN LÝ<br>W3C DTCG",
+        "body": "Hệ thống token biên dịch qua chuẩn W3C DTCG là nguồn chân lý duy nhất, xuất bản đồng thời CSS custom properties, Tailwind plugin và native Figma Variables.",
+        "heroNum": "100 %",
+        "heroLabel": "Ràng Buộc AST Token",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "ko": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "슬라이드 11 아키텍처 개요."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "ja": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "スライド 11 アーキテクチャ概要。"
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "es": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Resumen arquitectónico de la diapositiva 11."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "fr": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "Aperçu architectural de la diapositive 11."
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       },
       "zh": {
-        "eyebrow": "Canvas Craft",
-        "title": "Crafting Canvas Art: Auto-Layout &amp; Variables",
-        "subtitle": "Deterministic Figma node construction.",
-        "notes": "第 11 页系统架构深度解析。"
+        "title": "CANONICAL<br>TOKENS",
+        "body": "Design tokens compiled through the W3C DTCG standard represent the single source of truth across all platforms, exporting CSS custom properties, Tailwind plugins, and native Figma Variables simultaneously.",
+        "heroNum": "100 %",
+        "heroLabel": "Token AST Binding",
+        "notes": "Never hardcode raw values in code or canvas. All dimensions, colors, and elevations must resolve through DTCG alias tokens."
       }
     },
     "12": {
       "en": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Slide 12 architectural overview."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "vi": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Tổng quan kiến trúc slide 12."
+        "title": "4 CỬA ẢI<br>KIỂM ĐỊNH",
+        "body": "Tháp lọc 4 tầng kiểm tra mọi bản dựng trước khi phát hành: taste-lint bắt anti-pattern, validate-layout ngăn tràn lề và container soup, a11y-lint đạt WCAG 2.2 AA và audit tổng.",
+        "heroNum": "0",
+        "heroLabel": "Lỗi Được Phép Xuất Xưởng",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "ko": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "슬라이드 12 아키텍처 개요."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "ja": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "スライド 12 アーキテクチャ概要。"
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "es": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Resumen arquitectónico de la diapositiva 12."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "fr": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "Aperçu architectural de la diapositive 12."
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       },
       "zh": {
-        "eyebrow": "Audit Matrix",
-        "title": "Dissecting the 4 'Audit' Surfaces",
-        "subtitle": "Clear distinction between the 4 audit modalities.",
-        "notes": "第 12 页系统架构深度解析。"
+        "title": "4 QUALITY<br>SURFACES",
+        "body": "The 4-stage quality sieve inspects every generation before release: ui taste-lint catches anti-patterns, validate-layout prevents overflow and container soup, a11y-lint verifies WCAG 2.2 AA, and full audit gates release.",
+        "heroNum": "0",
+        "heroLabel": "Errors Allowed to Ship",
+        "notes": "Each surface focuses on a distinct defect domain. Full audit must produce Exit 0 before any PR merge."
       }
     },
     "13": {
       "en": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Slide 13 architectural overview."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "vi": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Tổng quan kiến trúc slide 13."
+        "title": "GIAO THỨC<br>XỬ LÝ LỖI",
+        "body": "Mọi cảnh báo tuân thủ quy tắc 3 bước: Tự động sửa qua ui autofix, tái cấu trúc layout tối đa 3 vòng lặp, và chuyển tiếp lên người dùng nếu có xung đột không thể tự giải quyết.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Vòng Lặp Hội Tụ Tối Đa",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "ko": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "슬라이드 13 아키텍처 개요."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "ja": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "スライド 13 アーキテクチャ概要。"
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "es": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Resumen arquitectónico de la diapositiva 13."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "fr": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "Aperçu architectural de la diapositive 13."
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       },
       "zh": {
-        "eyebrow": "Finding Triage",
-        "title": "Finding Triage Workflow &amp; 2 Golden Rules",
-        "subtitle": "How to triage, verify, and resolve issues.",
-        "notes": "第 13 页系统架构深度解析。"
+        "title": "TRIAGE &<br>AUTODETECT",
+        "body": "Every static finding follows a strict 3-tier triage rule: Autodefects are resolved via ui autofix, semantic layout issues are refactored within 3 iterations, and unresolvable conflicts escalate to user review.",
+        "heroNum": "≤ 3",
+        "heroLabel": "Turns to Convergence",
+        "notes": "Never enter infinite loop refactors. If an issue cannot be resolved in 3 turns, request human guidance."
       }
     },
     "14": {
       "en": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Slide 14 architectural overview."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "vi": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Tổng quan kiến trúc slide 14."
+        "title": "VÒNG LẶP<br>KÝ ỨC VECTOR",
+        "body": "Học hỏi liên tục qua không gian vector ONNX cục bộ. Đề bài mới truy vấn ký ức thiết kế cũ, các bài học trước đó mồi agent để không bao giờ lặp lại sai lầm trong quá khứ.",
+        "heroNum": "0.85",
+        "heroLabel": "Ngưỡng Truy Hồi Cosine",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "ko": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "슬라이드 14 아키텍처 개요."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "ja": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "スライド 14 アーキテクチャ概要。"
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "es": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Resumen arquitectónico de la diapositiva 14."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "fr": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "Aperçu architectural de la diapositive 14."
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       },
       "zh": {
-        "eyebrow": "Vector Memory",
-        "title": "Design Memory Loop (Recall &amp; Reflect)",
-        "subtitle": "Semantic memory query, synthesize, and store.",
-        "notes": "第 14 页系统架构深度解析。"
+        "title": "VECTOR<br>MEMORY LOOP",
+        "body": "Continuous learning powered by local vector embeddings. Incoming user briefs query historical design memories; previous corrections prime the agent to guarantee historical mistakes are never repeated.",
+        "heroNum": "0.85",
+        "heroLabel": "Recall Cosine Threshold",
+        "notes": "Every design critique and user correction is distilled into permanent memory, compounding organizational craft over time."
       }
     },
     "15": {
       "en": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Slide 15 architectural overview."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "vi": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Tổng quan kiến trúc slide 15."
+        "title": "LÒ LUYỆN<br>ĐÚC KẾT BÀI HỌC",
+        "body": "Phản tư sau khi sinh giao diện tự động trích xuất quy tắc thẩm mỹ từ chỉnh sửa của người dùng và PR diff, lưu trữ vào .design/memory.json hoàn toàn riêng tư cục bộ.",
+        "heroNum": "100 %",
+        "heroLabel": "Bảo Mật Ký Ức Cục Bộ",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "ko": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "슬라이드 15 아키텍처 개요."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "ja": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "スライド 15 アーキテクチャ概要。"
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "es": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Resumen arquitectónico de la diapositiva 15."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "fr": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "Aperçu architectural de la diapositive 15."
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
       },
       "zh": {
-        "eyebrow": "Taste Elo",
-        "title": "Taste Elo Rating &amp; Sample Curation",
-        "subtitle": "Blind pair-wise voting to curate top specimens.",
-        "notes": "第 15 页系统架构深度解析。"
+        "title": "CRUCIBLE<br>DISTILLATION",
+        "body": "Post-generation reflection automatically extracts actionable craft rules from user overrides and merged PR diffs, crystallizing new invariants into .design/memory.json with zero cloud exposure.",
+        "heroNum": "100 %",
+        "heroLabel": "Local Privacy Capture",
+        "notes": "Distilled lessons are structured, tagged by component type, and ranked by frequency of occurrence."
+      }
+    },
+    "16": {
+      "en": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "vi": {
+        "title": "KHOA HỌC MÀU<br>OKLCH DISPLAY P3",
+        "body": "Chuẩn hóa không gian màu OKLCH triệt tiêu biến dạng độ sáng cảm nhận của HSL. Tạo dải màu hài hòa toán học với độ sáng đồng nhất trên 100% dải màu rộng Display P3.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Độ Chuẩn Xác Semver Patch",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "ko": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "ja": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "es": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "fr": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
+      },
+      "zh": {
+        "title": "OKLCH COLOR<br>SCIENCE",
+        "body": "Standardizing on the OKLCH color space eliminates HSL perceptual brightness distortion. Generates harmonious color scales with mathematically constant perceived lightness across 100% Display P3 gamut.",
+        "heroNum": "ΔE 0.02",
+        "heroLabel": "Semver Patch Precision",
+        "notes": "Color changes are governed by semantic versioning: Delta E under 0.02 is patch, under 0.05 is minor, above 0.05 is major."
       }
     },
     "17": {
       "en": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Slide 17 architectural overview."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "vi": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Tổng quan kiến trúc slide 17."
+        "title": "RADAR THẨM MỸ<br>6+1 TRỤC",
+        "body": "Đánh giá thẩm mỹ khách quan trên 6 chiều giác quan: Layout, Typography, Spacing, Iconography, Motion và Depth, xoay quanh mỏ neo bắt buộc Core 0 Tính nhất quán.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Điểm Tối Thiểu Xuất Xưởng",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "ko": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "슬라이드 17 아키텍처 개요."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "ja": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "スライド 17 アーキテクチャ概要。"
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "es": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Resumen arquitectónico de la diapositiva 17."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "fr": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "Aperçu architectural de la diapositive 17."
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       },
       "zh": {
-        "eyebrow": "Taste Rubric",
-        "title": "6+1 Aesthetic Axes (Taste Rubric)",
-        "subtitle": "Scoring every axis from 0 to 10 with hard floors.",
-        "notes": "第 17 页系统架构深度解析。"
+        "title": "6+1 TASTE<br>RUBRIC RADAR",
+        "body": "Objective aesthetic evaluation across 6 sensory dimensions—Layout, Typography, Spacing, Iconography, Motion, and Depth—centered around the mandatory Core 0 Token Consistency anchor.",
+        "heroNum": "8.0 +",
+        "heroLabel": "Minimum Score to Ship",
+        "notes": "A design cannot ship if Consistency Core 0 is breached, regardless of how high individual aesthetic axes score."
       }
     },
     "18": {
       "en": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Slide 18 architectural overview."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "vi": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Tổng quan kiến trúc slide 18."
+        "title": "12 ĐỊNH LUẬT<br>CÔNG HỌC UX",
+        "body": "Áp dụng công học kinh điển—vùng chạm Fitts Law (≥ 44px), phân đoạn Miller Law, độ trễ Hick Law và mô hình tâm trí Jakob Law trực tiếp vào linter và token.",
+        "heroNum": "12",
+        "heroLabel": "Luật Công Học Thực Thi",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "ko": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "슬라이드 18 아키텍처 개요."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "ja": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "スライド 18 アーキテクチャ概要。"
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "es": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Resumen arquitectónico de la diapositiva 18."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "fr": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "Aperçu architectural de la diapositive 18."
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       },
       "zh": {
-        "eyebrow": "Machine Floor",
-        "title": "14 Hard Machine Floor Linters",
-        "subtitle": "Zero tolerance deterministic code linters.",
-        "notes": "第 18 页系统架构深度解析。"
+        "title": "12 COGNITIVE<br>UX LAWS",
+        "body": "Enforcing classic ergonomics—Fitts Law touch targets (min 44px), Miller Law chunking, Hick Law decision latency, and Jakob Law mental models—directly into layout linters and token presets.",
+        "heroNum": "12",
+        "heroLabel": "Enforced Ergonomic Laws",
+        "notes": "UX laws are encoded into deterministic linter rules so accessibility and ergonomics cannot be bypassed."
       }
     },
     "19": {
       "en": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Slide 19 architectural overview."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "vi": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Tổng quan kiến trúc slide 19."
+        "title": "BỘ PERSONA<br>BẢN SẮC THIẾT KẾ",
+        "body": "11 bản sắc thiết kế độc đáo: Editorial, Hyper-Density, Brutalist, Spatial Glass, Retro Terminal. Mỗi persona định hình thang phông, bo góc, độ sâu bóng đổ và tốc độ chuyển động.",
+        "heroNum": "11",
+        "heroLabel": "Bản Sắc Thiết Kế Riêng",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "ko": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "슬라이드 19 아키텍처 개요."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "ja": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "スライド 19 アーキテクチャ概要。"
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "es": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Resumen arquitectónico de la diapositiva 19."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "fr": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "Aperçu architectural de la diapositive 19."
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       },
       "zh": {
-        "eyebrow": "Cognitive Laws",
-        "title": "12 Classical Cognitive UX Laws",
-        "subtitle": "Integrating Fitts, Hick, Miller, and Doherty into code.",
-        "notes": "第 19 页系统架构深度解析。"
+        "title": "DESIGN<br>PERSONAS",
+        "body": "11 distinctive aesthetic stances spanning Editorial, Hyper-Density, Brutalist, Spatial Glass, and Retro Terminal. Each persona dictates typography scales, corner radii, elevation depth, and motion speed.",
+        "heroNum": "11",
+        "heroLabel": "Bespoke Design Personas",
+        "notes": "Explicit persona declarations prevent generic corporate dashboard syndrome."
       }
     },
     "20": {
       "en": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Slide 20 architectural overview."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "vi": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Tổng quan kiến trúc slide 20."
+        "title": "THANG BẬC<br>CHUYỂN ĐỘNG",
+        "body": "Kỷ luật chuyển động phân tầng: Chỉ leo từ T1 Phản hồi xúc giác lên T6 WebGL khi câu chuyện đòi hỏi và ngân sách cho phép, bảo vệ tuyệt đối bởi prefers-reduced-motion.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Ngân Sách Khung Hình Khóa",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "ko": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "슬라이드 20 아키텍처 개요."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "ja": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "スライド 20 アーキテクチャ概要。"
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "es": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Resumen arquitectónico de la diapositiva 20."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "fr": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "Aperçu architectural de la diapositive 20."
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
       },
       "zh": {
-        "eyebrow": "Motion Ladder",
-        "title": "6-Tier Motion Ladder (T1–T6)",
-        "subtitle": "From subtle hover to continuous spatial camera flights.",
-        "notes": "第 20 页系统架构深度解析。"
+        "title": "THE MOTION<br>LADDER",
+        "body": "Tiered kinetic discipline: Climb from T1 Micro-feedback up to T6 WebGL only when the product narrative demands it and performance budgets allow, strictly clamped by prefers-reduced-motion fallbacks.",
+        "heroNum": "60 FPS",
+        "heroLabel": "Locked Kinetic Budget",
+        "notes": "Animations must serve narrative purpose. Decorative motion without function is classified as code debt."
+      }
+    },
+    "21": {
+      "en": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "vi": {
+        "title": "ĐIỆN ẢNH CUỘN<br>SCROLL-CINEMA",
+        "body": "Nối chuỗi các phân đoạn camera không gian thành đường bay liên tục 60fps điều khiển trực tiếp bằng thao tác cuộn, khóa chính xác bằng ngàm vật lý vận tốc tiếp tuyến.",
+        "heroNum": "0 ms",
+        "heroLabel": "Độ Giật Cục Chuyển Tiếp",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "ko": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "ja": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "es": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "fr": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
+      },
+      "zh": {
+        "title": "SCROLL-CINEMA<br>FLIGHT",
+        "body": "Chaining separately rendered spatial camera sequences into a continuous 60fps flight driven directly by user scroll gestures, locked by frame-matching kinetic velocity seams.",
+        "heroNum": "0 ms",
+        "heroLabel": "Seam Handoff Stutter",
+        "notes": "Seam physics guarantee velocity vector alignment between Hero Orbit, Exploded View, and Macro Core."
       }
     },
     "22": {
       "en": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Slide 22 architectural overview."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "vi": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Tổng quan kiến trúc slide 22."
+        "title": "KHÔNG GIAN 3D<br>GFLOW HARDWARE",
+        "body": "Module GFlow chuyên biệt mang lại shader WebGL tăng tốc phần cứng, nén hình học Draco và vòng đời thu hồi bộ nhớ nghiêm ngặt chống rò rỉ GPU.",
+        "heroNum": "2 K",
+        "heroLabel": "Độ Phân Giải Subpixel 2K",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "ko": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "슬라이드 22 아키텍처 개요."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "ja": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "スライド 22 アーキテクチャ概要。"
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "es": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Resumen arquitectónico de la diapositiva 22."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "fr": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "Aperçu architectural de la diapositive 22."
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       },
       "zh": {
-        "eyebrow": "GFlow Video AI",
-        "title": "GFlow Hand: Google Flow Automation (Veo / Imagen)",
-        "subtitle": "Video-to-Video and Image-to-Video camera control.",
-        "notes": "第 22 页系统架构深度解析。"
+        "title": "3D SPATIAL<br>GFLOW",
+        "body": "Dedicated GFlow hand provides hardware-accelerated WebGL canvas shaders, Draco compressed geometries, and strict memory lifecycle teardown preventing GPU leaks.",
+        "heroNum": "2 K",
+        "heroLabel": "Subpixel Texture Resolution",
+        "notes": "All WebGL contexts must implement explicit destroy and dispose lifecycles on slide or view unmount."
       }
     },
     "23": {
       "en": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Slide 23 architectural overview."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "vi": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Tổng quan kiến trúc slide 23."
+        "title": "KIỂM ĐỊNH<br>HÌNH ẢNH HỒI QUY",
+        "body": "Ma trận hồi quy thị giác headless tự động chụp toàn trang trên 3 kích thước 1920, 1440 và 390, chứng minh không có độ trôi layout hay lỗi font trước khi duyệt PR.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Màn Hình Đã Xác Minh",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "ko": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "슬라이드 23 아키텍처 개요."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "ja": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "スライド 23 アーキテクチャ概要。"
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "es": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Resumen arquitectónico de la diapositiva 23."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "fr": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "Aperçu architectural de la diapositive 23."
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       },
       "zh": {
-        "eyebrow": "WebGL Canvas",
-        "title": "Canvas T6 &amp; WebGL Shaders: Liquid Glass",
-        "subtitle": "High-performance shaders with strict teardown contract.",
-        "notes": "第 23 页系统架构深度解析。"
+        "title": "VISUAL<br>REGRESSION",
+        "body": "Automated headless visual regression matrices capture full-page snapshots across 1920, 1440, and 390 viewports, verifying zero layout shifts or font hydration glitches prior to PR approval.",
+        "heroNum": "3 / 3",
+        "heroLabel": "Viewports Verified",
+        "notes": "Automated headless Playwright sweeps catch subtle overflow and clipping before human review."
       }
     },
     "24": {
       "en": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Slide 24 architectural overview."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "vi": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Tổng quan kiến trúc slide 24."
+        "title": "ĐÚC KẾT &<br>TÍCH LŨY TAY NGHỀ",
+        "body": "Mỗi lần giao hàng kích hoạt phản tư tự động: chấm điểm biến thể, ghi nhận lựa chọn của con người và tích lũy gu thẩm mỹ vào kho tri thức chung của tổ chức.",
+        "heroNum": "10 X",
+        "heroLabel": "Gia Tốc Tốc Độ Đội Ngũ",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "ko": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "슬라이드 24 아키텍처 개요."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "ja": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "スライド 24 アーキテクチャ概要。"
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "es": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Resumen arquitectónico de la diapositiva 24."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "fr": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "Aperçu architectural de la diapositive 24."
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       },
       "zh": {
-        "eyebrow": "Delivery Contract",
-        "title": "Qualified Delivery Contract v2",
-        "subtitle": "The 5 mandatory artifacts before merging PR.",
-        "notes": "第 24 页系统架构深度解析。"
+        "title": "COMPOUNDED<br>CRAFT REFLECTION",
+        "body": "Every design delivery triggers an automated reflection pass: scoring aesthetic variants, recording human selection patterns, and compounding design taste directly into the shared repository corpus.",
+        "heroNum": "10 X",
+        "heroLabel": "Design Team Velocity",
+        "notes": "Compounding craft transforms single-use generations into permanent organizational capability."
       }
     },
     "25": {
       "en": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Slide 25 architectural overview."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "vi": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Tổng quan kiến trúc slide 25."
+        "title": "QUY TRÌNH<br>ĐÓNG GÓI 6 BƯỚC",
+        "body": "Tháp tinh chế đóng gói bắt buộc chạy công cụ theo đúng thứ tự bắt lỗi: Flow state machine, Evidence mục tiêu, VR baseline, Token cặp đôi, Rendered a11y và Full audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Cửa Ải Đạt Chuẩn",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "ko": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "슬라이드 25 아키텍처 개요."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "ja": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "スライド 25 アーキテクチャ概要。"
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "es": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Resumen arquitectónico de la diapositiva 25."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "fr": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "Aperçu architectural de la diapositive 25."
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       },
       "zh": {
-        "eyebrow": "Full-Stack Audit",
-        "title": "The Mandatory 6-Step Full-Stack Audit Pipeline",
-        "subtitle": "Executing linters in the exact defect-catching order.",
-        "notes": "第 25 页系统架构深度解析。"
+        "title": "DELIVERY<br>PIPELINE",
+        "body": "The mandatory 6-stage delivery refinery executes tools in the exact order that catches defects: Flow validation, Evidence alignment, VR baseline, Paired tokens, Rendered a11y, and Full-stack audit.",
+        "heroNum": "6 / 6",
+        "heroLabel": "Pipeline Stages Passed",
+        "notes": "Never invert the pipeline order. Flow validation must precede token checks to avoid wasted lint runs."
       }
     },
     "26": {
       "en": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Slide 26 architectural overview."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "vi": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Tổng quan kiến trúc slide 26."
+        "title": "BẢNG PHÂN LOẠI<br>PHIÊN BẢN SEMVER",
+        "body": "Quy tắc Semantic Versioning chặt chẽ cho thiết kế: Chỉnh token nhỏ là Patch, thêm component là Minor, thay đổi màu Delta E > 0.05 bắt buộc nâng Major.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Ràng Buộc Semver Sản Xuất",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "ko": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "슬라이드 26 아키텍처 개요."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "ja": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "スライド 26 アーキテクチャ概要。"
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "es": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Resumen arquitectónico de la diapositiva 26."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "fr": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "Aperçu architectural de la diapositive 26."
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
       },
       "zh": {
-        "eyebrow": "Delivery Checklist",
-        "title": "Delivery Checklist &amp; PR Semver Matrix",
-        "subtitle": "Evaluating patch vs minor vs major breaking changes.",
-        "notes": "第 26 页系统架构深度解析。"
+        "title": "SEMVER PR<br>MATRIX",
+        "body": "Rigorous semantic versioning rules for design releases: Non-breaking token tweaks are Patches, new component additions are Minors, and color palette shifts above Delta E 0.05 mandate Major version bumps.",
+        "heroNum": "v1.0.0",
+        "heroLabel": "Production Semver Bound",
+        "notes": "Mathematical Semver prevents downstream web apps from silently breaking on upstream token changes."
+      }
+    },
+    "27": {
+      "en": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "vi": {
+        "title": "5 CÂU CHUYỆN<br>NGỤ NGÔN THIẾT KẾ",
+        "body": "Chuyển hóa sơ đồ mã khô khan thành thực thể cơ học sống động: Chuyến Bay Liền Mạch, Cây Cầu Hai Bờ, Sàn Thép 14 Tấm, Thang Chuyển Động và Ký Ức Đúc Kết.",
+        "heroNum": "5",
+        "heroLabel": "Ngụ Ngôn Không Gian Sống",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "ko": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "ja": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "es": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "fr": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      },
+      "zh": {
+        "title": "THE 5 DESIGN<br>FABLES",
+        "body": "Transforming abstract code diagrams into living spatial mechanisms: The Seamless Flight, The Two-Way Bridge, The 14-Plank Floor, The Motion Ladder, and Sol Vector Distillation.",
+        "heroNum": "5",
+        "heroLabel": "Living Design Fables",
+        "notes": "Every diagram in DESIGN:OS tells a functional spatial story, rejecting isomorphic card templates."
+      }
+    },
+    "28": {
+      "en": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "vi": {
+        "title": "SẴN SÀNG CHO<br>SẢN XUẤT",
+        "body": "Hệ thống thiết kế đa runtime của bạn đã được biên dịch, kiểm định và sẵn sàng. Chạy ui generate để tạo trải nghiệm tiếp theo với độ chuẩn xác tuyệt đối và tốc độ tức thì.",
+        "heroNum": "SHIP",
+        "heroLabel": "Sàn Chất Lượng Giao Hàng",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "ko": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "ja": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "es": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "fr": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
+      },
+      "zh": {
+        "title": "READY FOR<br>PRODUCTION",
+        "body": "Your complete multi-runtime design system is compiled, audited, and ready. Run ui generate to create your next experience with guaranteed mathematical perfection, zero LLM luck, and instant speed.",
+        "heroNum": "SHIP",
+        "heroLabel": "Qualified Delivery Floor",
+        "notes": "Thank you for completing the DESIGN:OS 28-Slide Masterclass. Build something extraordinary today!"
       }
     }
   }


### PR DESCRIPTION
Complete 28-Slide Radiant Big Number Redesign:
- Exact aesthetic match to reference style: Obsidian matte canvas + Luminous gradient master card + Tactile metric orbs cluster.
- Big Numbers, Less Content, High Visual Density.
- Massive condensed display uppercase typography (60px) + gigantic hero numbers (96px).
- Fable Thinking applied across all 28 slides.
- Full 7-language i18n support.
- 0 errors across 10 design-os audit tools.