### PR TITLE
Root rules are decided by the selector's subject, at the shared layer

### DIFF
--- a/knowledge/design-agents.md
+++ b/knowledge/design-agents.md
@@ -65,9 +65,16 @@ agents as they want; a project with zero agents is a fully supported state
 
 ## §5 Runtime scope
 
-Claude Code only for now (`.claude/agents/`). codex and antigravity have no stable
-subagent format yet; when they do, the same templates + genealogy naming will emit
-their trees. Until then nothing is written for them.
+**This scope is about SUBAGENTS only** (`ui agents` → `.claude/agents/`) — NOT the
+`ui init` runtime adapters. Subagents are Claude Code only for now: codex and
+antigravity have no stable subagent format yet; when they do, the same templates +
+genealogy naming will emit their trees. Until then no *subagent tree* is written for them.
+
+This is NOT the same as runtime support. `ui init` DOES emit design:os skills +
+workflows for antigravity (`.agent/skills/design-os-*/`, `.agent/workflows/ui-*.md`) and
+codex/agents-md (`AGENTS.md` sentinel) — that is a separate mechanism, see the adapters
+under `src/adapters/`, not this file. "Nothing is written" here means *no subagent
+roster*, never "design:os is unavailable on that runtime."
 
 ## §6 Drift check — the emitter/linter pair
 

