### PR TITLE
feat(kit): typography polish — balanced titles, pretty bodies, hairline photo outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-08-19 - Kit typography polish: balanced titles, pretty bodies, hairline photos
+
+### Changed
+- Every kit title rule (`Card`, `Dialog`, `Toast`, `Alert`, `Popover`) sets
+  `text-wrap: balance`; every body/description rule sets `text-wrap: pretty` — headings
+  stop ragging on one orphan word, running copy stops leaving widows.
+- The Avatar photo carries the hairline image outline: `1px` of
+  `color-mix(in oklab, var(--color-foreground) 8%, transparent)` at `outline-offset: -1px`,
+  so a light photo reads bounded in light mode and a dark one in dark mode — one
+  token-driven declaration instead of a per-mode pair.
+- Breadcrumb links set `text-underline-position: from-font` +
+  `text-decoration-skip-ink: auto`, so the hover underline clears descenders.
+- Paired-standard rule honored in-kind: a kit floor test asserts each declaration
+  per component, so a reverted emitter goes red in CI (interfaces.dev adoption,
+  gap e1690's emitter half; the knowledge half stays in the librarian queue).
+
 ## 2026-08-19 - The repo's own surfaces meet the punctuation floor
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
+| 2026-08-19 | **Kit typography polish** — kit titles set `text-wrap: balance`, bodies `text-wrap: pretty`, the Avatar photo carries a token-driven 1px hairline outline, breadcrumb underlines clear descenders (`from-font` + `skip-ink`); a kit floor test pins every declaration so a reverted emitter goes red | `#192` |
 | 2026-08-19 | **The repo's own surfaces meet the punctuation floor** — the site and guide slides pass `content-lint` clean (typographic apostrophes, curly quotes, the CSS snippet marked up as `<code>`); `data-numbers-not-tabular` validated on 1,071 real files (3 genuine designed-UI positives) and its date-column behavior recorded as a decision | `#191` |
 | 2026-08-19 | **Five interface-craft floors from the interfaces.dev cheat sheet** — smart punctuation and verb-first button labels in `content-lint`, blocked-paste detection in `a11y-lint` (error, WCAG 3.3.8), unguarded `:hover` on mobile-intent documents in `validate-layout`, and missing tabular figures on numeric tables in `taste-lint`; the kit's Button/Breadcrumb hover rules now sit behind `@media (hover: hover)` so the kit passes its own new floor | `#189` |
 | 2026-08-17 | **Onboarding points at the plugin repo when the Figma agent is absent** — the Figma next step said `figma-agent status` on every machine, which is a `command not found` unless the separately-shipped Design Agent is installed; a PATH probe now picks the right sentence | `#187` |

--- a/src/core/component-kit/alert.ts
+++ b/src/core/component-kit/alert.ts
@@ -28,8 +28,8 @@ const markup = `<div class="ui-kit ui-alert">
     .ui-alert__box--warning .ui-alert__dot { background: var(--color-warning); }
     .ui-alert__box--danger .ui-alert__dot { background: var(--color-danger); }
     .ui-alert__text { display: grid; gap: var(--space-1); }
-    .ui-alert__title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
-    .ui-alert__body { font-size: var(--font-size-xs); color: var(--color-muted-foreground); line-height: 1.5; }
+    .ui-alert__title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); text-wrap: balance; }
+    .ui-alert__body { font-size: var(--font-size-xs); color: var(--color-muted-foreground); line-height: 1.5; text-wrap: pretty; }
     .ui-alert__action {
       font: inherit; font-size: var(--font-size-xs); font-weight: var(--font-weight-medium); cursor: pointer;
       align-self: center; white-space: nowrap; padding: var(--space-1) var(--space-3);

--- a/src/core/component-kit/avatar.ts
+++ b/src/core/component-kit/avatar.ts
@@ -27,7 +27,7 @@ const markup = `<div class="ui-kit ui-avatar">
     .ui-avatar__face--sm { width: 1.75rem; height: 1.75rem; font-size: var(--font-size-xs); }
     .ui-avatar__face--md { width: 2.25rem; height: 2.25rem; font-size: var(--font-size-sm); }
     .ui-avatar__face--lg { width: 3rem;    height: 3rem;    font-size: var(--font-size-md); }
-    .ui-avatar__img { width: 100%; height: 100%; object-fit: cover; }
+    .ui-avatar__img { width: 100%; height: 100%; object-fit: cover; outline: 1px solid color-mix(in oklab, var(--color-foreground) 8%, transparent); outline-offset: -1px; }
   </style>
   <div class="ui-avatar__row">
     <span class="ui-avatar__cap">Sizes</span>
@@ -53,7 +53,7 @@ export const avatar: KitComponent = {
     "State=Static",
   ],
   tokensUsed: [
-    "color.accent", "color.accent-foreground", "color.border", "color.muted-foreground",
+    "color.accent", "color.accent-foreground", "color.border", "color.foreground", "color.muted-foreground",
     "radius.full",
     "font-family.body", "font-weight.semibold",
     "font-size.xs", "font-size.sm", "font-size.md",

--- a/src/core/component-kit/breadcrumb.ts
+++ b/src/core/component-kit/breadcrumb.ts
@@ -14,7 +14,7 @@ const markup = `<nav class="ui-kit ui-bc" aria-label="Breadcrumb">
   <style>
     .ui-bc { font-family: var(--font-family-body); font-size: var(--font-size-sm); }
     .ui-bc__list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
-    .ui-bc__link { color: var(--color-muted-foreground); text-decoration: none; border-radius: var(--radius-sm); transition: color var(--duration-fast) ease; }
+    .ui-bc__link { color: var(--color-muted-foreground); text-decoration: none; border-radius: var(--radius-sm); transition: color var(--duration-fast) ease; text-underline-position: from-font; text-decoration-skip-ink: auto; }
     /* Touch floor: real :hover only where hover exists — on touch it sticks after a tap. */
     @media (hover: hover) { .ui-bc__link:hover { color: var(--color-foreground); text-decoration: underline; } }
     .ui-bc__link:focus-visible { outline: 2px solid var(--color-ring); outline-offset: 2px; color: var(--color-foreground); }

--- a/src/core/component-kit/card.ts
+++ b/src/core/component-kit/card.ts
@@ -22,9 +22,9 @@ const markup = `<div class="ui-kit ui-card">
       box-shadow: var(--elevation-card-offset-x) var(--elevation-card-offset-y) var(--elevation-card-blur) var(--elevation-card-spread) var(--elevation-card-color);
     }
     .ui-card__head { display: grid; gap: var(--space-1); }
-    .ui-card__title { font-family: var(--font-family-display); font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); }
+    .ui-card__title { font-family: var(--font-family-display); font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); text-wrap: balance; }
     .ui-card__sub { font-size: var(--font-size-xs); color: var(--color-muted-foreground); }
