### PR TITLE
fix(release): pin npm@11 for OIDC publish on Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,10 @@ jobs:
 
       # OIDC trusted publishing (configured on npmjs.com for this repo+workflow):
       # no token secret — npm exchanges the Actions OIDC identity directly.
-      # Node 20 ships npm 10.x, which predates trusted publishing; upgrade first.
+      # Node 20 ships npm 10.x, which predates trusted publishing. npm@12 requires
+      # Node >= 22, so pin npm@11 (OIDC support since 11.5.1, runs on Node 20.17+).
       - name: Publish to npm (OIDC trusted publishing)
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11
+          npm --version
           npm publish --provenance --access public


### PR DESCRIPTION
The v0.3.0 OIDC re-run failed with EBADENGINE: `npm install -g npm@latest` now resolves to npm@12, which requires Node ≥ 22.22 while the runner uses Node 20. Pin npm@11 (trusted publishing support since 11.5.1; engines allow Node ^20.17). Adds `npm --version` to the step log for future diagnosis. After merge, v0.3.0 gets re-tagged once more.