### PR TITLE
release: 0.4.0 — the tractability release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-19 - ease-design 0.4.0
+
+One day, ten merged PRs, one thesis proven: the tractability frontier is movable.
+Everything below ships in this release — 14 new machine floors across four linter
+families, four autofix floor repairs, the composed judge `ui gate` (+ its 89-check
+coverage registry), FloorFinding schema v1 with declared repair scopes, four
+tractability telemetry event types, and a measured −65% error-at-birth improvement
+from teaching the floors at generation time (evaluation-260819-2016).
+
+
 ## 2026-08-19 - font-display gets its repair (the floor teaching could not move)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
+| 2026-08-19 | **`ease-design@0.4.0`** — the tractability release: 14 floors, 4 floor repairs, `ui gate` + coverage registry, FloorFinding schema v1, telemetry events, and a measured −65% error-at-birth from born-passing knowledge | `v0.4.0` |
 | 2026-08-19 | **font-display gets its repair** — the one floor the born-passing A/B showed teaching cannot move (6→6 across arms) becomes an autofix: `@font-face` gains `font-display: swap`, Google-Fonts hrefs gain `display=swap`; 12→0 on the A/B corpus in one pass | `#200` |
 | 2026-08-19 | **Tractability telemetry events** — the ledger learns `route_decided`, `attempt_completed`, `outcome_recorded` (accept REQUIRES the final gate verdict with provenance refs) and `taste_veto` (file + mandatory reason; the stream the FP gauge and librarian recurrence will read) — the labeled-loop data the moat thesis lives on | `#199` |
 | 2026-08-19 | **FloorFinding schema v1 + `ui gate coverage`** — findings gain declared repair fields (`expected`/`actual`/`fixHint`/`repairScope`) and the gate grows a coverage registry (88 checks, per-project activity, paired against the sources AND against runtime emission) — the evidence base for tractability routing and strict patch validation | `#198` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ease-design",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Multi-runtime design-cli — describe what you want, get pro-taste UI.",
   "type": "module",
   "keywords": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,7 +64,7 @@ import { promptPlanCommand } from "./commands/prompt-plan.js";
 
 // Keep in sync with package.json "version". A test (tests/cli-version.test.ts)
 // asserts these match, so drift fails CI rather than shipping silently.
-const VERSION = "0.3.0";
+const VERSION = "0.4.0";
 
 // ─── Command registry ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Version bump for the day's ten merged PRs (#189→#200): 14 machine floors, 4 autofix floor repairs, `ui gate` + 89-check coverage registry, FloorFinding schema v1 (repairScope contract), 4 telemetry event types, and the born-passing A/B evidence (−65% errors at birth, plans/reports/evaluation-260819-2016).

package.json + src/cli.ts VERSION bumped in sync (cli-version test green). Tag `v0.4.0` follows the merge; the release workflow publishes via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)