--- a/src/core/layout-checks-viewport.ts
+++ b/src/core/layout-checks-viewport.ts
@@ -41,10 +41,25 @@ export function checkCss100vwWidth(html: string): LayoutFinding[] {
 
 // ─── overflow-x: hidden on a root element (breaks sticky) ───────────────────────
 
-/** A root selector: `html` / `body` element (not `.body-text`), or `:root`. */
-const ROOT_SELECTOR = /(?:^|[\s,>+~(])(?:html|body)(?![\w-])|:root\b/i;
 /** `overflow` or `overflow-x` (not `-y`) set to a value containing `hidden`. */
 const OVERFLOW_X_HIDDEN = /overflow(?:-x)?\s*:\s*[^;}]*\bhidden\b/i;
+
+/**
+ * True when the SUBJECT (rightmost compound) of any comma-separated selector is a
+ * root element — `html`/`body` (with optional class/attr/pseudo, but not
+ * `.body-text`) or `:root`. The subject is what the rule actually styles, so a
+ * descendant rule like `html.js .ln { overflow: hidden }` targets `.ln`, NOT the
+ * root, and must not flag. (The old start-anchored match mis-read every
+ * `html…`/`body…`-prefixed descendant selector — e.g. `body.dark .card` — as a
+ * root rule, a very common false positive.)
+ */
+function selectorSubjectIsRoot(selector: string): boolean {
+  return selector.split(",").some((part) => {
+    const compounds = part.trim().split(/[\s>+~]+/);
+    const subject = compounds[compounds.length - 1] ?? "";
+    return /^(?:html|body)(?![\w-])/i.test(subject) || /^:root(?![\w-])/i.test(subject);
+  });
+}
 
 /**
  * root-overflow-x-hidden: `overflow-x: hidden` (or shorthand `overflow: hidden`)
@@ -58,7 +73,7 @@ export function checkRootOverflowXHidden(html: string): LayoutFinding[] {
   const css = cssRegions(html);
   const usesSticky = /position\s*:\s*sticky/i.test(css);
   for (const { selector, body } of cssRules(css)) {
-    if (!ROOT_SELECTOR.test(selector)) continue;
+    if (!selectorSubjectIsRoot(selector)) continue;
     if (!OVERFLOW_X_HIDDEN.test(body)) continue;
     let message = `overflow-x: hidden on ${selector} — hidden breaks position:sticky descendants; use overflow-x: clip (same clipping, sticky survives)`;
     if (usesSticky) message += ` (this page USES sticky — it is broken right now)`;

--- a/src/core/layout-checks-viewport.ts
+++ b/src/core/layout-checks-viewport.ts
@@ -11,7 +11,7 @@
  * imports nothing back). Pure string/regex — no DOM, no deps.
  */
 import type { LayoutFinding } from "./layout-lint.js";
-import { cssRegions, cssRules, lineOf } from "./taste-checks-shared.js";
+import { cssRegions, cssRules, lineOf, selectorSubjectIsRoot } from "./taste-checks-shared.js";
 
 // ─── width: 100vw (scrollbar-gutter overflow) ───────────────────────────────────
 
@@ -43,23 +43,6 @@ export function checkCss100vwWidth(html: string): LayoutFinding[] {
 
 /** `overflow` or `overflow-x` (not `-y`) set to a value containing `hidden`. */
 const OVERFLOW_X_HIDDEN = /overflow(?:-x)?\s*:\s*[^;}]*\bhidden\b/i;
-
-/**
- * True when the SUBJECT (rightmost compound) of any comma-separated selector is a
- * root element — `html`/`body` (with optional class/attr/pseudo, but not
- * `.body-text`) or `:root`. The subject is what the rule actually styles, so a
- * descendant rule like `html.js .ln { overflow: hidden }` targets `.ln`, NOT the
- * root, and must not flag. (The old start-anchored match mis-read every
- * `html…`/`body…`-prefixed descendant selector — e.g. `body.dark .card` — as a
- * root rule, a very common false positive.)
- */
-function selectorSubjectIsRoot(selector: string): boolean {
-  return selector.split(",").some((part) => {
-    const compounds = part.trim().split(/[\s>+~]+/);
-    const subject = compounds[compounds.length - 1] ?? "";
-    return /^(?:html|body)(?![\w-])/i.test(subject) || /^:root(?![\w-])/i.test(subject);
-  });
-}
 
 /**
  * root-overflow-x-hidden: `overflow-x: hidden` (or shorthand `overflow: hidden`)

--- a/src/core/taste-checks-invisible-surface.ts
+++ b/src/core/taste-checks-invisible-surface.ts
@@ -19,7 +19,7 @@
  * Pure string/regex — no DOM, no deps.
  */
 import type { TasteFinding } from "./taste-lint.js";
-import { cssRegions, lineOf } from "./taste-checks-shared.js";
+import { cssRegions, cssRules, lineOf, selectorSubjectIsRoot } from "./taste-checks-shared.js";
 
 const CHECK_ID = "mode-invisible-surface";
 const ALPHA_FLOOR = 0.15; // below this a same-colour tint reads as no boundary at all
@@ -60,9 +60,13 @@ function rootText(html: string): string {
   const tagRe = /<(?:html|body)\b([^>]*)>/gi;
   let m: RegExpExecArray | null;
   while ((m = tagRe.exec(html)) !== null) roots.push(m[0] ?? "");
-  const css = cssRegions(html);
-  const rootRule = /(?:^|[\s,{])(?:html|body|:root)\b[^{]*\{([^}]*)\}/gi;
-  while ((m = rootRule.exec(css)) !== null) roots.push(m[1] ?? "");
+  // Only rules whose SUBJECT is the root count. Matching `html|body|:root`
+  // anywhere in the selector pulled in every descendant rule — `body.dark .card`
+  // — so one dark card could decide the whole document's mode, which is exactly
+  // what the comment above promises cannot happen.
+  for (const rule of cssRules(cssRegions(html))) {
+    if (selectorSubjectIsRoot(rule.selector)) roots.push(rule.body);
+  }
   return roots.join(" ");
 }
 

--- a/src/core/taste-checks-shared.ts
+++ b/src/core/taste-checks-shared.ts
@@ -47,3 +47,30 @@ export function cssRules(css: string): CssRule[] {
   }
   return out;
 }
+
+/**
+ * True when the SUBJECT (rightmost compound) of any comma-separated selector is a
+ * root element — `html`/`body` (with optional class/attr/pseudo, but not
+ * `.body-text`) or `:root`.
+ *
+ * The subject is what a rule actually styles, so `html.js .ln { … }` targets
+ * `.ln`, NOT the root. Matching anywhere in the selector instead reads every
+ * `html…`/`body…`-prefixed DESCENDANT rule — `body.dark .card` is the common one —
+ * as a root rule.
+ *
+ * Lives here because two checks need the same answer and each grew its own
+ * prefix-matching regex: `root-overflow-x-hidden` in layout-checks-viewport, and
+ * the colour-mode root scan in taste-checks-invisible-surface. Fixing one and not
+ * the other is how a repaired bug walks back in through the sibling.
+ *
+ * Known limit: a root wrapped in a functional pseudo — `:is(body)`, `:where(html)`
+ * — is not recognised. Rare enough to accept; stated so the next reader does not
+ * mistake it for an oversight.
+ */
+export function selectorSubjectIsRoot(selector: string): boolean {
+  return selector.split(",").some((part) => {
+    const compounds = part.trim().split(/[\s>+~]+/);
+    const subject = compounds[compounds.length - 1] ?? "";
+    return /^(?:html|body)(?![\w-])/i.test(subject) || /^:root(?![\w-])/i.test(subject);
+  });
+}

--- a/tests/layout-lint.test.ts
+++ b/tests/layout-lint.test.ts
@@ -270,6 +270,18 @@ describe("lintLayout — root-overflow-x-hidden", () => {
     const { findings } = lintLayout(html);
     expect(findings.some((f) => f.checkId === "root-overflow-x-hidden")).toBe(false);
   });
+
+  it("does NOT flag a descendant rule that only STARTS with html/body (subject is a deep class)", () => {
+    const html = '<!doctype html><html class="js"><body><style>.nav{position:sticky;top:0}html.js .ln{overflow:hidden}body.dark .card{overflow:hidden}</style></body></html>';
+    const { findings } = lintLayout(html);
+    expect(findings.some((f) => f.checkId === "root-overflow-x-hidden")).toBe(false);
+  });
+
+  it("still flags when body IS the subject of a descendant selector (main body)", () => {
+    const html = '<!doctype html><html><body><style>main body{overflow-x:hidden}</style></body></html>';
+    const { findings } = lintLayout(html);
+    expect(findings.some((f) => f.checkId === "root-overflow-x-hidden")).toBe(true);
+  });
 });
 
 // ─── Delivery-asset discipline (P4) ───────────────────────────────────────────

