### PR TITLE
docs(slides): fold projection-deck lessons into the slide mode and workflow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,3 +104,12 @@ The linter shipped with the Tenant-section emitter that fails any emitted sectio
 write, AND fails a host layout that puts `overflow`/`transform`/`filter`/`contain` on a sticky-pin
 ancestor (silently kills `position:sticky`). Emitter + linter, same commit.
 _Avoid_: embed-check, section-validator
+
+**Plate**:
+A generated image placed BEHIND content to light a surface, never to carry it — the surface
+carries the text. Lives on its own layer (a masked pseudo-element) rather than as the host
+element's `background-image`, because a background drags the host's rectangle along with it and
+any image whose ground is not perfectly black then shows its bounding box. A plate is admitted
+only where the image IS the evidence for that surface's claim.
+_Avoid_: background image (that names the mechanism a plate deliberately avoids), hero image,
+texture, decoration

--- a/knowledge/mode-constraints.md
+++ b/knowledge/mode-constraints.md
@@ -202,11 +202,36 @@ Target: a presentation slide (deck member).
   `width:1920px; height:1080px; overflow:hidden; position:relative; margin:0;`.
   Nothing may extend beyond 1920 × 1080. No scrollbars. No clipped content.
 - **Fill & fit (critical):** Content must fill the **entire** viewport. Put `h-[1080px]`
-  (or `min-h-[1080px]`) on the main wrapper and use `flex flex-col justify-between` or CSS
-  Grid to distribute content vertically. No large empty regions — if content is sparse,
-  scale up typography, increase spacing, or add visual elements.
-- **Typography:** Display/Title 64–96 px/Bold, H1 48 px/Bold, H2 36 px/Semibold,
-  Body 24–28 px, Caption 18 px. Headlines should be large; body text substantial.
+  (or `min-h-[1080px]`) on the main wrapper and use CSS Grid or flex to distribute content
+  vertically. No large empty regions — if content is sparse, scale up typography, increase
+  spacing, or add visual elements.
+  **`justify-between` is not a composition.** Filling a container and then spreading N loose
+  children across it produces arbitrary voids — a real deck measured 144 / 120 / 152 px
+  between four children, three different large gaps, none of them a decision. Group the
+  content into **three anchored zones** (a top marker, the substance, a floor block) so the
+  flexible space lands in two places you chose. The machine-checkable form: **large voids
+  inside one container must agree with each other** — two equal voids are a three-zone
+  rhythm, three unequal ones are drift.
+- **Percentage grid columns plus a gap always overflow.** `grid-template-columns: 50% 50%`
+  with any `gap` exceeds the track by exactly that gap; the same is true of every `N% M%`
+  pair. Use `minmax(0, Nfr)` — the `minmax(0, …)` also lets a track shrink below its content
+  so long unbreakable words wrap instead of widening the column.
+- **Typography:** Derive the whole scale from **one modular ratio** (1.333 for an
+  editorial deck); do not hand-pick sizes per element. Display/Title 64–96 px/Bold,
+  H1 48 px/Bold, H2 36 px/Semibold, Body 24–28 px, Caption 18 px.
+  **Know what those numbers mean before trusting them:** a 1080-tall canvas maps a
+  standard 540 pt slide at ~2 px per point, so 24 px body is **~12 pt** — comfortable on
+  a laptop, marginal from the back of a room. The classic projection floor is 24 pt
+  (48 px), but a deck with six-card grids cannot carry 48 px body without cutting copy.
+  **Pick the scale and the words-per-slide together**, and say which you optimised for;
+  a deck read from a link and a deck thrown on a wall are different briefs.
+  Set leading, tracking and weight **per role**, not per element: display tight and
+  negatively tracked, body open at ~1.5, small uppercase labels widened. Express measure
+  in `ch`, never px — a px `max-width` tuned at one size becomes a 24-character column at
+  another.
+- **Type roles are surface-agnostic:** a role used on two different grounds must not
+  hardcode ink for one of them. Let colour inherit from the surface and set it on the
+  surface, or the same headline that reads on a light card is invisible on a dark stage.
 - **Layout:** Generous edge padding (60–120 px). Center content within the padded area.
 - **Colors:** High-contrast text on solid or gradient backgrounds. No low-contrast text.
 - **Backgrounds:** Each slide has a distinct full-bleed background — solid, gradient, or
