### PR TITLE
Onboarding points at the plugin repo when the Figma agent is absent

### DIFF
--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -58,6 +58,8 @@ const HINTS = {
   heartbeat: "wired automatically by `ui ds init`/`ui ds import`",
   agents: "run `ui agents init` for soul-bound project agents (Claude Code)",
   figma: "open the Figma Design Agent plugin, then `figma-agent status`",
+  figmaAbsent:
+    "using Figma? install the Design Agent: https://github.com/jangtrinh/design-os-figma-plugin",
 } as const;
 
 /** `design/soul.md`'s frontmatter `status:` value, or null if unreadable/absent.
@@ -97,6 +99,29 @@ function hasFigmaRef(): boolean {
   return (env["FIGMA_AGENT_FILE"] ?? "").length > 0;
 }
 
+/**
+ * Is the `figma-agent` binary reachable on PATH?
+ *
+ * Walks PATH entries and stats the candidate — no process is spawned, so the
+ * kernel stays a pure transform (Art I.2) and a probe can never hang on a
+ * misbehaving binary.
+ *
+ * Onboarding's whole job is to say what to do next, so a next step the reader
+ * cannot perform is worse than no step at all: before this probe existed, every
+ * run told the reader to type `figma-agent status`, and on a machine without it
+ * that is a `command not found` in the one place a newcomer trusts. The agent
+ * lives in its own repo (design-os-figma-plugin), so absence is the normal case,
+ * not a fault.
+ */
+function figmaAgentOnPath(): boolean {
+  const path = env["PATH"] ?? "";
+  if (path.length === 0) return false;
+  return path
+    .split(":")
+    .filter((dir) => dir.length > 0)
+    .some((dir) => existsSync(join(dir, "figma-agent")));
+}
+
 function detectSteps(cwd: string): Step[] {
   const hasAdapters =
     existsSync(join(cwd, ".claude", "ease-design.json")) ||
@@ -118,7 +143,9 @@ function detectSteps(cwd: string): Step[] {
     { id: "soul", label: "design soul", state: soulState, optional: false, hint: HINTS.soul },
     { id: "heartbeat", label: "learning loop (soul · heartbeat · harvest)", state: hasHeartbeat ? "done" : "pending", optional: false, hint: HINTS.heartbeat },
     { id: "agents", label: "project agents      (optional)", state: hasAgents ? "done" : "pending", optional: true, hint: HINTS.agents },
-    { id: "figma", label: "figma design agent  (optional)", state: hasFigma ? "done" : "pending", optional: true, hint: HINTS.figma },
+    // The hint depends on whether the agent is reachable: tell an equipped
+    // machine to open the plugin, and an unequipped one where to get it.
+    { id: "figma", label: "figma design agent  (optional)", state: hasFigma ? "done" : "pending", optional: true, hint: figmaAgentOnPath() ? HINTS.figma : HINTS.figmaAbsent },
   ];
 }
 

--- a/tests/cmd-onboard.test.ts
+++ b/tests/cmd-onboard.test.ts
@@ -51,6 +51,52 @@ describe("ui onboard — empty project", () => {
     expect(byId["figma"]?.optional).toBe(true);
   });
 
+  describe("the figma hint follows what the machine actually has", () => {
+    // Onboarding exists to name the next action, so a next action the reader
+    // cannot perform is worse than none: the hint used to say `figma-agent
+    // status` on every machine, and the agent lives in a separate repo, so on
+    // most machines that is a `command not found`.
+    const withPath = <T>(value: string | undefined, fn: () => T): T => {
+      const before = process.env["PATH"];
+      if (value === undefined) delete process.env["PATH"];
+      else process.env["PATH"] = value;
+      try {
+        return fn();
+      } finally {
+        if (before === undefined) delete process.env["PATH"];
+        else process.env["PATH"] = before;
+      }
+    };
+
+    // Read the hint off the TEXT output: the JSON envelope deliberately carries
+    // only id/state/optional, and the hint is what a human actually acts on.
+    const figmaHint = (): string => {
+      const { out } = captureRun(["onboard", "--cwd", tmp()]);
+      const line = out.split("\n").findIndex((l) => l.includes("figma design agent"));
+      return line === -1 ? "" : (out.split("\n")[line + 1] ?? "");
+    };
+
+    it("points at the plugin repo when figma-agent is not on PATH", () => {
+      const hint = withPath(join(tmpdir(), "definitely-empty-path-dir"), figmaHint);
+      expect(hint).toContain("design-os-figma-plugin");
+      expect(hint).not.toContain("figma-agent status");
+    });
+
+    it("tells an equipped machine to open the plugin instead", () => {
+      const dir = mkdtempSync(join(tmpdir(), "ease-fakebin-"));
+      writeFileSync(join(dir, "figma-agent"), "#!/bin/sh\n", { mode: 0o755 });
+      const hint = withPath(dir, figmaHint);
+      expect(hint).toContain("figma-agent status");
+      expect(hint).not.toContain("design-os-figma-plugin");
+    });
+
+    it("does not crash when PATH is unset", () => {
+      // An empty environment must degrade to the install hint, not throw — the
+      // command's contract is to always exit 0.
+      expect(withPath(undefined, figmaHint)).toContain("design-os-figma-plugin");
+    });
+  });
+
   it("shows the honest text checklist with pending marks and hints", () => {
     const dir = tmp();
     const { out } = captureRun(["onboard", "--cwd", dir]);


### PR DESCRIPTION
Closes #185.

## What the user saw

`ui onboard` printed one next step for the Figma track on **every** machine:

```
[ ] figma design agent  (optional)
      → open the Figma Design Agent plugin, then `figma-agent status`
```

The agent is not part of this package — it lives in [design-os-figma-plugin](https://github.com/jangtrinh/design-os-figma-plugin). So on a machine that has not installed it, onboarding's advice is a `command not found`, in the one place a newcomer trusts to tell them what to do next.

## The change

A PATH probe decides the hint: an equipped machine is told to open the plugin, an unequipped one is given the repo. The step stays **optional** and its state logic is untouched — only the sentence changes.

The probe stats PATH entries rather than spawning anything, so the kernel stays a pure transform (Art I.2) and a misbehaving binary cannot hang a command whose contract is to always exit 0. An unset PATH degrades to the install hint.

## Provenance

A commit for this existed on a branch that stopped 2026-07-22 (`52149fc`, preserved at tag `archive/260722-runtime-and-fixes`). It was **not** cherry-picked: its hint text named the pre-split layout, so porting it would have wired a correct probe to a destination that no longer exists. Re-derived instead.

## Verified by breaking it

Forcing the probe true fails both absent-machine cases; forcing it false fails the equipped one. Three new tests, and the hint is read off the text output — the JSON envelope carries only id/state/optional, and the sentence is what a human acts on.

Gates: `typecheck` · `lint` · `build` all exit 0 · suite **198 files / 3490 passed**.