### PR TITLE
Name the field --tokens actually writes to

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -55,7 +55,8 @@ Name format:
   Category/Variant — both segments PascalCase, letters only (e.g. Button/Primary)
 
 Token paths:
-  Comma-separated, each matching ^[a-z][a-z0-9.-]*$ (e.g. color.primary,space.4)
+  --tokens is comma-separated, each matching ^[a-z][a-z0-9.-]*$ (e.g. color.primary,space.4)
+  and is written to the record's 'tokensUsed' field.
 
 States enum:
   default, hover, active, focus, disabled

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -424,7 +424,7 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
         flags: [
           { name: "category", type: "string", required: true, summary: "Component category" },
           { name: "markup", type: "string", required: true, summary: "Markup source file, or '-' for stdin" },
-          { name: "tokens", type: "string", summary: "Comma-separated token paths the component uses" },
+          { name: "tokens", type: "string", summary: "Comma-separated token paths the component uses; written to the record's 'tokensUsed' field" },
           { name: "variants", type: "string", summary: "Comma-separated variant names" },
           { name: "states", type: "string", values: ["default", "hover", "active", "focus", "disabled"], summary: "Comma-separated states (each from the enum); folded into --variants as State=X, not into the record's own states field" },
           { name: "description", type: "string", summary: "Free-text component description" },


### PR DESCRIPTION
Recovered from a stash left behind on 2026-07-30 (`phase1-guard-wip`), whose other half — the `SEALED_PATH_COLLISION` guard — already landed as #173. This is the part that did not.

`ui registry add --tokens` documented what it accepts and never said where the value lands. The record stores it as **`tokensUsed`**, so a probe looking for a `tokens` key finds nothing and concludes the flag was discarded. That is not hypothetical: it is the false finding a real field report made, and one we re-ran and wrongly confirmed.

Two lines, both surfaces a user can actually read — the command help and the machine-readable signature.

Gates: typecheck · lint · build all exit 0 · suite 197 files / 3465 passed.