@@ -215,10 +240,20 @@ Target: a presentation slide (deck member).
   slide body, hidden with `display:none`, holding 1–3 sentences the presenter would say.
 - **Hierarchy:** One main idea per slide. Bold headline, minimal body text — think keynote
   slide, not document.
-- **Imagery:** Large hero images where appropriate; images are decorative, not
-  informational.
-- **Consistency:** All slides in a deck share the same palette, font family, and design
-  language.
+- **Imagery:** An image belongs on a slide only where it **is** the evidence for that
+  slide's claim, or the subject itself — never as atmosphere. Ambient texture applied
+  evenly across a deck reads as decoration, not design, and on card-dense slides it is
+  barely visible anyway: file weight and noise for nothing. Keep an explicit allowlist with
+  a stated reason per image.
+  Content never sits on an unmediated image. A plate lights a surface; the surface carries
+  the text. Give the plate its own layer (a masked pseudo-element), not the card's own
+  `background-image` — a plate painted as the card's background makes the card's rectangle
+  the plate's rectangle, and any image whose ground is not perfectly black shows its
+  bounding box.
+- **Consistency:** All slides share one palette, font family and design language.
+  Consistency means **one legible system, not one uniform treatment** — a magazine does not
+  put a photo on every page. Imagery, emphasis and density may vary by structural role as
+  long as the rule is legible; that is pacing, not inconsistency.
 
 ## Dashboard
 

--- a/templates/workflows/slides.md
+++ b/templates/workflows/slides.md
@@ -334,3 +334,61 @@ The outline does not get re-planned to fix a styling drift.
 
 The deck is finished when every slide passes the per-slide gate and the deck-level
 Consistency check passes.
+
+### Machine-checkable deck gates
+
+Read-through review misses these; each one is a defect a real deck shipped with, and each
+is cheap to automate. Encode them as a runnable check rather than a checklist — a standard
+without a linter drifts.
+
+| Gate | Rule | The failure it catches |
+|---|---|---|
+| `type/tokenised` | every `font-size` resolves through a scale token | 19 hand-picked sizes with no ratio behind them |
+| `type/one-ratio` | the scale's steps hold one ratio | a step nudged in isolation |
+| `space/on-scale` | every gap/pad/margin on one base unit | off-grid values (`6px`, `13px`, `70px`) |
+| `grid/no-percent-columns` | no `N% M%` column pairs | `50%+50%+gap` overflowing every split slide |
+| `css/no-orphan-elements` | no element whose every class is unstyled | a whole slide rendering as a raw text dump |
+| `stage/exact-size` | each slide is exactly the board size | silent clipping |
+| `fit/no-container-spill` | nothing overflows its own padding box | copy running out of its card |
+| `rhythm/voids-agree` | large voids in one container must match | `justify-between` drift |
+| `contrast/wcag-aa` | 4.5:1 body / 3:1 large, against the real surface | a headline invisible on its own ground |
+| `i18n/fit-every-language` | the fit gate runs in **every** shipped language | a deck that clips the moment a viewer switches |
+
+Three traps worth stating outright, because each cost a full debugging pass:
+
+- **Composite before judging contrast.** A gate that reads `rgba(255,255,255,0.07)` as
+  opaque white invents failures; one that ignores gradient stops misses real ones. Take the
+  **worst stop** of a gradient and composite semi-transparent layers over what is beneath.
+  A gate that cries wolf gets ignored, which is worse than no gate.
+- **Measure the settled state.** Sampling a hover before its transition ends measures a
+  frame no user sees; reading the resting style of a control inside a *closed* overlay
+  reports a state that does not exist. Open it, wait for it, then measure.
+- **Prove each gate can fail.** Feed it a violation, confirm red; remove it, confirm green.
+  A gate that has never failed has not been shown to work.
+
+Also test the deck in **every language it ships**. A fit gate run only in the default
+language passes a deck that clips the moment a viewer switches — verbose languages run
+materially longer than the English a layout was tuned against. And an advertised language
+whose content is byte-identical to another is not translated: a picker that silently
+renders English is worse than offering fewer languages.
+
+### If the deck is one navigable page rather than N files
+
+A single-page deck that scales a fixed board with a CSS `transform` carries three extra
+rules, each of which silently breaks otherwise-correct work:
+
+- **Nothing may animate the stage or its ancestors** — it fights the inline scale. Animate
+  slide children only.
+- **Never re-declare type inside `@media`.** Viewport-conditional rules fire *inside* the
+  fixed board and are then scaled again; one deck set body copy to 15 px inside a 1920 px
+  stage, landing at roughly 7 px on a phone. The transform alone does the fitting.
+- Slides toggled `display:none` / `flex` cannot animate on exit — the element is gone.
+  **Enter-only is the correct architecture**, not a compromise. Bind entrance keyframes to
+  an attribute the navigation adds, never to the `active` class alone, or any check that
+  flips that class synchronously will sample a mid-flight frame.
+
+Motion for a deck lives at **T1** (`knowledge/motion-craft.md`): a direction-aware content
+cascade where the chrome stays fixed and only the content zone moves, with forward, back
+and jump visually distinct — a jump is a cut, not a step, because lateral motion implies
+adjacency. Reach past T1 only if the ladder genuinely selects it; shipping a library for a
+fade is the anti-pattern that ladder exists to prevent.