--- a/tests/taste-checks-shared-root-selector.test.ts
+++ b/tests/taste-checks-shared-root-selector.test.ts
@@ -1,0 +1,55 @@
+/**
+ * `selectorSubjectIsRoot` — the shared answer to "does this rule style the root?"
+ *
+ * It exists because two checks needed that answer and each grew its own regex
+ * that matched the root name ANYWHERE in the selector: `root-overflow-x-hidden`
+ * (layout-checks-viewport) and the colour-mode root scan
+ * (taste-checks-invisible-surface). Both therefore read `body.dark .card` — a
+ * rule that styles `.card` — as a root rule.
+ *
+ * The behavioural regression for the first consumer lives in layout-lint.test.ts,
+ * where it is proven to go red without the fix. The second consumer's finding
+ * count cannot discriminate (any dark declaration anywhere trips its mixed-mode
+ * bail first), so the predicate itself is what gets pinned here — which is the
+ * honest place for it anyway, since it is the shared thing both depend on.
+ */
+import { describe, expect, it } from "vitest";
+import { selectorSubjectIsRoot } from "../src/core/taste-checks-shared.js";
+
+describe("selectorSubjectIsRoot — the subject decides, not the prefix", () => {
+  it.each([
+    ["html", "bare root element"],
+    ["body", "bare root element"],
+    [":root", "the pseudo-class form"],
+    ["html.js", "root carrying a state class"],
+    ["body.dark", "root carrying a theme class"],
+    ["body[data-theme='dark']", "root carrying an attribute"],
+    ["html, body", "a comma list where every part is a root"],
+    ["main, body", "a comma list where only the LAST part is a root"],
+    ["body, .card", "a comma list where only the FIRST part is a root"],
+  ])("%s → root (%s)", (selector) => {
+    expect(selectorSubjectIsRoot(selector)).toBe(true);
+  });
+
+  it.each([
+    ["body.dark .card", "descendant — the subject is .card"],
+    ["html.js .ln", "descendant — the subject is .ln"],
+    ["body > .page-shell", "child combinator — the subject is .page-shell"],
+    ["body .a .b .c", "deep descendant"],
+    ["html + body ~ .x", "sibling combinators — the subject is .x"],
+    [".body-text", "a class that merely starts with the word body"],
+    [".htmlish", "a class that merely starts with the word html"],
+    ["#bodyguard", "an id that merely starts with the word body"],
+    [":rooted", "a pseudo-class that merely starts with :root"],
+  ])("%s → NOT root (%s)", (selector) => {
+    expect(selectorSubjectIsRoot(selector)).toBe(false);
+  });
+
+  it("does not recognise a root wrapped in a functional pseudo — stated, not accidental", () => {
+    // Documented limit in the helper's own comment. Pinned so that if someone
+    // later teaches it :is()/:where(), this test fails and they update the note
+    // rather than leaving the doc claiming a limit that no longer exists.
+    expect(selectorSubjectIsRoot(":is(body)")).toBe(false);
+    expect(selectorSubjectIsRoot(":where(html)")).toBe(false);
+  });
+});

