### PR TITLE
feat(autofix): floor repairs — hover guard, tabular figures, focus-ring restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@
 ### Added
 - `ui autofix` gains three floor repairs, each gated by the same check function its
   linter runs (a repair the checker cannot confirm fixed nothing): `hover-media-guard`
-  wraps raw `:hover` rules in `@media (hover: hover)` in place (cascade order kept;
-  nesting inside an unrelated media query stays valid); `table-tabular-nums` injects
-  the one declaration the lint prescribes; `focus-outline-restore` deletes
-  outline-killing focus declarations and `focus:outline-none` utility tokens so the
-  browser ring returns — programmatic focus targets (`tabindex="-1"`) are left alone.
+  wraps raw flat `:hover` rules in `@media (hover: hover)` in place (cascade order
+  kept; wrapping inside an unrelated media query is valid nested media; CSS-nested
+  rules and mixed selector lists are skipped as misses — structural safety over
+  coverage, and string literals are blanked so a `}` in `content:"…"` can never
+  mis-pair a brace); `table-tabular-nums` emits a fresh one-line `<style>` in
+  `<head>` (never adopts a block that may live in a script string or a comment);
+  `focus-outline-restore` deletes whole-value outline kills and
+  `focus:outline-none` utility tokens so the browser ring returns — programmatic
+  focus targets (`tabindex="-1"`), documentation copy in `<pre>/<code>`, and
+  framework values (`data-class`/`:class`) are all left alone.
   Floor repairs rewrite CSS and attribute values only; copy text is never edited
   (owner decision), so punctuation and label violations still route through refine.
 - `generation-craft-defaults.md` gains a "Machine floors — emit to pass" section: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026-08-19 - The floors repair themselves, and generation is told to be born passing
+
+### Added
+- `ui autofix` gains three floor repairs, each gated by the same check function its
+  linter runs (a repair the checker cannot confirm fixed nothing): `hover-media-guard`
+  wraps raw `:hover` rules in `@media (hover: hover)` in place (cascade order kept;
+  nesting inside an unrelated media query stays valid); `table-tabular-nums` injects
+  the one declaration the lint prescribes; `focus-outline-restore` deletes
+  outline-killing focus declarations and `focus:outline-none` utility tokens so the
+  browser ring returns — programmatic focus targets (`tabindex="-1"`) are left alone.
+  Floor repairs rewrite CSS and attribute values only; copy text is never edited
+  (owner decision), so punctuation and label violations still route through refine.
+- `generation-craft-defaults.md` gains a "Machine floors — emit to pass" section: the
+  generator is told the floors up front instead of paying a bounded refine round for
+  what the linters would catch anyway.
+
+
 ## 2026-08-19 - Three more floors: labels, focus rings, concentric corners
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
+| 2026-08-19 | **The floors repair themselves** — `ui autofix` wraps unguarded `:hover` in `@media (hover: hover)`, injects `tabular-nums` on numeric tables, and restores killed focus rings, each repair gated by its own linter check and confirmed silent after; generation-craft-defaults now teaches the floors up front so variants are born passing | `#195` |
 | 2026-08-19 | **Three more floors: labels, focus rings, concentric corners** — `input-unlabeled` + `focus-outline-removed` (a11y errors, WCAG 3.3.2/2.4.7), `equal-nested-radii` (taste warning; the concentric rule finally gets its linter), and the critique workflow walks every state, slows motion to 10%, and reports considered-but-rejected fixes instead of padding suggestions | `#193` |
 | 2026-08-19 | **Kit typography polish** — kit titles set `text-wrap: balance`, bodies `text-wrap: pretty`, the Avatar photo carries a token-driven 1px hairline outline, breadcrumb underlines clear descenders (`from-font` + `skip-ink`); a kit floor test pins every declaration so a reverted emitter goes red | `#192` |
 | 2026-08-19 | **The repo's own surfaces meet the punctuation floor** — the site and guide slides pass `content-lint` clean (typographic apostrophes, curly quotes, the CSS snippet marked up as `<code>`); `data-numbers-not-tabular` validated on 1,071 real files (3 genuine designed-UI positives) and its date-column behavior recorded as a decision | `#191` |

--- a/knowledge/generation-craft-defaults.md
+++ b/knowledge/generation-craft-defaults.md
@@ -87,6 +87,28 @@ Use the lowest sufficient tier in `motion-craft.md`.
 Motion must serve hierarchy, causality, feedback, or atmosphere. Animation quantity is never a
 quality metric.
 
+## Machine floors — emit to pass, not to be repaired
+
+Every candidate runs the full linter set and the autofixer before critique, and the
+critique gate caps any axis with a linter finding below the pass threshold. A variant
+born violating a floor spends a bounded refine round on what should have been emitted
+correctly. Emit these from the first keystroke:
+
+- Real `:hover` styling sits inside `@media (hover: hover)`; specimen states use static
+  classes. Tailwind `hover:` utilities already comply.
+- Numeric data columns and changing values carry `font-variant-numeric: tabular-nums`
+  (or a monospace face).
+- Headings set `text-wrap: balance`; running copy sets `text-wrap: pretty`.
+- Every text control has a programmatic label (`<label for>`, a wrapping label, or
+  `aria-label`) — a placeholder is never a label. Never cancel paste.
+- Never remove a focus outline without a visible replacement ring; a `tabindex="-1"`
+  programmatic focus target is the one legitimate suppression.
+- Nested rounded corners stay concentric (outer = inner + padding); transitions name
+  exact properties, never `all`; animation ships with a `prefers-reduced-motion` path.
+- Copy is typeset: `…` `’` curly quotes; button labels start with a verb and repeat the
+  consequence (never a bare OK/Yes) — the autofixer repairs CSS and attributes only,
+  so copy violations always cost a refine round.
+
 ## Custom controls
 
 Custom appearance is the default. Custom behavior must be earned.

