### PR TITLE
fix(ingest-figma-ds): refuse to write the unsealed bundle at the sealed path

### DIFF
--- a/src/commands/ingest-figma-ds.ts
+++ b/src/commands/ingest-figma-ds.ts
@@ -72,6 +72,7 @@ Error codes:
   READ_ERROR       ds.json exists but cannot be read
   BAD_JSON         ds.json is not valid JSON
   BAD_DS           ds.json is not a scan-design-system output (missing components/tokens/styles)
+  SEALED_PATH_COLLISION  --out resolves to a directory named 'design' — the sealed DS path
   WRITE_ERROR      An output file could not be written
 `;
 
@@ -151,9 +152,23 @@ function runIngest(parsed: ParsedArgs): CommandResult {
 
   // 4. Validate shape + transform
   let result;
+  // Guard: --out must not resolve to a directory literally named "design" — that is
+  // the sealed path (design/component-registry.json, design/ds.manifest.json) that
+  // `ds init` and `ds import` own. This command writes the portable, UNSEALED bundle;
+  // landing it at the sealed path would drop an unsealed component-registry.json where
+  // loadDesignSystem expects a manifest-backed one. Refuse before any write.
+  const outDir = resolve(flagStr(parsed, "out") ?? process.cwd());
+  if (basename(outDir) === "design") {
+    return err(
+      "SEALED_PATH_COLLISION",
+      `--out '${outDir}' is the sealed design-system path (a directory named 'design') — ` +
+        "ingest-figma-ds writes an unsealed bundle and must not land it there. Use a " +
+        "different --out, then 'ui ds import' to seal it into a project's design/ directory.",
+    );
+  }
+
   try {
     const ds = parseDsFile(json);
-    const outDir = resolve(flagStr(parsed, "out") ?? process.cwd());
     const name = flagStr(parsed, "name") ?? basename(outDir);
     const source = `figma scan-design-system (${basename(dsPath)})`;
     result = { ...ingestDesignSystem(ds, name, source), outDir, source, name };
@@ -162,8 +177,7 @@ function runIngest(parsed: ParsedArgs): CommandResult {
     throw e;
   }
 
-  // 5. Write the portable stores
-  const { outDir } = result;
+  // 5. Write the portable stores (outDir was resolved and guarded above)
   const tokensPath = join(outDir, "tokens.json");
   // Stage-4 N6 — route through the shared resolver so a foreign artifact (e.g. a project's
   // own generated component registry) already occupying `component-registry.json` is never

--- a/tests/cmd-ingest-figma-ds.test.ts
+++ b/tests/cmd-ingest-figma-ds.test.ts
@@ -280,4 +280,25 @@ describe("ui ingest-figma-ds — error paths", () => {
     expect(code).toBe(1);
     expect(env.error?.code).toBe("BAD_ARG");
   });
+
+  it("SEALED_PATH_COLLISION when --out resolves to a directory named 'design'", () => {
+    // The sealed path belongs to `ds init` / `ds import`, which write a
+    // manifest-backed registry there. Landing this command's UNSEALED bundle at
+    // the same path leaves loadDesignSystem reading a registry with no manifest.
+    const sealedDir = join(out, "design");
+    const { code, env } = json(["ingest-figma-ds", DS, "--out", sealedDir, "--json"]);
+    expect(code).toBe(1);
+    expect(env.error?.code).toBe("SEALED_PATH_COLLISION");
+    // Refused BEFORE any write — a partial bundle at the sealed path would be
+    // worse than the collision it is guarding against.
+    expect(existsSync(join(sealedDir, "component-registry.json"))).toBe(false);
+    expect(existsSync(join(sealedDir, "tokens.json"))).toBe(false);
+  });
+
+  it("does not refuse an --out that merely CONTAINS 'design' as a substring", () => {
+    const notSealed = join(out, "design-system-export");
+    const { code, env } = json(["ingest-figma-ds", DS, "--out", notSealed, "--json"]);
+    expect(code).toBe(0);
+    expect(env.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
Recovered from an abandoned agent worktree during worktree cleanup — it had been sitting **uncommitted, with no PR**, while `main` carried the hole.

## The hole

`ds init` and `ds import` own `design/`: a **manifest-backed** component registry lives there, and `loadDesignSystem` reads it expecting that manifest.

`ingest-figma-ds` writes the portable, **unsealed** bundle. Pointing `--out` at a directory named `design` drops an unsealed `component-registry.json` exactly where a sealed one is expected — and nothing downstream announces the mismatch. The failure surfaces later, somewhere else, as a design system that reads wrong.

## The guard

`SEALED_PATH_COLLISION`, raised **before any write**. A half-written bundle at the sealed path would be worse than the collision it guards against, so `outDir` is resolved and checked ahead of the transform rather than inside it.

The message names the way out rather than just the problem: use a different `--out`, then `ui ds import` to seal it into a project's `design/`.

Substring matches are **not** collisions — `design-system-export` is fine — and a test pins that, so the guard cannot quietly widen into refusing legitimate paths.

## Ported, not applied

The original patch no longer applied; `main` had moved. It was ported by hand, which surfaced one thing the original did not have to deal with: `outDir` was declared twice once hoisted, so the later local declaration is gone and the guard's resolution is the single one.

## Verified red-first

| Check | Result |
|---|---|
| Guard removed | the new test **fails** |
| Guard restored | `cmd-ingest-figma-ds` **20/20** |
| Live run: `ui ingest-figma-ds … --out <dir>/design --json` | returns **`SEALED_PATH_COLLISION`** |

A guard never observed refusing has not been shown to guard anything.

## Gates

`build` · `typecheck` · `lint` · `ui knowledge check` all **exit 0** · full suite **196/196 files, 3453 passed**.