--- a/tests/taste-checks-web-craft.test.ts
+++ b/tests/taste-checks-web-craft.test.ts
@@ -69,6 +69,19 @@ describe("mode-invisible-surface", () => {
     expect(checkModeInvisibleSurface('<div class="bg-white/5">x</div>')).toHaveLength(1);
   });
 
+  it("still reads a genuine root rule — `html, body { background: #0b0b0b }` is dark", () => {
+    // The root scan now takes only rules whose SUBJECT is the root. This proves
+    // "ignore descendants" did not degrade into "ignore everything": a real root
+    // rule must still set the mode.
+    const html = [
+      "<style>html, body { background: #0b0b0b }</style>",
+      '<body><div class="border border-black/10">x</div></body>',
+    ].join("\n");
+    const f = checkModeInvisibleSurface(html);
+    expect(f).toHaveLength(1);
+    expect(f[0]?.message).toContain("dark-mode");
+  });
+
   it("flags a literal rgba(255,255,255,0.08) background on a light document", () => {
     const f = checkModeInvisibleSurface('<div style="background:rgba(255,255,255,0.08)">x</div>');
     expect(f).toHaveLength(1);


### PR DESCRIPTION
Recovered from `fix/validate-layout-root-overflow-subject`, a branch that stopped on 2026-07-22 and never opened a PR. Two of its commits carried live value; the rest is dispositioned separately.

## The bug, reproduced on `main`

`root-overflow-x-hidden` is meant to flag `overflow: hidden` on a root element, because `hidden` severs `position: sticky` for every descendant. Its selector test matched the root name **anywhere**:

```js
/(?:^|[\s,>+~(])(?:html|body)(?![\w-])|:root\b/i.test("body .carousel")   // true
/(?:^|[\s,>+~(])(?:html|body)(?![\w-])|:root\b/i.test("html > .page-shell") // true
```

So `body.dark .card { overflow: hidden }` — an extremely common shape — was reported as a root rule. The check has been emitting these false positives on every page that themes off a root class.

## The part that matters more than the fix

The same question, asked with the same wrong answer, lived in a second place: `taste-checks-invisible-surface.ts` decided the document's colour mode from `html|body|:root` rules matched the same way. A dark descendant rule could be read as the document background and flip the mode — which would silence an invisible-hairline finding on a page that genuinely has one.

Per Article IV, the answer moves to `taste-checks-shared.ts` as `selectorSubjectIsRoot`, and both consumers read it. Fixing only the reported site is how the redirect-stub bug came back through a second consumer (L1→L4).

## Scope of the recovery

| Commit | Action |
|---|---|
| `744488e` root-overflow subject fix | cherry-picked — the three files it touches and depends on have **zero drift** since the merge base, so the 133 intervening commits are noise for this change |
| `7579012` knowledge §5 runtime-scope clarification | cherry-picked — claims re-verified against current adapters |
| `52149fc` onboard Figma capability probe | **not** taken — right problem, but its hint text encodes a repo layout that no longer exists; filed for re-derivation |
| `e21e4f6`, `f0e6e7a` figma-agent | dead here; that directory moved to its own repo |

## Verified by breaking it

Breaking `selectorSubjectIsRoot` back to prefix-matching turns **both** consumers' tests red — the layout regression and the predicate suite. Restoring returns 92 green.

Two of my own probes failed first and are worth recording, because both were green when they should have been red:
- One break edited `rule.selector` while the code says `selector` — the perl matched nothing, so a green run meant only that nothing had changed. Breaks are now confirmed landed by grepping for the symbol before trusting the result.
- The first colour-mode test passed with **and** without the fix: the luminance probe takes the first match, so a root rule declared earlier masked the difference. That test could not discriminate, so it is gone; the predicate is pinned directly instead, and the reason is written into the file.

The known limit — `:is(body)` / `:where(html)` are not recognised as roots — is stated beside the helper and pinned by a test, so teaching it functional pseudos will fail that test and force the note to be updated rather than left lying.

## Gates

`typecheck` · `lint` · `build` · `ui knowledge check` (0 findings) all exit 0 · suite **198 files / 3487 passed**, up 22 tests.
