### PR TITLE
fix(examples): artifacts inherit the design system instead of overriding it

### DIFF
--- a/examples/diagrams/layers.html
+++ b/examples/diagrams/layers.html
@@ -18,57 +18,49 @@
    * and never a literal.
    */
   :root {
-    --color-background:       #fbfaf8;
-    --color-card:             #ffffff;
-    --color-foreground:       #1a1a17;
-    --color-muted-foreground: #6f6f66;
-    --color-border:           #e6e3dd;
-    --color-input:            #d6d2c9;
-    --color-accent:           #b4531f;
-    --color-primary:          #2f5d73;
 
-    --diagram-paper:       var(--color-background);
-    --diagram-surface:     var(--color-card);
-    --diagram-ink:         var(--color-foreground);
-    --diagram-muted:       var(--color-muted-foreground);
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 65%, var(--color-background));
-    --diagram-rule:        var(--color-border);
-    --diagram-rule-solid:  var(--color-input);
-    --diagram-accent:      var(--color-accent);
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 12%, var(--color-background));
-    --diagram-link:        var(--color-primary);
+    --diagram-paper:       var(--color-background, #fbfaf8);
+    --diagram-surface:     var(--color-card, #ffffff);
+    --diagram-ink:         var(--color-foreground, #1a1a17);
+    --diagram-muted:       var(--color-muted-foreground, #6f6f66);
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #6f6f66) 65%, var(--color-background, #fbfaf8));
+    --diagram-rule:        var(--color-border, #e6e3dd);
+    --diagram-rule-solid:  var(--color-input, #d6d2c9);
+    --diagram-accent:      var(--color-accent, #b4531f);
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #b4531f) 12%, var(--color-background, #fbfaf8));
+    --diagram-link:        var(--color-primary, #2f5d73);
 
     --diagram-hairline: 1px;
     --diagram-gap: 24px;
   }
 
   :root[data-theme="dark"] {
-    --color-background:       #14140f;
-    --color-card:             #1c1c17;
-    --color-foreground:       #f2efe9;
-    --color-muted-foreground: #a3a096;
-    --color-border:           #2e2e26;
-    --color-input:            #3d3d33;
-    --color-accent:           #e08c4a;
-    --color-primary:          #7fb4cc;
+    --diagram-paper:       var(--color-background, #14140f);
+    --diagram-surface:     var(--color-card, #1c1c17);
+    --diagram-ink:         var(--color-foreground, #f2efe9);
+    --diagram-muted:       var(--color-muted-foreground, #a3a096);
+    --diagram-rule:        var(--color-border, #2e2e26);
+    --diagram-rule-solid:  var(--color-input, #3d3d33);
+    --diagram-accent:      var(--color-accent, #e08c4a);
+    --diagram-link:        var(--color-primary, #7fb4cc);
 
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
   }
 
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
-      --color-background:       #14140f;
-      --color-card:             #1c1c17;
-      --color-foreground:       #f2efe9;
-      --color-muted-foreground: #a3a096;
-      --color-border:           #2e2e26;
-      --color-input:            #3d3d33;
-      --color-accent:           #e08c4a;
-      --color-primary:          #7fb4cc;
+      --diagram-paper:       var(--color-background, #14140f);
+      --diagram-surface:     var(--color-card, #1c1c17);
+      --diagram-ink:         var(--color-foreground, #f2efe9);
+      --diagram-muted:       var(--color-muted-foreground, #a3a096);
+      --diagram-rule:        var(--color-border, #2e2e26);
+      --diagram-rule-solid:  var(--color-input, #3d3d33);
+      --diagram-accent:      var(--color-accent, #e08c4a);
+      --diagram-link:        var(--color-primary, #7fb4cc);
 
-      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-      --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+      --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
     }
   }
 

--- a/examples/diagrams/nested.html
+++ b/examples/diagrams/nested.html
@@ -15,57 +15,49 @@
    * from a broken token read.
    */
   :root {
-    --color-background:       #fbfaf8;
-    --color-card:             #ffffff;
-    --color-foreground:       #1a1a17;
-    --color-muted-foreground: #6f6f66;
-    --color-border:           #e6e3dd;
-    --color-input:            #d6d2c9;
-    --color-accent:           #b4531f;
-    --color-primary:          #2f5d73;
 
-    --diagram-paper:       var(--color-background);
-    --diagram-surface:     var(--color-card);
-    --diagram-ink:         var(--color-foreground);
-    --diagram-muted:       var(--color-muted-foreground);
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 65%, var(--color-background));
-    --diagram-rule:        var(--color-border);
-    --diagram-rule-solid:  var(--color-input);
-    --diagram-accent:      var(--color-accent);
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 12%, var(--color-background));
-    --diagram-link:        var(--color-primary);
+    --diagram-paper:       var(--color-background, #fbfaf8);
+    --diagram-surface:     var(--color-card, #ffffff);
+    --diagram-ink:         var(--color-foreground, #1a1a17);
+    --diagram-muted:       var(--color-muted-foreground, #6f6f66);
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #6f6f66) 65%, var(--color-background, #fbfaf8));
+    --diagram-rule:        var(--color-border, #e6e3dd);
+    --diagram-rule-solid:  var(--color-input, #d6d2c9);
+    --diagram-accent:      var(--color-accent, #b4531f);
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #b4531f) 12%, var(--color-background, #fbfaf8));
+    --diagram-link:        var(--color-primary, #2f5d73);
 
     --diagram-hairline: 1px;
     --diagram-gap: 24px;
   }
 
   :root[data-theme="dark"] {
-    --color-background:       #14140f;
-    --color-card:             #1c1c17;
-    --color-foreground:       #f2efe9;
-    --color-muted-foreground: #a3a096;
-    --color-border:           #2e2e26;
-    --color-input:            #3d3d33;
-    --color-accent:           #e08c4a;
-    --color-primary:          #7fb4cc;
+    --diagram-paper:       var(--color-background, #14140f);
+    --diagram-surface:     var(--color-card, #1c1c17);
+    --diagram-ink:         var(--color-foreground, #f2efe9);
+    --diagram-muted:       var(--color-muted-foreground, #a3a096);
+    --diagram-rule:        var(--color-border, #2e2e26);
+    --diagram-rule-solid:  var(--color-input, #3d3d33);
+    --diagram-accent:      var(--color-accent, #e08c4a);
+    --diagram-link:        var(--color-primary, #7fb4cc);
 
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
   }
 
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
-      --color-background:       #14140f;
-      --color-card:             #1c1c17;
-      --color-foreground:       #f2efe9;
-      --color-muted-foreground: #a3a096;
-      --color-border:           #2e2e26;
-      --color-input:            #3d3d33;
-      --color-accent:           #e08c4a;
-      --color-primary:          #7fb4cc;
+      --diagram-paper:       var(--color-background, #14140f);
+      --diagram-surface:     var(--color-card, #1c1c17);
+      --diagram-ink:         var(--color-foreground, #f2efe9);
+      --diagram-muted:       var(--color-muted-foreground, #a3a096);
+      --diagram-rule:        var(--color-border, #2e2e26);
+      --diagram-rule-solid:  var(--color-input, #3d3d33);
+      --diagram-accent:      var(--color-accent, #e08c4a);
+      --diagram-link:        var(--color-primary, #7fb4cc);
 
-      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-      --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+      --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
     }
   }
 

--- a/examples/diagrams/org-chart.html
+++ b/examples/diagrams/org-chart.html
@@ -15,57 +15,49 @@
    * from a broken token read.
    */
   :root {
-    --color-background:       #fbfaf8;
-    --color-card:             #ffffff;
-    --color-foreground:       #1a1a17;
-    --color-muted-foreground: #6f6f66;
-    --color-border:           #e6e3dd;
-    --color-input:            #d6d2c9;
-    --color-accent:           #b4531f;
-    --color-primary:          #2f5d73;
 
-    --diagram-paper:       var(--color-background);
-    --diagram-surface:     var(--color-card);
-    --diagram-ink:         var(--color-foreground);
-    --diagram-muted:       var(--color-muted-foreground);
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 65%, var(--color-background));
-    --diagram-rule:        var(--color-border);
-    --diagram-rule-solid:  var(--color-input);
-    --diagram-accent:      var(--color-accent);
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 12%, var(--color-background));
-    --diagram-link:        var(--color-primary);
+    --diagram-paper:       var(--color-background, #fbfaf8);
+    --diagram-surface:     var(--color-card, #ffffff);
+    --diagram-ink:         var(--color-foreground, #1a1a17);
+    --diagram-muted:       var(--color-muted-foreground, #6f6f66);
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #6f6f66) 65%, var(--color-background, #fbfaf8));
+    --diagram-rule:        var(--color-border, #e6e3dd);
+    --diagram-rule-solid:  var(--color-input, #d6d2c9);
+    --diagram-accent:      var(--color-accent, #b4531f);
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #b4531f) 12%, var(--color-background, #fbfaf8));
+    --diagram-link:        var(--color-primary, #2f5d73);
 
     --diagram-hairline: 1px;
     --diagram-gap: 24px;
   }
 
   :root[data-theme="dark"] {
-    --color-background:       #14140f;
-    --color-card:             #1c1c17;
-    --color-foreground:       #f2efe9;
-    --color-muted-foreground: #a3a096;
-    --color-border:           #2e2e26;
-    --color-input:            #3d3d33;
-    --color-accent:           #e08c4a;
-    --color-primary:          #7fb4cc;
+    --diagram-paper:       var(--color-background, #14140f);
+    --diagram-surface:     var(--color-card, #1c1c17);
+    --diagram-ink:         var(--color-foreground, #f2efe9);
+    --diagram-muted:       var(--color-muted-foreground, #a3a096);
+    --diagram-rule:        var(--color-border, #2e2e26);
+    --diagram-rule-solid:  var(--color-input, #3d3d33);
+    --diagram-accent:      var(--color-accent, #e08c4a);
+    --diagram-link:        var(--color-primary, #7fb4cc);
 
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
   }
 
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
-      --color-background:       #14140f;
-      --color-card:             #1c1c17;
-      --color-foreground:       #f2efe9;
-      --color-muted-foreground: #a3a096;
-      --color-border:           #2e2e26;
-      --color-input:            #3d3d33;
-      --color-accent:           #e08c4a;
-      --color-primary:          #7fb4cc;
+      --diagram-paper:       var(--color-background, #14140f);
+      --diagram-surface:     var(--color-card, #1c1c17);
+      --diagram-ink:         var(--color-foreground, #f2efe9);
+      --diagram-muted:       var(--color-muted-foreground, #a3a096);
+      --diagram-rule:        var(--color-border, #2e2e26);
+      --diagram-rule-solid:  var(--color-input, #3d3d33);
+      --diagram-accent:      var(--color-accent, #e08c4a);
+      --diagram-link:        var(--color-primary, #7fb4cc);
 
-      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-      --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+      --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
     }
   }
 

--- a/examples/diagrams/product-flow.html
+++ b/examples/diagrams/product-flow.html
@@ -15,57 +15,49 @@
    * from a broken token read.
    */
   :root {
-    --color-background:       #fbfaf8;
-    --color-card:             #ffffff;
-    --color-foreground:       #1a1a17;
-    --color-muted-foreground: #6f6f66;
-    --color-border:           #e6e3dd;
-    --color-input:            #d6d2c9;
-    --color-accent:           #b4531f;
-    --color-primary:          #2f5d73;
 
-    --diagram-paper:       var(--color-background);
-    --diagram-surface:     var(--color-card);
-    --diagram-ink:         var(--color-foreground);
-    --diagram-muted:       var(--color-muted-foreground);
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 65%, var(--color-background));
-    --diagram-rule:        var(--color-border);
-    --diagram-rule-solid:  var(--color-input);
-    --diagram-accent:      var(--color-accent);
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 12%, var(--color-background));
-    --diagram-link:        var(--color-primary);
+    --diagram-paper:       var(--color-background, #fbfaf8);
+    --diagram-surface:     var(--color-card, #ffffff);
+    --diagram-ink:         var(--color-foreground, #1a1a17);
+    --diagram-muted:       var(--color-muted-foreground, #6f6f66);
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #6f6f66) 65%, var(--color-background, #fbfaf8));
+    --diagram-rule:        var(--color-border, #e6e3dd);
+    --diagram-rule-solid:  var(--color-input, #d6d2c9);
+    --diagram-accent:      var(--color-accent, #b4531f);
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #b4531f) 12%, var(--color-background, #fbfaf8));
+    --diagram-link:        var(--color-primary, #2f5d73);
 
     --diagram-hairline: 1px;
     --diagram-gap: 24px;
   }
 
   :root[data-theme="dark"] {
-    --color-background:       #14140f;
-    --color-card:             #1c1c17;
-    --color-foreground:       #f2efe9;
-    --color-muted-foreground: #a3a096;
-    --color-border:           #2e2e26;
-    --color-input:            #3d3d33;
-    --color-accent:           #e08c4a;
-    --color-primary:          #7fb4cc;
+    --diagram-paper:       var(--color-background, #14140f);
+    --diagram-surface:     var(--color-card, #1c1c17);
+    --diagram-ink:         var(--color-foreground, #f2efe9);
+    --diagram-muted:       var(--color-muted-foreground, #a3a096);
+    --diagram-rule:        var(--color-border, #2e2e26);
+    --diagram-rule-solid:  var(--color-input, #3d3d33);
+    --diagram-accent:      var(--color-accent, #e08c4a);
+    --diagram-link:        var(--color-primary, #7fb4cc);
 
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
   }
 
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
-      --color-background:       #14140f;
-      --color-card:             #1c1c17;
-      --color-foreground:       #f2efe9;
-      --color-muted-foreground: #a3a096;
-      --color-border:           #2e2e26;
-      --color-input:            #3d3d33;
-      --color-accent:           #e08c4a;
-      --color-primary:          #7fb4cc;
+      --diagram-paper:       var(--color-background, #14140f);
+      --diagram-surface:     var(--color-card, #1c1c17);
+      --diagram-ink:         var(--color-foreground, #f2efe9);
+      --diagram-muted:       var(--color-muted-foreground, #a3a096);
+      --diagram-rule:        var(--color-border, #2e2e26);
+      --diagram-rule-solid:  var(--color-input, #3d3d33);
+      --diagram-accent:      var(--color-accent, #e08c4a);
+      --diagram-link:        var(--color-primary, #7fb4cc);
 
-      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-      --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+      --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
     }
   }
 

--- a/examples/diagrams/state.html
+++ b/examples/diagrams/state.html
@@ -15,57 +15,49 @@
    * from a broken token read.
    */
   :root {
-    --color-background:       #fbfaf8;
-    --color-card:             #ffffff;
-    --color-foreground:       #1a1a17;
-    --color-muted-foreground: #6f6f66;
-    --color-border:           #e6e3dd;
-    --color-input:            #d6d2c9;
-    --color-accent:           #b4531f;
-    --color-primary:          #2f5d73;
 
-    --diagram-paper:       var(--color-background);
-    --diagram-surface:     var(--color-card);
-    --diagram-ink:         var(--color-foreground);
-    --diagram-muted:       var(--color-muted-foreground);
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 65%, var(--color-background));
-    --diagram-rule:        var(--color-border);
-    --diagram-rule-solid:  var(--color-input);
-    --diagram-accent:      var(--color-accent);
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 12%, var(--color-background));
-    --diagram-link:        var(--color-primary);
+    --diagram-paper:       var(--color-background, #fbfaf8);
+    --diagram-surface:     var(--color-card, #ffffff);
+    --diagram-ink:         var(--color-foreground, #1a1a17);
+    --diagram-muted:       var(--color-muted-foreground, #6f6f66);
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #6f6f66) 65%, var(--color-background, #fbfaf8));
+    --diagram-rule:        var(--color-border, #e6e3dd);
+    --diagram-rule-solid:  var(--color-input, #d6d2c9);
+    --diagram-accent:      var(--color-accent, #b4531f);
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #b4531f) 12%, var(--color-background, #fbfaf8));
+    --diagram-link:        var(--color-primary, #2f5d73);
 
     --diagram-hairline: 1px;
     --diagram-gap: 24px;
   }
 
   :root[data-theme="dark"] {
-    --color-background:       #14140f;
-    --color-card:             #1c1c17;
-    --color-foreground:       #f2efe9;
-    --color-muted-foreground: #a3a096;
-    --color-border:           #2e2e26;
-    --color-input:            #3d3d33;
-    --color-accent:           #e08c4a;
-    --color-primary:          #7fb4cc;
+    --diagram-paper:       var(--color-background, #14140f);
+    --diagram-surface:     var(--color-card, #1c1c17);
+    --diagram-ink:         var(--color-foreground, #f2efe9);
+    --diagram-muted:       var(--color-muted-foreground, #a3a096);
+    --diagram-rule:        var(--color-border, #2e2e26);
+    --diagram-rule-solid:  var(--color-input, #3d3d33);
+    --diagram-accent:      var(--color-accent, #e08c4a);
+    --diagram-link:        var(--color-primary, #7fb4cc);
 
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
   }
 
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
-      --color-background:       #14140f;
-      --color-card:             #1c1c17;
-      --color-foreground:       #f2efe9;
-      --color-muted-foreground: #a3a096;
-      --color-border:           #2e2e26;
-      --color-input:            #3d3d33;
-      --color-accent:           #e08c4a;
-      --color-primary:          #7fb4cc;
+      --diagram-paper:       var(--color-background, #14140f);
+      --diagram-surface:     var(--color-card, #1c1c17);
+      --diagram-ink:         var(--color-foreground, #f2efe9);
+      --diagram-muted:       var(--color-muted-foreground, #a3a096);
+      --diagram-rule:        var(--color-border, #2e2e26);
+      --diagram-rule-solid:  var(--color-input, #3d3d33);
+      --diagram-accent:      var(--color-accent, #e08c4a);
+      --diagram-link:        var(--color-primary, #7fb4cc);
 
-      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-      --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+      --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
     }
   }
 

--- a/examples/diagrams/tree.html
+++ b/examples/diagrams/tree.html
@@ -15,57 +15,49 @@
    * from a broken token read.
    */
   :root {
-    --color-background:       #fbfaf8;
-    --color-card:             #ffffff;
-    --color-foreground:       #1a1a17;
-    --color-muted-foreground: #6f6f66;
-    --color-border:           #e6e3dd;
-    --color-input:            #d6d2c9;
-    --color-accent:           #b4531f;
-    --color-primary:          #2f5d73;
 
-    --diagram-paper:       var(--color-background);
-    --diagram-surface:     var(--color-card);
-    --diagram-ink:         var(--color-foreground);
-    --diagram-muted:       var(--color-muted-foreground);
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 65%, var(--color-background));
-    --diagram-rule:        var(--color-border);
-    --diagram-rule-solid:  var(--color-input);
-    --diagram-accent:      var(--color-accent);
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 12%, var(--color-background));
-    --diagram-link:        var(--color-primary);
+    --diagram-paper:       var(--color-background, #fbfaf8);
+    --diagram-surface:     var(--color-card, #ffffff);
+    --diagram-ink:         var(--color-foreground, #1a1a17);
+    --diagram-muted:       var(--color-muted-foreground, #6f6f66);
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #6f6f66) 65%, var(--color-background, #fbfaf8));
+    --diagram-rule:        var(--color-border, #e6e3dd);
+    --diagram-rule-solid:  var(--color-input, #d6d2c9);
+    --diagram-accent:      var(--color-accent, #b4531f);
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #b4531f) 12%, var(--color-background, #fbfaf8));
+    --diagram-link:        var(--color-primary, #2f5d73);
 
     --diagram-hairline: 1px;
     --diagram-gap: 24px;
   }
 
   :root[data-theme="dark"] {
-    --color-background:       #14140f;
-    --color-card:             #1c1c17;
-    --color-foreground:       #f2efe9;
-    --color-muted-foreground: #a3a096;
-    --color-border:           #2e2e26;
-    --color-input:            #3d3d33;
-    --color-accent:           #e08c4a;
-    --color-primary:          #7fb4cc;
+    --diagram-paper:       var(--color-background, #14140f);
+    --diagram-surface:     var(--color-card, #1c1c17);
+    --diagram-ink:         var(--color-foreground, #f2efe9);
+    --diagram-muted:       var(--color-muted-foreground, #a3a096);
+    --diagram-rule:        var(--color-border, #2e2e26);
+    --diagram-rule-solid:  var(--color-input, #3d3d33);
+    --diagram-accent:      var(--color-accent, #e08c4a);
+    --diagram-link:        var(--color-primary, #7fb4cc);
 
-    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-    --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+    --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+    --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
   }
 
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
-      --color-background:       #14140f;
-      --color-card:             #1c1c17;
-      --color-foreground:       #f2efe9;
-      --color-muted-foreground: #a3a096;
-      --color-border:           #2e2e26;
-      --color-input:            #3d3d33;
-      --color-accent:           #e08c4a;
-      --color-primary:          #7fb4cc;
+      --diagram-paper:       var(--color-background, #14140f);
+      --diagram-surface:     var(--color-card, #1c1c17);
+      --diagram-ink:         var(--color-foreground, #f2efe9);
+      --diagram-muted:       var(--color-muted-foreground, #a3a096);
+      --diagram-rule:        var(--color-border, #2e2e26);
+      --diagram-rule-solid:  var(--color-input, #3d3d33);
+      --diagram-accent:      var(--color-accent, #e08c4a);
+      --diagram-link:        var(--color-primary, #7fb4cc);
 
-      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground) 70%, var(--color-background));
-      --diagram-accent-tint: color-mix(in oklch, var(--color-accent) 18%, var(--color-background));
+      --diagram-soft:        color-mix(in oklch, var(--color-muted-foreground, #a3a096) 70%, var(--color-background, #14140f));
+      --diagram-accent-tint: color-mix(in oklch, var(--color-accent, #e08c4a) 18%, var(--color-background, #14140f));
     }
   }
 

--- a/scripts/normalize-example-theme.mjs
+++ b/scripts/normalize-example-theme.mjs
@@ -105,18 +105,70 @@ function replaceVarFallbacks(region, palette) {
   return out + region.slice(cursor);
 }
 
-function applyPalette(region, palette) {
-  return replaceVarFallbacks(region, palette)
-    // Direct declarations: --color-x: <value>;  (the batch that defined tokens outright)
+/**
+ * Convert an artifact that *declares* the base tokens into one that *consumes* them.
+ *
+ * One batch wrote `--color-background: #fbfaf8;` and referenced it bare as
+ * `var(--color-background)`. That renders correctly standalone but inverts the contract:
+ * a declaration in `:root` overrides whatever a host project compiled, so the artifact
+ * imposes its own skin instead of inheriting the design system. Dropping the declaration
+ * and moving the value into the `var()` fallback leaves standalone rendering byte-identical
+ * while letting a real design system win.
+ */
+function consumeInsteadOfDeclare(region, palette) {
+  return region
+    // Drop the base declarations along with the line they occupy.
+    .replace(new RegExp(`^[ \\t]*--color-(?:${NAMES})\\s*:[^;]+;[ \\t]*\\r?\\n`, "gm"), "")
+    // Give any now-bare consumer the canonical fallback.
     .replace(
-      new RegExp(`(--color-(${NAMES})\\s*:\\s*)[^;]+;`, "g"),
-      (_m, prefix, name) => `${prefix}${palette[name]};`,
+      new RegExp(`var\\(\\s*--color-(${NAMES})\\s*\\)`, "g"),
+      (_m, name) => `var(--color-${name}, ${palette[name]})`,
     );
+}
+
+function applyPalette(region, palette) {
+  return replaceVarFallbacks(consumeInsteadOfDeclare(region, palette), palette);
+}
+
+const ROLE_LINE = /^[ \t]*--(?:diagram|chart)-[\w-]+\s*:.*var\(--color-[\s\S]*?;[ \t]*$/gm;
+
+/**
+ * Make sure each dark block restates the whole role layer.
+ *
+ * The batch that declared base tokens relied on redeclaring `--color-*` inside its dark
+ * blocks; its role layer sat only in `:root`. Once the base declarations are dropped,
+ * nothing drives dark mode and the page renders light with dark-on-light text. The other
+ * batch never had this problem because it restates every role with a dark fallback — so
+ * this brings the stragglers to the same shape rather than inventing a third one.
+ *
+ * Roles the dark block already sets are left alone: a grammar may legitimately shift a
+ * mix ratio for contrast, and that intent should survive.
+ */
+function backfillDarkRoles(source) {
+  const lightBlock = /:root\s*\{([\s\S]*?)\n\s*\}/.exec(source);
+  if (lightBlock === null) return source;
+  const lightRoles = lightBlock[1].match(ROLE_LINE) ?? [];
+  if (lightRoles.length === 0) return source;
+
+  const roleName = (line) => /--((?:diagram|chart)-[\w-]+)\s*:/.exec(line)?.[1];
+
+  return source.replace(
+    /(:root\[data-theme="dark"\]\s*\{|:root:not\(\[data-theme="light"\]\)\s*\{)([\s\S]*?)(\n[ \t]*\})/g,
+    (_match, open, body, close) => {
+      const present = new Set((body.match(ROLE_LINE) ?? []).map(roleName));
+      const indent = /^([ \t]*)--/m.exec(body)?.[1] ?? "    ";
+      const missing = lightRoles
+        .filter((line) => !present.has(roleName(line)))
+        .map((line) => indent + applyPalette(line.trim(), DARK));
+      if (missing.length === 0) return open + body + close;
+      return `${open}\n${missing.join("\n")}${body.replace(/^\n/, "\n")}${close}`;
+    },
+  );
 }
 
 function normalize(source) {
   const [light, dark] = splitAtDark(source);
-  return applyPalette(light, LIGHT) + applyPalette(dark, DARK);
+  return backfillDarkRoles(applyPalette(light, LIGHT) + applyPalette(dark, DARK));
 }
 
 const files = DIRS.flatMap((dir) =>

--- a/tests/examples-corpus.test.ts
+++ b/tests/examples-corpus.test.ts
@@ -133,3 +133,37 @@ describe('corpus shares one canonical palette', () => {
     }
   });
 });
+
+/**
+ * An artifact consumes design tokens; it must never declare them.
+ *
+ * A `--color-background: #fbfaf8;` in `:root` renders fine standalone and is still wrong:
+ * it overrides whatever a host project compiled, so the artifact imposes its own skin
+ * instead of inheriting the design system — the inverse of the contract in
+ * diagram-craft.md. The value belongs in the `var()` fallback, which applies only when
+ * nothing else defines the token.
+ */
+describe('corpus consumes design tokens rather than declaring them', () => {
+  const all = [
+    ...diagramExamples.map((n) => [n, join(DIAGRAM_DIR, n)] as const),
+    ...chartExamples.map((n) => [n, join(CHART_DIR, n)] as const),
+  ];
+
+  it.each(all)('%s declares no base --color-* token', (_name, path) => {
+    const offending = readFileSync(path, 'utf8')
+      .split('\n')
+      .filter((line) => /^\s*--color-[a-z0-9-]+\s*:/.test(line))
+      .map((line) => line.trim());
+    expect(offending).toEqual([]);
+  });
+
+  // Dark mode has to be driven by the role layer, not by redeclaring the base tokens —
+  // otherwise removing a declaration silently leaves the page rendering light.
+  it.each(all)('%s drives dark mode through its role layer', (_name, path) => {
+    const html = readFileSync(path, 'utf8');
+    const darkStart = html.indexOf(':root[data-theme="dark"]');
+    expect(darkStart, 'expected a dark block').toBeGreaterThan(-1);
+    const darkBlock = html.slice(darkStart, html.indexOf('}', darkStart));
+    expect(darkBlock).toMatch(/--(?:diagram|chart)-(?:paper|ink)\s*:/);
+  });
+});


### PR DESCRIPTION
Follow-up to #161, which normalised the corpus **values** but not its **architecture**. My PR body there implied the override problem was fixed; it was not. This closes it.

## The defect

Six artifacts declared the base tokens outright and referenced them bare:

```css
:root {
  --color-background: #fbfaf8;          /* declaration */
  --diagram-paper: var(--color-background);
}
```

That renders correctly standalone and is still wrong: a declaration in `:root` beats whatever a host project compiled, so the artifact **imposes its own skin instead of inheriting the design system** — the inverse of the contract in `diagram-craft.md`. The value belongs in the `var()` fallback, where it applies only when nothing else defines the token.

## Dropping the declarations alone regresses dark mode

Worth spelling out, because it is not obvious. Those six drove dark by redeclaring `--color-*` inside their dark blocks; their role layer lived only in `:root`. Remove the base declarations and **nothing sets the dark values** — the page renders light paper with dark-on-light text, unreadable.

I caught this in the re-captured image before committing, not by reasoning. The dark blocks now restate the role layer with dark fallbacks, which is how the other 22 were already built — so this brings the stragglers to the existing shape rather than inventing a third one.

## Rendering is provably unchanged

Re-capturing all 56 images produces **zero diffs against main**, in both themes. The six files inherit correctly now and look byte-identical.

## Guards

Two checks in `tests/examples-corpus.test.ts`:

- no artifact may declare a base `--color-*` token
- every dark block must drive the role layer, not the base — so removing a declaration can never silently leave a page rendering light again

## Verification

`typecheck`, `lint` clean. **182 files, 3124 passed, 8 skipped** (excluding `spec-022-*`; see #160). All four drift guards green. The six converted files re-linted with zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)