--- a/src/commands/autofix.ts
+++ b/src/commands/autofix.ts
@@ -1,5 +1,5 @@
 /**
- * `ui autofix` command — apply 5 deterministic HTML fix rules.
+ * `ui autofix` command — apply the deterministic HTML fix rules.
  *
  * Default: fixed HTML → stdout, findings summary → stderr.
  * --write: overwrite the input file in place (opt-in side effect).
@@ -32,6 +32,12 @@ Rules applied (in order):
   lucide-createicons Insert lucide.createIcons() when Lucide icons are used
   cdn-urls           Replace versioned Lucide CDN URLs with @latest
   duplicate-ids      Append -N suffix to duplicate id="" values
+  hover-media-guard     Wrap raw :hover rules in @media (hover: hover) (mobile-intent docs)
+  table-tabular-nums    Add font-variant-numeric: tabular-nums for numeric table columns
+  focus-outline-restore Remove outline-killing focus declarations so the browser ring returns
+
+Floor repairs are gated by the same checks the linters run and rewrite only
+CSS and attribute values — copy text is never edited.
 
 Error codes:
   BAD_ARG        Missing <file.html> argument
@@ -49,7 +55,7 @@ Notes:
 
 export const autofixCommand = {
   name: CMD,
-  summary: "Apply 5 deterministic HTML fix rules (viewport, imgs, Lucide, CDN, dup-ids)",
+  summary: "Apply deterministic HTML fix rules (viewport, imgs, Lucide, CDN, dup-ids, floor repairs)",
   hasSubcommands: false,
   help: AUTOFIX_HELP,
 

--- a/src/core/a11y-checks-focus-and-labels.ts
+++ b/src/core/a11y-checks-focus-and-labels.ts
@@ -85,8 +85,8 @@ const TW_REPLACED = /\bfocus(?:-visible|-within)?:(?:ring|shadow|border|outline-
  * A programmatic focus target — a skip-link/dialog destination focused from
  * script with tabindex="-1". Suppressing its ring while real controls keep the
  * browser default is recommended practice, not a removal (WCAG techniques).
- */
-function isProgrammaticFocusTarget(selector: string, markup: string): boolean {
+ *  Exported for the paired repair (focus-outline-restore) — checker and repair share it. */
+export function isProgrammaticFocusTarget(selector: string, markup: string): boolean {
   if (/\[tabindex\s*=\s*["']?-1/i.test(selector)) return true;
   const id = /#([\w-]+)/.exec(selector)?.[1];
   if (id === undefined) return false;

--- a/src/core/html-autofix-floor-repairs.ts
+++ b/src/core/html-autofix-floor-repairs.ts
@@ -2,21 +2,33 @@
  * Floor repairs — deterministic autofixes for three interface-craft floors the
  * linters enforce. Each repair is GATED by the same check function that reports
  * the finding and only rewrites CSS or attribute values, never copy text (owner
- * decision). Checker and repair share one evidence source: a repair fires only
- * on a document its checker flags, and the paired test asserts the checker goes
- * silent afterward — a repair the checker can't confirm fixed nothing.
+ * decision — documentation copy in <pre>/<code> and framework values like
+ * data-class/:class are out of bounds). Checker and repair share one evidence
+ * source: a repair fires only on a document its checker flags, and the paired
+ * test asserts the checker goes silent afterward — a repair the checker can't
+ * confirm fixed nothing. Structural safety over coverage: a shape the rewriter
+ * cannot transform provably-intact (CSS nesting, mixed selector lists) is
+ * skipped as a miss, never guessed at.
  */
-import { checkStickyHoverUnguarded, stripHoverGuardedBlocks } from "./layout-checks-hover.js";
+import { checkStickyHoverUnguarded, stripHoverGuardedBlocks, blankStringLiterals } from "./layout-checks-hover.js";
 import { checkDataNumbersNotTabular } from "./taste-checks-typography.js";
 import { checkFocusOutlineRemoved, isProgrammaticFocusTarget } from "./a11y-checks-focus-and-labels.js";
 
 /** Blank to spaces, length- and newline-preserving (offsets stay valid). */
 const blankPreserving = (m: string): string => m.replace(/[^\n]/g, " ");
 
-/** Each <style> block's inner span, with offsets into the whole document. */
+/** Non-markup regions blanked — same discipline as the checkers' markupOnly. */
+function blankNonMarkup(html: string): string {
+  return html.replace(/<(script|pre|code|kbd|samp)\b[\s\S]*?<\/\1\s*>/gi, blankPreserving);
+}
+
+/** Each <style> block's inner span, with offsets into the whole document.
+ *  Scanned over the non-markup mask, so a "<style>" inside a script string or a
+ *  comment is never adopted as a rewrite target. */
 function styleSpans(html: string): Array<{ start: number; end: number }> {
   const out: Array<{ start: number; end: number }> = [];
-  for (const m of html.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)) {
+  const mask = blankNonMarkup(html).replace(/<!--[\s\S]*?-->/g, blankPreserving);
+  for (const m of mask.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)) {
     const inner = m[1] ?? "";
     const start = m.index + m[0].indexOf(inner);
     out.push({ start, end: start + inner.length });
@@ -39,8 +51,15 @@ function flatRules(css: string): Array<{ selector: string; start: number; end: n
  * hover-media-guard: wrap each unguarded `:hover` rule in place inside
  * `@media (hover: hover) { … }`. In-place wrapping preserves cascade order, and
  * a rule already inside an unrelated media query becomes valid nested media.
- * Gate + mask both come from the checker's own logic (mobile-intent gate via
- * checkStickyHoverUnguarded; guarded-block mask via stripHoverGuardedBlocks).
+ * Gate + mask come from the checker's own logic (mobile-intent gate via
+ * checkStickyHoverUnguarded; string literals blanked by the SAME helper the
+ * checker uses, so a `}` inside `content: "…"` can never mis-pair a brace;
+ * guarded blocks blanked via stripHoverGuardedBlocks).
+ *
+ * Skipped as misses, never guessed: a "selector" containing `;` (that is the
+ * declaration run of a CSS-nested rule — wrapping it would engulf the base
+ * styles), and a selector list whose comma-parts are not ALL `:hover` (wrapping
+ * would move sibling state like `.is-active` behind hover capability).
  */
 export function fixHoverMediaGuard(html: string): { html: string; applied: boolean } {
   if (checkStickyHoverUnguarded(html).length === 0) return { html, applied: false };
@@ -48,8 +67,14 @@ export function fixHoverMediaGuard(html: string): { html: string; applied: boole
   // Walk style blocks last-to-first so earlier spans stay valid while rewriting.
   for (const span of styleSpans(html).reverse()) {
     const css = html.slice(span.start, span.end);
-    const mask = stripHoverGuardedBlocks(css.replace(/\/\*[\s\S]*?\*\//g, blankPreserving));
-    const targets = flatRules(mask).filter((r) => /:hover\b/i.test(r.selector)).reverse();
+    const mask = stripHoverGuardedBlocks(
+      blankStringLiterals(css.replace(/\/\*[\s\S]*?\*\//g, blankPreserving)),
+    );
+    const targets = flatRules(mask)
+      .filter((r) => /:hover\b/i.test(r.selector))
+      .filter((r) => !r.selector.includes(";"))
+      .filter((r) => r.selector.split(",").every((part) => /:hover\b/i.test(part)))
+      .reverse();
     let content = css;
     for (const r of targets) {
       content = content.slice(0, r.start) +
@@ -63,40 +88,43 @@ export function fixHoverMediaGuard(html: string): { html: string; applied: boole
 }
 
 /**
- * table-tabular-nums: when numeric table columns lack tabular figures, inject
- * the one declaration the lint message prescribes into the first <style> block
- * (or a new block at the top of <head>). Digits then align down the column.
+ * table-tabular-nums: when numeric table columns lack tabular figures, emit a
+ * FRESH one-line <style> at the top of <head> with the declaration the lint
+ * message prescribes. Never adopts an existing block: the first-<style> found
+ * by a regex may live in a script string, a comment, or <noscript> — injecting
+ * there corrupts code or silences the checker without fixing the page.
  */
 export function fixTableTabularNums(html: string): { html: string; applied: boolean } {
   if (checkDataNumbersNotTabular(html).length === 0) return { html, applied: false };
-  const rule = "td, th { font-variant-numeric: tabular-nums; }";
-  const style = /<style\b[^>]*>/i.exec(html);
-  if (style !== null) {
-    const at = style.index + style[0].length;
-    return { html: `${html.slice(0, at)}\n${rule}${html.slice(at)}`, applied: true };
-  }
-  const head = /<head\b[^>]*>/i.exec(html);
+  const head = /<head\b[^>]*>/i.exec(blankNonMarkup(html));
   if (head === null) return { html, applied: false };
   const at = head.index + head[0].length;
-  return { html: `${html.slice(0, at)}\n<style>${rule}</style>${html.slice(at)}`, applied: true };
+  return {
+    html: `${html.slice(0, at)}<style>td, th { font-variant-numeric: tabular-nums; }</style>${html.slice(at)}`,
+    applied: true,
+  };
 }
 
-/** The outline-killing declaration, as the checker defines it. */
-const OUTLINE_KILL_DECL = /outline\s*:\s*(?:none|0(?:px)?)\s*(?:!important\s*)?;?/gi;
+/** The outline-killing declaration — whole-value only, same anchor discipline as
+ *  the checker: `outline: 0px solid transparent` is a REAL ring and must survive. */
+const OUTLINE_KILL_DECL = /outline\s*:\s*(?:none|0(?:px)?)\s*(?:!important\s*)?(?:;|(?=\s*\})|$)/gi;
 
 /**
  * focus-outline-restore: delete the outline-killing declaration from focus
  * rules (the browser default ring returns — the safest visible replacement)
- * and drop `focus*:outline-none` utility tokens from class attributes. Rules
- * on programmatic focus targets (tabindex="-1") are left alone — the checker
- * does not count them as removals, so the repair must not touch them either.
+ * and drop `focus*:outline-none` utility tokens from real class attributes.
+ * Rules on programmatic focus targets (tabindex="-1") are left alone — the
+ * checker does not count them as removals, so the repair must not touch them.
+ * The class pass runs over markup only (never <pre>/<code>/script copy), only
+ * on the `class` attribute itself (never data-class/:class), and rewrites an
+ * attribute only when a token was actually removed — no reflow-only diffs.
  */
 export function fixFocusOutlineRestore(html: string): { html: string; applied: boolean } {
   if (checkFocusOutlineRemoved(html).length === 0) return { html, applied: false };
   let fixed = html;
   for (const span of styleSpans(html).reverse()) {
     const css = html.slice(span.start, span.end);
-    const mask = css.replace(/\/\*[\s\S]*?\*\//g, blankPreserving);
+    const mask = blankStringLiterals(css.replace(/\/\*[\s\S]*?\*\//g, blankPreserving));
     let content = css;
     for (const r of flatRules(mask).reverse()) {
       if (!/:focus(-visible|-within)?\b/i.test(r.selector)) continue;
@@ -107,10 +135,20 @@ export function fixFocusOutlineRestore(html: string): { html: string; applied: b
     }
     fixed = fixed.slice(0, span.start) + content + fixed.slice(span.end);
   }
-  fixed = fixed.replace(/(\bclass\s*=\s*)(["'])([^"']*)\2/gi, (whole, prefix: string, q: string, v: string) => {
-    const cleaned = v.replace(/(?:^|\s)focus(?:-visible|-within)?:outline-none(?=\s|$)/g, " ").replace(/\s{2,}/g, " ").trim();
-    return cleaned === v.trim() ? whole : `${prefix}${q}${cleaned}${q}`;
-  });
+  // Class-token pass: find real class attributes on the non-markup mask, edit
+  // the original by position so copy regions are provably untouched.
+  const mask = blankNonMarkup(fixed);
+  const edits: Array<{ start: number; end: number; text: string }> = [];
+  for (const m of mask.matchAll(/(?<![-\w:])class\s*=\s*(["'])([^"']*)\1/gi)) {
+    const value = m[2] ?? "";
+    const cleaned = value.replace(/(?:^|\s)focus(?:-visible|-within)?:outline-none(?=\s|$)/g, " ");
+    if (cleaned === value) continue; // nothing removed → attribute untouched
+    const normalized = cleaned.replace(/\s{2,}/g, " ").trim();
+    // m[0] ends `…"value"` — the value starts exactly value.length+1 from the end.
+    const valueStart = m.index + m[0].length - 1 - value.length;
+    edits.push({ start: valueStart, end: valueStart + value.length, text: normalized });
+  }
+  for (const e of edits.reverse()) fixed = fixed.slice(0, e.start) + e.text + fixed.slice(e.end);
   const applied = fixed !== html;
   return { html: applied ? fixed : html, applied };
 }

--- a/src/core/html-autofix-floor-repairs.ts
+++ b/src/core/html-autofix-floor-repairs.ts
@@ -1,0 +1,116 @@
+/**
+ * Floor repairs — deterministic autofixes for three interface-craft floors the
+ * linters enforce. Each repair is GATED by the same check function that reports
+ * the finding and only rewrites CSS or attribute values, never copy text (owner
+ * decision). Checker and repair share one evidence source: a repair fires only
+ * on a document its checker flags, and the paired test asserts the checker goes
+ * silent afterward — a repair the checker can't confirm fixed nothing.
+ */
+import { checkStickyHoverUnguarded, stripHoverGuardedBlocks } from "./layout-checks-hover.js";
+import { checkDataNumbersNotTabular } from "./taste-checks-typography.js";
+import { checkFocusOutlineRemoved, isProgrammaticFocusTarget } from "./a11y-checks-focus-and-labels.js";
+
+/** Blank to spaces, length- and newline-preserving (offsets stay valid). */
+const blankPreserving = (m: string): string => m.replace(/[^\n]/g, " ");
+
+/** Each <style> block's inner span, with offsets into the whole document. */
+function styleSpans(html: string): Array<{ start: number; end: number }> {
+  const out: Array<{ start: number; end: number }> = [];
+  for (const m of html.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)) {
+    const inner = m[1] ?? "";
+    const start = m.index + m[0].indexOf(inner);
+    out.push({ start, end: start + inner.length });
+  }
+  return out;
+}
+
+/** Innermost flat CSS rules (selector + full span) within a masked CSS string. */
+function flatRules(css: string): Array<{ selector: string; start: number; end: number }> {
+  const out: Array<{ selector: string; start: number; end: number }> = [];
+  for (const m of css.matchAll(/([^{}]+)\{[^{}]*\}/g)) {
+    const raw = m[1] ?? "";
+    const lead = raw.length - raw.trimStart().length;
+    out.push({ selector: raw.trim(), start: m.index + lead, end: m.index + m[0].length });
+  }
+  return out;
+}
+
+/**
+ * hover-media-guard: wrap each unguarded `:hover` rule in place inside
+ * `@media (hover: hover) { … }`. In-place wrapping preserves cascade order, and
+ * a rule already inside an unrelated media query becomes valid nested media.
+ * Gate + mask both come from the checker's own logic (mobile-intent gate via
+ * checkStickyHoverUnguarded; guarded-block mask via stripHoverGuardedBlocks).
+ */
+export function fixHoverMediaGuard(html: string): { html: string; applied: boolean } {
+  if (checkStickyHoverUnguarded(html).length === 0) return { html, applied: false };
+  let fixed = html;
+  // Walk style blocks last-to-first so earlier spans stay valid while rewriting.
+  for (const span of styleSpans(html).reverse()) {
+    const css = html.slice(span.start, span.end);
+    const mask = stripHoverGuardedBlocks(css.replace(/\/\*[\s\S]*?\*\//g, blankPreserving));
+    const targets = flatRules(mask).filter((r) => /:hover\b/i.test(r.selector)).reverse();
+    let content = css;
+    for (const r of targets) {
+      content = content.slice(0, r.start) +
+        `@media (hover: hover) { ${content.slice(r.start, r.end)} }` +
+        content.slice(r.end);
+    }
+    fixed = fixed.slice(0, span.start) + content + fixed.slice(span.end);
+  }
+  const applied = fixed !== html;
+  return { html: applied ? fixed : html, applied };
+}
+
+/**
+ * table-tabular-nums: when numeric table columns lack tabular figures, inject
+ * the one declaration the lint message prescribes into the first <style> block
+ * (or a new block at the top of <head>). Digits then align down the column.
+ */
+export function fixTableTabularNums(html: string): { html: string; applied: boolean } {
+  if (checkDataNumbersNotTabular(html).length === 0) return { html, applied: false };
+  const rule = "td, th { font-variant-numeric: tabular-nums; }";
+  const style = /<style\b[^>]*>/i.exec(html);
+  if (style !== null) {
+    const at = style.index + style[0].length;
+    return { html: `${html.slice(0, at)}\n${rule}${html.slice(at)}`, applied: true };
+  }
+  const head = /<head\b[^>]*>/i.exec(html);
+  if (head === null) return { html, applied: false };
+  const at = head.index + head[0].length;
+  return { html: `${html.slice(0, at)}\n<style>${rule}</style>${html.slice(at)}`, applied: true };
+}
+
+/** The outline-killing declaration, as the checker defines it. */
+const OUTLINE_KILL_DECL = /outline\s*:\s*(?:none|0(?:px)?)\s*(?:!important\s*)?;?/gi;
+
+/**
+ * focus-outline-restore: delete the outline-killing declaration from focus
+ * rules (the browser default ring returns — the safest visible replacement)
+ * and drop `focus*:outline-none` utility tokens from class attributes. Rules
+ * on programmatic focus targets (tabindex="-1") are left alone — the checker
+ * does not count them as removals, so the repair must not touch them either.
+ */
+export function fixFocusOutlineRestore(html: string): { html: string; applied: boolean } {
+  if (checkFocusOutlineRemoved(html).length === 0) return { html, applied: false };
+  let fixed = html;
+  for (const span of styleSpans(html).reverse()) {
+    const css = html.slice(span.start, span.end);
+    const mask = css.replace(/\/\*[\s\S]*?\*\//g, blankPreserving);
+    let content = css;
+    for (const r of flatRules(mask).reverse()) {
+      if (!/:focus(-visible|-within)?\b/i.test(r.selector)) continue;
+      if (isProgrammaticFocusTarget(r.selector, html)) continue;
+      const body = content.slice(r.start, r.end);
+      const repaired = body.replace(OUTLINE_KILL_DECL, "");
+      if (repaired !== body) content = content.slice(0, r.start) + repaired + content.slice(r.end);
+    }
+    fixed = fixed.slice(0, span.start) + content + fixed.slice(span.end);
+  }
+  fixed = fixed.replace(/(\bclass\s*=\s*)(["'])([^"']*)\2/gi, (whole, prefix: string, q: string, v: string) => {
+    const cleaned = v.replace(/(?:^|\s)focus(?:-visible|-within)?:outline-none(?=\s|$)/g, " ").replace(/\s{2,}/g, " ").trim();
+    return cleaned === v.trim() ? whole : `${prefix}${q}${cleaned}${q}`;
+  });
+  const applied = fixed !== html;
+  return { html: applied ? fixed : html, applied };
+}

--- a/src/core/html-autofix.ts
+++ b/src/core/html-autofix.ts
@@ -1,7 +1,7 @@
 /**
  * Deterministic HTML autofix rules — pure string/regex transforms, zero deps.
  *
- * Five rules run in sequence; each returns the (possibly modified) HTML and a
+ * The registered rules run in sequence; each returns the (possibly modified) HTML and a
  * boolean indicating whether it fired. runAutofix threads the HTML through all
  * five and returns the final string plus a findings list.
  *
@@ -11,6 +11,7 @@
  *     the /api/unsplash/search fetch step is removed (dead endpoint in ease-design).
  */
 import { getImageFallbackScriptInline } from "./html-img-fallback-script.js";
+import { fixHoverMediaGuard, fixTableTabularNums, fixFocusOutlineRestore } from "./html-autofix-floor-repairs.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -184,9 +185,14 @@ const RULES = [
   { id: "lucide-createicons",fn: fixLucideCreateIcons, desc: "Added lucide.createIcons() call" },
   { id: "cdn-urls",          fn: fixCdnUrls,          desc: "Fixed outdated CDN URLs" },
   { id: "duplicate-ids",     fn: fixDuplicateIds,     desc: "Fixed duplicate element IDs" },
+  // Floor repairs — CSS/attribute-only fixes for linted floors; each is gated by
+  // its own checker (see html-autofix-floor-repairs.ts) and never touches copy.
+  { id: "hover-media-guard",     fn: fixHoverMediaGuard,     desc: "Wrapped raw :hover rules in @media (hover: hover)" },
+  { id: "table-tabular-nums",    fn: fixTableTabularNums,    desc: "Added tabular figures to numeric table columns" },
+  { id: "focus-outline-restore", fn: fixFocusOutlineRestore, desc: "Restored the focus ring (removed outline-killing declarations)" },
 ] as const;
 
-/** Apply all five rules in order. Returns fixed HTML + list of rules that fired. */
+/** Apply every rule in order. Returns fixed HTML + list of rules that fired. */
 export function runAutofix(html: string): AutofixResult {
   let current = html;
   const findings: AutofixFinding[] = [];

--- a/src/core/layout-checks-hover.ts
+++ b/src/core/layout-checks-hover.ts
@@ -27,8 +27,9 @@ const MOBILE_INTENT = /\b(?:sm|md|lg|xl|2xl):[a-z[]/i;
 /** Opening of a hover-capability media guard: @media … (hover: hover) / (any-hover: hover) … { */
 const HOVER_GUARD_HEAD = /@media[^{]*\(\s*(?:any-)?hover\s*:\s*hover\s*\)[^{]*\{/gi;
 
-/** Blank every @media (hover: hover) {…} block, brace-depth aware, offsets preserved. */
-function stripHoverGuardedBlocks(css: string): string {
+/** Blank every @media (hover: hover) {…} block, brace-depth aware, offsets preserved.
+ *  Exported for the paired repair (hover-media-guard) — checker and repair share one mask. */
+export function stripHoverGuardedBlocks(css: string): string {
   let out = css;
   let m: RegExpExecArray | null;
   HOVER_GUARD_HEAD.lastIndex = 0;

--- a/src/core/layout-checks-hover.ts
+++ b/src/core/layout-checks-hover.ts
@@ -24,6 +24,13 @@ import { hasViewportMeta } from "./a11y-checks.js";
 const WIDTH_MEDIA = /@media[^{]*\(\s*(?:max|min)-width/i;
 const MOBILE_INTENT = /\b(?:sm|md|lg|xl|2xl):[a-z[]/i;
 
+/** Blank CSS string literals to spaces, length-preserving — a `}` inside
+ *  `content: "…"` must never pair a brace. Shared by the checker's mask and the
+ *  hover-media-guard repair, so both walk the same structure. */
+export function blankStringLiterals(css: string): string {
+  return css.replace(/(["'])(?:\\.|(?!\1)[^\\\n])*\1/g, (s) => " ".repeat(s.length));
+}
+
 /** Opening of a hover-capability media guard: @media … (hover: hover) / (any-hover: hover) … { */
 const HOVER_GUARD_HEAD = /@media[^{]*\(\s*(?:any-)?hover\s*:\s*hover\s*\)[^{]*\{/gi;
 
@@ -50,8 +57,9 @@ export function stripHoverGuardedBlocks(css: string): string {
 
 export function checkStickyHoverUnguarded(html: string): LayoutFinding[] {
   if (!hasViewportMeta(html) && !WIDTH_MEDIA.test(html) && !MOBILE_INTENT.test(html)) return [];
-  // CSS comments are blanked first — a ":hover" mentioned in prose is not a rule.
-  const css = cssRegions(html).replace(/\/\*[\s\S]*?\*\//g, (m) => " ".repeat(m.length));
+  // CSS comments and string literals are blanked first — a ":hover" mentioned in
+  // prose is not a rule, and a "}" inside content:"…" must not close a guard early.
+  const css = blankStringLiterals(cssRegions(html).replace(/\/\*[\s\S]*?\*\//g, (m) => " ".repeat(m.length)));
   const unguarded = stripHoverGuardedBlocks(css);
   const count = [...unguarded.matchAll(/:hover\b/gi)].length;
   if (count === 0) return [];

--- a/tests/html-autofix-floor-repairs.test.ts
+++ b/tests/html-autofix-floor-repairs.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Floor repairs — the autofix half of the interface-craft floors. Each repair is
+ * gated by the SAME check function that reports the finding, and every positive
+ * case asserts the check goes silent after the repair (checker and repair share
+ * one evidence source — a repair the checker can't confirm fixed nothing).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  fixHoverMediaGuard,
+  fixTableTabularNums,
+  fixFocusOutlineRestore,
+} from "../src/core/html-autofix-floor-repairs.js";
+import { runAutofix } from "../src/core/html-autofix.js";
+import { checkStickyHoverUnguarded } from "../src/core/layout-checks-hover.js";
+import { checkDataNumbersNotTabular } from "../src/core/taste-checks-typography.js";
+import { checkFocusOutlineRemoved } from "../src/core/a11y-checks.js";
+
+const VIEWPORT = '<meta name="viewport" content="width=device-width, initial-scale=1">';
+
+describe("hover-media-guard", () => {
+  const bad = `${VIEWPORT}<style>.btn:hover{background:#eee}.card{color:#111}</style>`;
+
+  it("wraps the unguarded :hover rule in place and the check goes silent", () => {
+    const { html, applied } = fixHoverMediaGuard(bad);
+    expect(applied).toBe(true);
+    expect(html).toMatch(/@media \(hover: hover\)\s*\{\s*\.btn:hover\{background:#eee\}\s*\}/);
+    expect(html).toContain(".card{color:#111}"); // non-hover rules untouched
+    expect(checkStickyHoverUnguarded(html)).toEqual([]);
+  });
+
+  it("wraps a :hover rule nested inside an unrelated media query too", () => {
+    const nested = `${VIEWPORT}<style>@media (min-width: 768px){.a:hover{opacity:.8}}</style>`;
+    const { html } = fixHoverMediaGuard(nested);
+    expect(checkStickyHoverUnguarded(html)).toEqual([]);
+  });
+
+  it("is idempotent and leaves already-guarded documents untouched", () => {
+    const once = fixHoverMediaGuard(bad).html;
+    const twice = fixHoverMediaGuard(once);
+    expect(twice.applied).toBe(false);
+    expect(twice.html).toBe(once);
+  });
+
+  it("does not touch a desktop-only document (no mobile intent — the check's own gate)", () => {
+    const desktop = "<style>.btn:hover{background:#eee}</style>";
+    expect(fixHoverMediaGuard(desktop).applied).toBe(false);
+  });
+});
+
+describe("table-tabular-nums", () => {
+  const TABLE = "<table><tr><td>1,204</td></tr><tr><td>982</td></tr><tr><td>1,410</td></tr></table>";
+  const bad = `<head><style>body{font-family:Inter}</style></head><body>${TABLE}</body>`;
+
+  it("injects the td,th tabular-nums rule and the check goes silent", () => {
+    const { html, applied } = fixTableTabularNums(bad);
+    expect(applied).toBe(true);
+    expect(html).toMatch(/td,\s*th\s*\{\s*font-variant-numeric:\s*tabular-nums;?\s*\}/);
+    expect(checkDataNumbersNotTabular(html)).toEqual([]);
+  });
+
+  it("creates a style block in head when none exists", () => {
+    const noStyle = `<head><title>t</title></head><body>${TABLE}</body>`;
+    const { html, applied } = fixTableTabularNums(noStyle);
+    expect(applied).toBe(true);
+    expect(checkDataNumbersNotTabular(html)).toEqual([]);
+  });
+
+  it("is idempotent and skips documents the check does not flag", () => {
+    const once = fixTableTabularNums(bad).html;
+    expect(fixTableTabularNums(once).applied).toBe(false);
+    expect(fixTableTabularNums("<table><tr><td>Alpha</td><td>Beta</td></tr></table>").applied).toBe(false);
+  });
+});
+
+describe("focus-outline-restore", () => {
+  it("deletes the outline-killing declaration so the browser ring returns", () => {
+    const bad = "<style>button:focus { outline: none; color: red; }</style>";
+    const { html, applied } = fixFocusOutlineRestore(bad);
+    expect(applied).toBe(true);
+    expect(html).toContain("color: red");
+    expect(html).not.toMatch(/outline\s*:\s*none/);
+    expect(checkFocusOutlineRemoved(html)).toEqual([]);
+  });
+
+  it("removes the Tailwind focus:outline-none class token, keeping siblings", () => {
+    const bad = '<button class="px-3 focus:outline-none font-bold">Go</button>';
+    const { html, applied } = fixFocusOutlineRestore(bad);
+    expect(applied).toBe(true);
+    expect(html).toContain("px-3");
+    expect(html).toContain("font-bold");
+    expect(html).not.toContain("focus:outline-none");
+    expect(checkFocusOutlineRemoved(html)).toEqual([]);
+  });
+
+  it("never touches a document whose removal has a legitimate replacement", () => {
+    const ok = "<style>button:focus { outline: none; box-shadow: 0 0 0 2px var(--ring); }</style>";
+    expect(fixFocusOutlineRestore(ok).applied).toBe(false);
+  });
+
+  it("is idempotent", () => {
+    const once = fixFocusOutlineRestore("<style>a:focus{outline:0}</style>").html;
+    expect(fixFocusOutlineRestore(once).applied).toBe(false);
+  });
+});
+
+describe("runAutofix — floor repairs are registered", () => {
+  it("one pass over a document violating all three floors clears all three checks", () => {
+    const bad = `<!doctype html><html lang="en"><head>${VIEWPORT}<title>t</title>` +
+      "<style>button:focus{outline:none}.btn:hover{background:#eee}</style></head><body>" +
+      "<table><tr><td>1,204</td></tr><tr><td>982</td></tr><tr><td>1,410</td></tr></table></body></html>";
+    const { html, findings } = runAutofix(bad);
+    const ids = findings.map((f) => f.ruleId);
+    expect(ids).toContain("hover-media-guard");
+    expect(ids).toContain("table-tabular-nums");
+    expect(ids).toContain("focus-outline-restore");
+    expect(checkStickyHoverUnguarded(html)).toEqual([]);
+    expect(checkDataNumbersNotTabular(html)).toEqual([]);
+    expect(checkFocusOutlineRemoved(html)).toEqual([]);
+  });
+});

--- a/tests/html-autofix-floor-repairs.test.ts
+++ b/tests/html-autofix-floor-repairs.test.ts
@@ -118,3 +118,98 @@ describe("runAutofix — floor repairs are registered", () => {
     expect(checkFocusOutlineRemoved(html)).toEqual([]);
   });
 });
+
+// ─── Adversarial shapes from the stage-4 review — every output must stay structural ───
+
+/** Brace balance with string literals blanked — a cheap "does the CSS still close" probe. */
+function cssBraceBalanced(html: string): boolean {
+  for (const m of html.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)) {
+    const css = (m[1] ?? "").replace(/(["'])(?:\\.|(?!\1)[^\\\n])*\1/g, (s) => " ".repeat(s.length));
+    let depth = 0;
+    for (const ch of css) {
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+      if (depth < 0) return false;
+    }
+    if (depth !== 0) return false;
+  }
+  return true;
+}
+
+describe("hover-media-guard — structural safety", () => {
+  it("never engulfs base declarations of a CSS-nested rule (selector with ';' is not a selector)", () => {
+    const html = `${VIEWPORT}<style>.card { padding: 2rem; background: var(--surface); &:hover { transform: translateY(-2px); } }</style>`;
+    const { html: out } = fixHoverMediaGuard(html);
+    expect(out).toContain("padding: 2rem; background: var(--surface);");
+    expect(out).not.toMatch(/@media \(hover: hover\) \{ padding/);
+    expect(cssBraceBalanced(out)).toBe(true);
+  });
+
+  it("a '}' inside a CSS string cannot produce an unclosed block", () => {
+    const html = `${VIEWPORT}<style>.code:hover { content: "} }"; color: red; } .other { color: blue; }</style>`;
+    const { html: out } = fixHoverMediaGuard(html);
+    expect(cssBraceBalanced(out)).toBe(true);
+    expect(out).toContain(".other { color: blue; }");
+    expect(checkStickyHoverUnguarded(out)).toEqual([]);
+  });
+
+  it("a selector list mixing :hover with a non-hover state is skipped (miss, never a wrap)", () => {
+    const html = `${VIEWPORT}<style>.c:hover, .c.is-active { transform: scale(1.05); }</style>`;
+    const { html: out } = fixHoverMediaGuard(html);
+    expect(out).toBe(html); // .is-active styling must not move behind hover capability
+  });
+});
+
+describe("table-tabular-nums — placement safety", () => {
+  const TABLE = "<table><tr><td>1,204</td></tr><tr><td>982</td></tr><tr><td>1,410</td></tr></table>";
+
+  it("never injects into a <style> living inside a script string (fresh head block instead)", () => {
+    const html = `<head><title>t</title></head><body><script>document.body.insertAdjacentHTML('beforeend', '<style>.x{color:red}</style>');</script>${TABLE}</body>`;
+    const { html: out, applied } = fixTableTabularNums(html);
+    expect(applied).toBe(true);
+    expect(out).not.toMatch(/insertAdjacentHTML\('beforeend', '<style>\n/);
+    expect(out).toMatch(/<head[^>]*>\s*<style>td, th \{ font-variant-numeric: tabular-nums; \}<\/style>/);
+  });
+
+  it("ignores commented-out/noscript style blocks — the injected rule must be live", () => {
+    const html = `<head><title>t</title></head><body><!-- <style>.dead{}</style> --><noscript><style>.ns{}</style></noscript>${TABLE}</body>`;
+    const { html: out } = fixTableTabularNums(html);
+    expect(out).toMatch(/<head[^>]*>\s*<style>td, th \{ font-variant-numeric: tabular-nums; \}<\/style>/);
+  });
+});
+
+describe("focus-outline-restore — markup-only class pass", () => {
+  it("never edits documentation copy in <pre>/<code>, and never touches data-class/:class", () => {
+    const html = '<button class="focus:outline-none">Go</button>' +
+      '<pre><code>&lt;button class="focus:outline-none"&gt;</code></pre>' +
+      '<div data-class="focus:outline-none ring-0"></div>' +
+      '<div :class="btn focus:outline-none"></div>';
+    const { html: out } = fixFocusOutlineRestore(html);
+    expect(out).toContain('<pre><code>&lt;button class="focus:outline-none"&gt;</code></pre>');
+    expect(out).toContain('data-class="focus:outline-none ring-0"');
+    expect(out).toContain(':class="btn focus:outline-none"');
+    expect(out).toContain('<button class="">Go</button>');
+  });
+
+  it("leaves attributes untouched when no token was removed (no diff noise)", () => {
+    const html = '<style>a:focus{outline:none}</style><div class="grid  grid-cols-2\n gap-4  p-6">x</div>';
+    const { html: out } = fixFocusOutlineRestore(html);
+    expect(out).toContain('class="grid  grid-cols-2\n gap-4  p-6"');
+  });
+
+  it("a real ring in any focus rule means the checker is silent — the repair must not act at all", () => {
+    // Shared-evidence semantics: outline: 0px solid transparent IS a ring, so the
+    // checker does not fire and the aligned repair leaves the whole document alone.
+    const html = "<style>a:focus { outline: none; } b:focus-visible { outline: 0px solid transparent; }</style>";
+    expect(fixFocusOutlineRestore(html).applied).toBe(false);
+  });
+
+  it("deletes only the whole-value kill and keeps sibling declarations and non-focus rules", () => {
+    const html = "<style>a:focus { outline: 0px; color: red; } .brand { outline: 0px solid gold; }</style>";
+    const { html: out, applied } = fixFocusOutlineRestore(html);
+    expect(applied).toBe(true);
+    expect(out).toContain("color: red");
+    expect(out).toContain("outline: 0px solid gold"); // non-focus rule untouched
+    expect(out).not.toMatch(/a:focus \{ outline: 0px;/);
+  });
+});


### PR DESCRIPTION
Channel 2 + 3 of wiring the adopted floors into generation (channel 1 — the lint gate on every candidate — was already live in `generate.md`):

## Channel 3 — `ui autofix` floor repairs (CSS/attribute only, copy never edited)

| Rule | Repairs | Gate |
|---|---|---|
| `hover-media-guard` | wraps unguarded `:hover` rules in `@media (hover: hover)` **in place** (cascade order kept; nested media valid) | `checkStickyHoverUnguarded` |
| `table-tabular-nums` | injects `td, th { font-variant-numeric: tabular-nums; }` | `checkDataNumbersNotTabular` |
| `focus-outline-restore` | deletes outline-killing focus declarations + `focus:outline-none` tokens → browser ring returns; `tabindex="-1"` targets untouched | `checkFocusOutlineRemoved` |

Each repair is **gated by the same check function its linter runs** and every positive test asserts the checker goes silent after the repair — checker and repair share one evidence source (`stripHoverGuardedBlocks` and `isProgrammaticFocusTarget` are exported and reused, not reimplemented). Deliberately NOT auto-fixed: punctuation (copy — owner decision), `paste-blocked` (behavior surgery), `equal-nested-radii` (which radius to change is design judgment).

## Channel 2 — born passing

`generation-craft-defaults.md` gains a "Machine floors — emit to pass" section: the generator learns the floors up front instead of paying a bounded refine round for what the linters catch anyway.

## Verification

- Red-first (module-missing failures), 12 paired tests incl. one `runAutofix` integration case clearing all three checks in one pass.
- Break-to-verify через built CLI: `ui autofix --write` on a violating fixture → 3 fixes applied, all 3 lints re-run clean.
- Idempotency pinned per rule. Gates: typecheck, lint, build, `ui knowledge check` 0 findings, **3564 passed / 10 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)