-    .ui-card__body { font-size: var(--font-size-sm); line-height: 1.5; }
+    .ui-card__body { font-size: var(--font-size-sm); line-height: 1.5; text-wrap: pretty; }
     .ui-card__foot { display: flex; gap: var(--space-2); align-items: center; }
     .ui-card__btn {
       font: inherit; font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); cursor: pointer;

--- a/src/core/component-kit/dialog.ts
+++ b/src/core/component-kit/dialog.ts
@@ -23,14 +23,14 @@ const markup = `<div class="ui-kit ui-dialog">
       box-shadow: var(--elevation-overlay-offset-x) var(--elevation-overlay-offset-y) var(--elevation-overlay-blur) var(--elevation-overlay-spread) var(--elevation-overlay-color);
     }
     .ui-dialog__head { display: flex; align-items: start; justify-content: space-between; gap: var(--space-3); }
-    .ui-dialog__title { font-family: var(--font-family-display); font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); }
+    .ui-dialog__title { font-family: var(--font-family-display); font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); text-wrap: balance; }
     .ui-dialog__close {
       font: inherit; line-height: 1; cursor: pointer; flex: none;
       padding: var(--space-1); border-radius: var(--radius-button);
       border: 1px solid transparent; background: transparent; color: var(--color-muted-foreground);
     }
     .ui-dialog__close.is-focus { outline: 2px solid var(--color-ring); outline-offset: 1px; }
-    .ui-dialog__body { font-size: var(--font-size-sm); color: var(--color-muted-foreground); line-height: 1.5; }
+    .ui-dialog__body { font-size: var(--font-size-sm); color: var(--color-muted-foreground); line-height: 1.5; text-wrap: pretty; }
     .ui-dialog__actions { display: flex; justify-content: flex-end; gap: var(--space-2); }
     .ui-dialog__btn {
       font: inherit; font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); cursor: pointer;

--- a/src/core/component-kit/popover.ts
+++ b/src/core/component-kit/popover.ts
@@ -34,8 +34,8 @@ const markup = `<div class="ui-kit ui-pop">
       position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%);
       border: var(--space-1) solid transparent; border-bottom-color: var(--color-popover);
     }
