### PR TITLE
fix(release): publish via npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ name: Release
 # so a broken or mis-tagged build can never reach the registry.
 #
 # Setup (one-time, by the maintainer):
-#   1. Create an npm automation token; add it as the repo secret NPM_TOKEN.
+#   1. Configure npm Trusted Publishing (npmjs.com → package → Settings →
+#      Trusted Publisher: this repo + release.yml). No token secret needed.
 #   2. Release flow:
 #        npm version patch|minor|major   # bumps package.json + creates the git tag
 #        git push --follow-tags           # triggers this workflow
@@ -52,7 +53,10 @@ jobs:
       - run: npm run build
       - run: npm test
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # OIDC trusted publishing (configured on npmjs.com for this repo+workflow):
+      # no token secret — npm exchanges the Actions OIDC identity directly.
+      # Node 20 ships npm 10.x, which predates trusted publishing; upgrade first.
+      - name: Publish to npm (OIDC trusted publishing)
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public


### PR DESCRIPTION
## What

The v0.3.0 release run failed at the publish step: `E404 PUT https://registry.npmjs.org/ease-design` — the `NPM_TOKEN` secret has been invalidated by npm's bypass-2FA token restrictions. Trusted Publishing (OIDC) is now configured on npmjs.com for this repo + `release.yml`, so the workflow:

- drops `NODE_AUTH_TOKEN` (a dead token would take precedence over OIDC);
- upgrades npm before publishing (Node 20 ships npm 10.x; trusted publishing needs ≥ 11.5).

After merge, `v0.3.0` will be re-tagged on main (package.json already reads 0.3.0, so the tag↔version guard holds).

## Gates

Workflow-only change; the release job itself re-runs the four gates before publishing.