### PR DESCRIPTION
Distils what building a real 28-slide projection deck (#158) taught, into the two files that shape the next one. Every rule here replaced an assumption that shipped a defect.

## `knowledge/mode-constraints.md` — Slide section

**Typography now says what its own numbers mean.** A 1080-tall canvas maps a standard 540pt slide at ~2px per point, so the existing "Body 24–28px" is **~12pt** — comfortable on a laptop, marginal from the back of a room. The classic projection floor is 24pt (**48px**), but a deck with six-card grids cannot carry 48px body without cutting copy. I tried; it broke the deck. The rule is now: **pick the scale and the words-per-slide together, and say which you optimised for.**

Also added: derive the scale from one ratio rather than hand-picking (the deck had accumulated **19 unrelated sizes**); set leading/tracking/weight per *role*; express measure in `ch` not px; and make type roles **surface-agnostic** — ink hardcoded for one card colour made the same headline invisible on another ground.

**`justify-between` is not a composition.** Filling a container then spreading N loose children across it measured **144 / 120 / 152px** — three different large gaps, none a decision. Replaced with three anchored zones, and a checkable form: *large voids in one container must agree with each other.*

**Percentage grid columns plus a gap always overflow** by exactly that gap. This silently broke 12 grids across 11 slides.

**Imagery** was "images are decorative" — now: an image belongs only where it **is** the evidence. Uniform ambient texture reads as decoration; I shipped it across all 28 slides and had to revert. Content never sits on an unmediated plate.

**Consistency** clarified: one legible *system*, not one uniform *treatment*. A magazine doesn't put a photo on every page.

## `templates/workflows/slides.md`

A table of **ten machine-checkable deck gates**, each tied to the defect it catches — plus the three traps that each cost a full debugging pass:

- **Composite before judging contrast.** A gate reading `rgba(255,255,255,0.07)` as opaque white invented 6 false failures. A gate that cries wolf gets ignored.
- **Measure the settled state.** Sampling a hover mid-transition, or a control inside a *closed* overlay, reports a state no user sees.
- **Prove each gate can fail** before trusting it green.

Also: fit-test **every shipped language** (a default-language-only gate passes a deck that clips on switch), and rules for a single-page deck on a transform-scaled stage — never animate the stage, never re-declare type inside `@media` (one deck rendered body copy at ~7px on phones this way), and enter-only animation is correct when slides toggle `display`.

## Verification

`typecheck`, `lint`, `build` pass. `ui knowledge check` — **0 findings**. Docs-only: no `src/` or `tests/` changes.