-    .ui-pop__title { font-family: var(--font-family-display); font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
-    .ui-pop__body { font-size: var(--font-size-xs); color: var(--color-muted-foreground); line-height: 1.5; }
+    .ui-pop__title { font-family: var(--font-family-display); font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); text-wrap: balance; }
+    .ui-pop__body { font-size: var(--font-size-xs); color: var(--color-muted-foreground); line-height: 1.5; text-wrap: pretty; }
     .ui-pop__row { display: flex; gap: var(--space-2); }
     .ui-pop__btn {
       font: inherit; font-size: var(--font-size-xs); font-weight: var(--font-weight-medium); cursor: pointer;

--- a/src/core/component-kit/toast.ts
+++ b/src/core/component-kit/toast.ts
@@ -28,8 +28,8 @@ const markup = `<div class="ui-kit ui-toast">
     .ui-toast__item--success .ui-toast__dot { background: var(--color-success); }
     .ui-toast__item--danger  .ui-toast__dot { background: var(--color-danger); }
     .ui-toast__text { display: grid; gap: var(--space-1); }
-    .ui-toast__title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
-    .ui-toast__body { font-size: var(--font-size-xs); color: var(--color-muted-foreground); line-height: 1.5; }
+    .ui-toast__title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); text-wrap: balance; }
+    .ui-toast__body { font-size: var(--font-size-xs); color: var(--color-muted-foreground); line-height: 1.5; text-wrap: pretty; }
     .ui-toast__close {
       font: inherit; line-height: 1; cursor: pointer; flex: none;
       padding: var(--space-1); border-radius: var(--radius-button);

--- a/tests/component-kit.test.ts
+++ b/tests/component-kit.test.ts
@@ -284,3 +284,52 @@ describe("component-kit — token-only boundary holds on Table", () => {
     }
   });
 });
+
+// ─── Typography-polish floor (interfaces.dev; gap e1690's emitter half) ─────────
+//
+// The paired-standard rule: these emitters practise the standard, and THIS test is
+// the check that fails without it. Titles balance their line breaks, running copy
+// wraps pretty, the kit's real photo carries the hairline outline, and drawn
+// underlines clear descenders. Asserted per-rule against the emitters' own CSS so
+// a reverted declaration goes red here, not in a reviewer's eyeball.
+describe("component-kit — typography-polish floor", () => {
+  const byName = (name: string): string => COMPONENT_KIT.find((c) => c.name === name)!.markup;
+
+  it("every kit title rule balances its wrap (text-wrap: balance)", () => {
+    for (const [name, cls] of [
+      ["Display/Card", ".ui-card__title"], ["Overlay/Dialog", ".ui-dialog__title"],
+      ["Display/Toast", ".ui-toast__title"], ["Display/Alert", ".ui-alert__title"],
+      ["Overlay/Popover", ".ui-pop__title"],
+    ] as const) {
+      const m = byName(name);
+      expect(m, `${name} ${cls} lacks text-wrap: balance`).toMatch(
+        new RegExp(`${cls.replace(/[.$]/g, "\\$&")}\\s*\\{[^}]*text-wrap:\\s*balance`),
+      );
+    }
+  });
+
+  it("every kit body/description rule wraps pretty (text-wrap: pretty)", () => {
+    for (const [name, cls] of [
+      ["Display/Card", ".ui-card__body"], ["Overlay/Dialog", ".ui-dialog__body"],
+      ["Display/Toast", ".ui-toast__body"], ["Display/Alert", ".ui-alert__body"],
+      ["Overlay/Popover", ".ui-pop__body"],
+    ] as const) {
+      const m = byName(name);
+      expect(m, `${name} ${cls} lacks text-wrap: pretty`).toMatch(
+        new RegExp(`${cls.replace(/[.$]/g, "\\$&")}\\s*\\{[^}]*text-wrap:\\s*pretty`),
+      );
+    }
+  });
+
+  it("the avatar photo carries the 1px hairline outline, inset by -1px", () => {
+    const m = byName("Display/Avatar");
+    expect(m).toMatch(/\.ui-avatar__img\s*\{[^}]*outline:\s*1px solid color-mix\(in oklab, var\(--color-foreground\) 8%, transparent\)/);
+    expect(m).toMatch(/\.ui-avatar__img\s*\{[^}]*outline-offset:\s*-1px/);
+  });
+
+  it("breadcrumb underlines clear descenders (from-font + skip-ink)", () => {
+    const m = byName("Structure/Breadcrumb");
+    expect(m).toMatch(/\.ui-bc__link\s*\{[^}]*text-underline-position:\s*from-font/);
+    expect(m).toMatch(/\.ui-bc__link\s*\{[^}]*text-decoration-skip-ink:\s*auto/);
+  });
+});


### PR DESCRIPTION
The emitter half of gap e1690 (interfaces.dev adoption), same discipline as #189:

| Rule | Where |
|---|---|
| `text-wrap: balance` on titles | Card, Dialog, Toast, Alert, Popover |
| `text-wrap: pretty` on bodies/descriptions | same five |
| 1px hairline image outline, `outline-offset: -1px`, via `color-mix(in oklab, var(--color-foreground) 8%, transparent)` — one token-driven declaration covers light and dark | Avatar photo |
| `text-underline-position: from-font` + `text-decoration-skip-ink: auto` | Breadcrumb links |

**Paired standard**: a kit floor test asserts every declaration per component — all four prongs were red before the emitters changed, and a reverted declaration goes red in CI. The kit's own `tokensUsed` hygiene gate caught Avatar's new `color.foreground` dependency.

**Librarian note**: the knowledge half of e1689–e1691 ran the veto chain this session and stopped `single_project_only` (all 14 groups single-project — the gate refusing day-one external knowledge is it working); gaps stay open for recurrence.

Gates: typecheck, lint, build, 3530 passed / 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)