### PR TITLE
feat(init): ui init --with-agents — opt-in roster at init time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-20 - `ui init --with-agents`: opt-in roster at init time
+
+### Added
+- `ui init --with-agents` runs `ui agents init` in the same invocation, once the adapter
+  tree is installed. Strictly opt-in per the ratified roster decision — nothing changes
+  without the flag. Requires the claude runtime (agents are Claude Code subagents) and an
+  existing project DS: without `design/ds.manifest.json` the whole init pre-flights to
+  `DS_NOT_FOUND` before any file is written, teaching the order (`ui ds init` / `/ui:learn`
+  first). Agent generation runs through the agents command's own seam, so EXISTS
+  pre-flight, rollback, and stamping stay one implementation; failures after the adapter
+  write are reported honestly (`EXISTS` → re-run with `--force`).
 ## 2026-08-20 - Routing-accuracy benchmark: the routing doctrine gets measured, and loses twice
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
+| 2026-08-20 | **`ui init --with-agents`** — opt-in roster generation in the same init run (claude runtime + existing project DS required; pre-flights to `DS_NOT_FOUND` before any write) | `#205` |
 | 2026-08-20 | **Routing doctrine, measured** — an 83-prompt blind benchmark (authored from frontmatter only, routed by context-clean agents) caught two doctrine bugs at must-ask 58%; after the fixes a 16-prompt reference-path re-run graded 16/16, putting the merged figures at verb 96% / must-ask 100% / composite 100% / 0 taste interrogations | `#206` |
 | 2026-08-20 | **Native-expert agents** — `knowledge/need-routing.md` turns a stated need into the right design:os application (19-verb decision gates, three sanctioned asks, the composition rule); two-way parity checks make an untaught new capability a red build, and a per-role allowlist keeps agent templates pointing instead of enumerating (born-red on the real designer drift) | `#203` |
 | 2026-08-19 | **`ease-design@0.4.0`** — the tractability release: 14 floors, 4 floor repairs, `ui gate` + coverage registry, FloorFinding schema v1, telemetry events, and a measured −65% error-at-birth from born-passing knowledge | `v0.4.0` |

--- a/knowledge/design-agents.md
+++ b/knowledge/design-agents.md
@@ -58,7 +58,9 @@ studio or project means `ui agents init --force`.
 
 ## §4 Roster is opt-in
 
-`ui init` never generates agents — it only prints a hint. A user runs
+`ui init` never generates agents on its own — it prints a hint, and only the
+explicit `ui init --with-agents` flag exercises the opt-in in the same run
+(claude runtime + existing project DS required). A user otherwise runs
 `ui agents init` (optionally `--roster designer,curator`) to get one or as many
 agents as they want; a project with zero agents is a fully supported state
 (`agents check` reports it as a warning, never an error).

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -3,7 +3,8 @@
  * (Claude Code subagents under `.claude/agents/`). Pure kernel:
  * src/core/agents-gen.ts; knowledge: knowledge/design-agents.md.
  *
- * Opt-in by design — `ui init` never generates agents, it only hints. The
+ * Opt-in by design — `ui init` only hints, unless the user passes the
+ * explicit `--with-agents` flag (the opt-in, exercised at init time). The
  * emitter/linter pair: `init` renders templates/agents/<role>.md with the
  * genealogy name (studio soul `name:` × manifest name × role) and a stamp;
  * `check` re-renders the live templates and flags any file whose content no

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,6 +13,10 @@
  *   2. Writes the runtime's adapter tree (slash-commands + skills, or AGENTS.md block).
  *   On any write failure every file written during this invocation is removed or
  *   restored so the project is left in a clean state (all-or-nothing across runtimes).
+ *   Exception: with --with-agents, a residual agent-generation failure AFTER the
+ *   adapter write leaves the adapter tree in place and says so — everything
+ *   knowable up front (missing/malformed DS, agent-name collisions) is
+ *   pre-flighted before the first write instead.
  */
 import {
   writeFileSync,
@@ -40,6 +44,10 @@ import { generateAdapter } from "../adapters/index.js";
 import type { GenerateAdapterInput } from "../adapters/index.js";
 import { renderBanner } from "../core/report-style.js";
 import { agentsCommand } from "./agents.js";
+import { loadManifest, DSManifestError } from "../core/ds-manifest.js";
+import { ROSTER, agentName } from "../core/agents-gen.js";
+import { easeHome } from "../core/memory-store.js";
+import { STUDIO_SOUL_FILENAME, soulName } from "../core/ds-soul-studio.js";
 import {
   writeAdapterArtifacts,
   AdapterWriteError,
@@ -71,7 +79,9 @@ Options:
   --cwd <path>   Target directory (default: current working directory)
   --force        Overwrite existing manifest and adapter files
   --with-agents  Also run 'ui agents init' (opt-in roster; needs the claude
-                 runtime and an existing project DS — ds init/learn first)
+                 runtime and an existing project DS — ds init/learn first).
+                 Generates all three roles; for a subset run 'ui agents init
+                 --roster' separately
   --json         Emit a JSON envelope instead of writing to stderr
   -h, --help     Show this help
 
@@ -94,6 +104,9 @@ Notes:
   - With --all: all-or-nothing — if any target exists without --force, the
     command errors listing every conflict before writing any file.
   - On any write failure all files written this invocation are removed or restored.
+  - --with-agents pre-flights everything knowable (missing/malformed DS, existing
+    agent files) BEFORE writing; a residual agent failure after the adapter write
+    leaves the adapter tree in place and the error says so.
 
 Error codes:
   BAD_ARG         Missing --runtime, unknown runtime, --runtime + --all together,
@@ -101,7 +114,8 @@ Error codes:
   UNKNOWN_FLAG    Unrecognised --flag (rejected, with a did-you-mean hint)
   MANIFEST_EXISTS Target file already exists (use --force to overwrite)
   DS_NOT_FOUND    --with-agents needs design/ds.manifest.json — run 'ui ds init' first
-  EXISTS          --with-agents found existing agent files (use --force)
+  BAD_MANIFEST    --with-agents found design/ds.manifest.json but it is unusable
+  EXISTS          --with-agents found existing agent files (pre-flight; use --force)
   WRITE_ERROR     File could not be written
 `;
 
@@ -176,18 +190,45 @@ export const initCommand = {
     const cwdFlag = parsed.flags["cwd"];
     const targetCwd = typeof cwdFlag === "string" ? resolve(cwdFlag) : processCwd();
 
-    // ── --with-agents pre-flight (before ANY write — a failed combination
-    //    must never leave a half-installed adapter tree) ─────────────────────
+    // ── --with-agents pre-flight (before ANY write — every failure that is
+    //    knowable up front must fire here, so a failed combination never
+    //    leaves a half-installed adapter tree) ────────────────────────────────
     if (withAgents) {
       // Agents are Claude Code subagents only (agents.ts runtime scope).
       if (!runtimes.includes("claude")) {
         const msg = "--with-agents requires the claude runtime (agents are Claude Code subagents) — use --runtime claude or --all";
         return useJson ? errJson(CMD, "BAD_ARG", msg) : errText(`ui: ${msg}\n`);
       }
-      // Agents bind to a project design system; teach the order instead of failing late.
-      if (!existsSync(join(targetCwd, "design", "ds.manifest.json"))) {
-        const msg = "--with-agents needs a project design system: run 'ui ds init <name>' (or /ui:learn) first, then re-run — or drop the flag and run 'ui agents init' later";
-        return useJson ? errJson(CMD, "DS_NOT_FOUND", msg) : errText(`ui: ${msg}\n`);
+      // Agents bind to a project design system. Load (not just stat) the
+      // manifest: a malformed manifest is exactly as fatal as a missing one,
+      // and both are detectable before the first write.
+      let dsName: string;
+      try {
+        dsName = loadManifest(join(targetCwd, "design", "ds.manifest.json")).name;
+      } catch (e) {
+        if (e instanceof DSManifestError && e.code === "MANIFEST_NOT_FOUND") {
+          const msg = "--with-agents needs a project design system: run 'ui ds init <name>' (or /ui:learn) here first — or run init from the directory that holds design/, if your DS lives in a parent — or drop the flag and run 'ui agents init' later";
+          return useJson ? errJson(CMD, "DS_NOT_FOUND", msg) : errText(`ui: ${msg}\n`);
+        }
+        const msg = `--with-agents: design/ds.manifest.json is unusable — ${e instanceof Error ? e.message : String(e)} — fix the manifest, then re-run`;
+        return useJson ? errJson(CMD, "BAD_MANIFEST", msg) : errText(`ui: ${msg}\n`);
+      }
+      // EXISTS pre-flight through the same naming seam agents init uses
+      // (agentName × ROSTER × studio soul), so a collision surfaces before
+      // the adapter tree lands, not after.
+      if (!force) {
+        let studio: string | null = null;
+        try {
+          const p = join(easeHome(), STUDIO_SOUL_FILENAME);
+          studio = existsSync(p) ? soulName(readFileSync(p, "utf8")) : null;
+        } catch { studio = null; }
+        const existing = ROSTER
+          .map((r) => join(targetCwd, ".claude", "agents", `${agentName(r, dsName, studio)}.md`))
+          .filter((p) => existsSync(p));
+        if (existing.length > 0) {
+          const msg = `--with-agents: agent file(s) already exist — re-run with --force to overwrite: ${existing.map((p) => `'${p}'`).join(", ")}`;
+          return useJson ? errJson(CMD, "EXISTS", msg) : errText(`ui: ${msg}\n`);
+        }
       }
     }
 
@@ -428,21 +469,28 @@ export const initCommand = {
     // ── --with-agents: generate the roster now that adapters are installed ─
     // Runs through the agents command's own seam (json mode) so EXISTS
     // pre-flight, rollback, and stamping stay one implementation.
-    let agentsWritten: { role: string; name: string; path: string }[] | null = null;
+    let agentsWritten: { role: string; name: string; path: string; written: boolean }[] | null = null;
     if (withAgents) {
       const agentsFlags: Record<string, string | boolean> = { dir: targetCwd };
       if (force) agentsFlags["force"] = true;
-      const res = agentsCommand.run({
-        command: "agents", subcommand: "init", positionals: [],
-        flags: agentsFlags, help: false, version: false, json: true,
-        repeatedFlags: new Set<string>(),
-      });
-      let env: { ok: boolean; data?: { agents?: { role: string; name: string; path: string }[] }; error?: { code: string; message: string } };
-      try { env = JSON.parse(res.stdout ?? "{}") as typeof env; }
-      catch { env = { ok: false, error: { code: "WRITE_ERROR", message: (res.stderr ?? res.stdout ?? "agent generation failed").trim() } }; }
+      let env: { ok: boolean; data?: { agents?: { role: string; name: string; path: string; written: boolean }[] }; error?: { code: string; message: string } };
+      try {
+        const res = agentsCommand.run({
+          command: "agents", subcommand: "init", positionals: [],
+          flags: agentsFlags, help: false, version: false, json: true,
+          repeatedFlags: new Set<string>(),
+        });
+        env = JSON.parse(res.stdout ?? "{}") as typeof env;
+      } catch (e) {
+        // A throw from the subcall must not escape to the internal-error path
+        // — the adapter tree is already on disk and the user deserves to hear it.
+        env = { ok: false, error: { code: "WRITE_ERROR", message: e instanceof Error ? e.message : String(e) } };
+      }
       if (!env.ok) {
+        // Missing/malformed DS and name collisions were pre-flighted above, so
+        // only genuinely-late failures (disk write, template read, races)
+        // reach this fold. EXISTS is kept for the race case.
         const inner = env.error?.code ?? "WRITE_ERROR";
-        // Only codes init declares may surface; anything else folds to WRITE_ERROR.
         const code = inner === "EXISTS" || inner === "DS_NOT_FOUND" ? inner : "WRITE_ERROR";
         const msg =
           `adapter tree written, but agent generation failed: ${env.error?.message ?? "unknown error"}` +

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -39,6 +39,7 @@ import type { Runtime } from "../core/init-stub.js";
 import { generateAdapter } from "../adapters/index.js";
 import type { GenerateAdapterInput } from "../adapters/index.js";
 import { renderBanner } from "../core/report-style.js";
+import { agentsCommand } from "./agents.js";
 import {
   writeAdapterArtifacts,
   AdapterWriteError,
@@ -61,14 +62,16 @@ const CMD = "init";
 export const INIT_HELP = `ui init — write the ease-design manifest and per-runtime adapter tree
 
 Usage:
-  ui init --runtime <claude|antigravity|codex> [--cwd <path>] [--force] [--json]
-  ui init --all [--cwd <path>] [--force] [--json]
+  ui init --runtime <claude|antigravity|codex> [--cwd <path>] [--force] [--with-agents] [--json]
+  ui init --all [--cwd <path>] [--force] [--with-agents] [--json]
 
 Options:
   --runtime <r>  Target runtime: claude | antigravity | codex
   --all          Write manifests and adapter trees for all three runtimes
   --cwd <path>   Target directory (default: current working directory)
   --force        Overwrite existing manifest and adapter files
+  --with-agents  Also run 'ui agents init' (opt-in roster; needs the claude
+                 runtime and an existing project DS — ds init/learn first)
   --json         Emit a JSON envelope instead of writing to stderr
   -h, --help     Show this help
 
@@ -93,9 +96,12 @@ Notes:
   - On any write failure all files written this invocation are removed or restored.
 
 Error codes:
-  BAD_ARG         Missing --runtime, unknown runtime, or --runtime + --all together
+  BAD_ARG         Missing --runtime, unknown runtime, --runtime + --all together,
+                  or --with-agents without the claude runtime
   UNKNOWN_FLAG    Unrecognised --flag (rejected, with a did-you-mean hint)
   MANIFEST_EXISTS Target file already exists (use --force to overwrite)
+  DS_NOT_FOUND    --with-agents needs design/ds.manifest.json — run 'ui ds init' first
+  EXISTS          --with-agents found existing agent files (use --force)
   WRITE_ERROR     File could not be written
 `;
 
@@ -132,7 +138,7 @@ export const initCommand = {
     const useJson = parsed.json;
 
     // ── Reject unknown flags (loud misconfig beats a silent no-op) ─────────
-    const unknown = findUnknownFlag(parsed.flags, ["runtime", "all", "cwd", "force"]);
+    const unknown = findUnknownFlag(parsed.flags, ["runtime", "all", "cwd", "force", "with-agents"]);
     if (unknown !== null) {
       const msg = unknownFlagMessage(unknown);
       return useJson ? errJson(CMD, "UNKNOWN_FLAG", msg) : errText(`ui: ${msg}\n`);
@@ -140,6 +146,7 @@ export const initCommand = {
 
     const force = parsed.flags["force"] === true;
     const useAll = parsed.flags["all"] === true;
+    const withAgents = parsed.flags["with-agents"] === true;
     const runtimeFlag = parsed.flags["runtime"];
 
     // ── Validate flag combination ──────────────────────────────────────────
@@ -168,6 +175,21 @@ export const initCommand = {
     // ── Resolve target directory ───────────────────────────────────────────
     const cwdFlag = parsed.flags["cwd"];
     const targetCwd = typeof cwdFlag === "string" ? resolve(cwdFlag) : processCwd();
+
+    // ── --with-agents pre-flight (before ANY write — a failed combination
+    //    must never leave a half-installed adapter tree) ─────────────────────
+    if (withAgents) {
+      // Agents are Claude Code subagents only (agents.ts runtime scope).
+      if (!runtimes.includes("claude")) {
+        const msg = "--with-agents requires the claude runtime (agents are Claude Code subagents) — use --runtime claude or --all";
+        return useJson ? errJson(CMD, "BAD_ARG", msg) : errText(`ui: ${msg}\n`);
+      }
+      // Agents bind to a project design system; teach the order instead of failing late.
+      if (!existsSync(join(targetCwd, "design", "ds.manifest.json"))) {
+        const msg = "--with-agents needs a project design system: run 'ui ds init <name>' (or /ui:learn) first, then re-run — or drop the flag and run 'ui agents init' later";
+        return useJson ? errJson(CMD, "DS_NOT_FOUND", msg) : errText(`ui: ${msg}\n`);
+      }
+    }
 
     // ── Resolve package roots (templates/ + knowledge/) ────────────────────
     // Shared with `ui doctor` via resolvePackageRoots (init-stub.ts). Walks up
@@ -403,6 +425,33 @@ export const initCommand = {
       });
     }
 
+    // ── --with-agents: generate the roster now that adapters are installed ─
+    // Runs through the agents command's own seam (json mode) so EXISTS
+    // pre-flight, rollback, and stamping stay one implementation.
+    let agentsWritten: { role: string; name: string; path: string }[] | null = null;
+    if (withAgents) {
+      const agentsFlags: Record<string, string | boolean> = { dir: targetCwd };
+      if (force) agentsFlags["force"] = true;
+      const res = agentsCommand.run({
+        command: "agents", subcommand: "init", positionals: [],
+        flags: agentsFlags, help: false, version: false, json: true,
+        repeatedFlags: new Set<string>(),
+      });
+      let env: { ok: boolean; data?: { agents?: { role: string; name: string; path: string }[] }; error?: { code: string; message: string } };
+      try { env = JSON.parse(res.stdout ?? "{}") as typeof env; }
+      catch { env = { ok: false, error: { code: "WRITE_ERROR", message: (res.stderr ?? res.stdout ?? "agent generation failed").trim() } }; }
+      if (!env.ok) {
+        const inner = env.error?.code ?? "WRITE_ERROR";
+        // Only codes init declares may surface; anything else folds to WRITE_ERROR.
+        const code = inner === "EXISTS" || inner === "DS_NOT_FOUND" ? inner : "WRITE_ERROR";
+        const msg =
+          `adapter tree written, but agent generation failed: ${env.error?.message ?? "unknown error"}` +
+          (inner === "EXISTS" ? " — re-run with --force, or run 'ui agents init --force'" : "");
+        return useJson ? errJson(CMD, code, msg) : errText(`ui: ${msg}\n`);
+      }
+      agentsWritten = env.data?.agents ?? [];
+    }
+
     // ── Next-step hint (best-effort scan of the target project) ────────────
     const hint = computeNextStepHint(targetCwd);
 
@@ -410,6 +459,7 @@ export const initCommand = {
     if (useJson) {
       const data: Record<string, unknown> = { manifests, adapters: adapterResults };
       if (hint !== null) data.nextStep = hint.nextStep;
+      if (agentsWritten !== null) data.agents = agentsWritten;
       return okJson(CMD, data);
     }
 
@@ -436,9 +486,12 @@ export const initCommand = {
       "next: run `ui onboard` — your setup checklist and what to do next\n" +
       "      run `ui guide`   — see what DESIGN:OS can do";
     let body = hint !== null ? `${lines}\n${hint.hintLine}\n${nextBlock}` : `${lines}\n${nextBlock}`;
-    // Agents are opt-in (never auto-generated) — Claude Code installs get one hint line.
+    // Agents are opt-in (never auto-generated) — Claude Code installs get one
+    // hint line, unless --with-agents just exercised the opt-in in this run.
     if (runtimes.includes("claude")) {
-      body += "\noptional: `ui agents init` gives this project soul-bound task agents";
+      body += agentsWritten !== null
+        ? "\n" + agentsWritten.map((a) => `agent written: ${a.path} (${a.role})`).join("\n")
+        : "\noptional: `ui agents init` gives this project soul-bound task agents";
     }
     body = `${renderBanner(templatesRoot)}\n${body}`;
     return { exitCode: 0, stderr: body + "\n" };

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -562,7 +562,7 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
         { name: "force", type: "boolean", summary: "Overwrite existing manifest and adapter files" },
         { name: "with-agents", type: "boolean", summary: "Also run 'ui agents init' (claude runtime + existing project DS required)" },
       ],
-      errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "MANIFEST_EXISTS", "DS_NOT_FOUND", "EXISTS", "WRITE_ERROR"],
+      errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "MANIFEST_EXISTS", "DS_NOT_FOUND", "BAD_MANIFEST", "EXISTS", "WRITE_ERROR"],
     },
   },
 

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -560,8 +560,9 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
         { name: "all", type: "boolean", summary: "Write all three runtimes (mutually exclusive with --runtime)" },
         { name: "cwd", type: "string", summary: "Target directory (default: current working directory)" },
         { name: "force", type: "boolean", summary: "Overwrite existing manifest and adapter files" },
+        { name: "with-agents", type: "boolean", summary: "Also run 'ui agents init' (claude runtime + existing project DS required)" },
       ],
-      errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "MANIFEST_EXISTS", "WRITE_ERROR"],
+      errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "MANIFEST_EXISTS", "DS_NOT_FOUND", "EXISTS", "WRITE_ERROR"],
     },
   },
 

--- a/tests/cmd-init.test.ts
+++ b/tests/cmd-init.test.ts
@@ -478,3 +478,63 @@ describe("ui init --with-agents (opt-in roster at init time)", () => {
     expect(files).toContain("design-os agents · roster-role: designer");
   });
 });
+
+describe("ui init --with-agents pre-flight completeness (stage-4 B1/H2)", () => {
+  const personaData = new URL("../knowledge/personas/personas.json", import.meta.url).pathname;
+  const scaffoldDs = (cwd: string): void => {
+    expect(captureRun(["ds", "init", "proj-y", "--persona", "liquid-glass", "--intent", "preflight test", "--dir", cwd, "--persona-data", personaData]).code).toBe(0);
+  };
+
+  it("malformed design/ds.manifest.json → BAD_MANIFEST before any write", () => {
+    const cwd = makeTmpDir();
+    mkdirSync(join(cwd, "design"), { recursive: true });
+    writeFileSync(join(cwd, "design", "ds.manifest.json"), "{ this is not json");
+    const { code, out } = captureRun(["init", "--runtime", "claude", "--cwd", cwd, "--with-agents", "--json"]);
+    expect(code).toBe(1);
+    expect((JSON.parse(out) as { error: { code: string } }).error.code).toBe("BAD_MANIFEST");
+    expect(existsSync(join(cwd, ".claude"))).toBe(false);
+  });
+
+  it("existing agent files without --force → EXISTS before the adapter tree is written", () => {
+    const cwd = makeTmpDir();
+    scaffoldDs(cwd);
+    expect(captureRun(["agents", "init", "--dir", cwd]).code).toBe(0);
+    const { code, out } = captureRun(["init", "--runtime", "claude", "--cwd", cwd, "--with-agents", "--json"]);
+    expect(code).toBe(1);
+    expect((JSON.parse(out) as { error: { code: string } }).error.code).toBe("EXISTS");
+    // Pre-flight, not post-write: the manifest must NOT have landed.
+    expect(existsSync(join(cwd, ".claude", "ease-design.json"))).toBe(false);
+  });
+
+  it("--all --with-agents with a DS → three manifests AND stamped agents, exit 0", () => {
+    const cwd = makeTmpDir();
+    scaffoldDs(cwd);
+    const { code } = captureRun(["init", "--all", "--cwd", cwd, "--with-agents"]);
+    expect(code).toBe(0);
+    expect(existsSync(join(cwd, ".claude", "ease-design.json"))).toBe(true);
+    expect(existsSync(join(cwd, ".agent", "ease-design.json"))).toBe(true);
+    expect(existsSync(join(cwd, "AGENTS.ease-design.json"))).toBe(true);
+    expect(readdirSync(join(cwd, ".claude", "agents")).length).toBe(3);
+  });
+
+  it("--with-agents --force on a populated project → exit 0 (force reaches the agents subcall)", () => {
+    const cwd = makeTmpDir();
+    scaffoldDs(cwd);
+    expect(captureRun(["init", "--runtime", "claude", "--cwd", cwd, "--with-agents"]).code).toBe(0);
+    expect(captureRun(["init", "--runtime", "claude", "--cwd", cwd, "--with-agents", "--force"]).code).toBe(0);
+  });
+
+  it("JSON mode carries data.agents with role/name/path/written", () => {
+    const cwd = makeTmpDir();
+    scaffoldDs(cwd);
+    const { code, out } = captureRun(["init", "--runtime", "claude", "--cwd", cwd, "--with-agents", "--json"]);
+    expect(code).toBe(0);
+    const agents = (JSON.parse(out) as { data: { agents: { role: string; name: string; path: string; written: boolean }[] } }).data.agents;
+    expect(agents).toHaveLength(3);
+    for (const a of agents) {
+      expect(a.role.length).toBeGreaterThan(0);
+      expect(a.path.endsWith(`${a.name}.md`)).toBe(true);
+      expect(a.written).toBe(true);
+    }
+  });
+});

--- a/tests/cmd-init.test.ts
+++ b/tests/cmd-init.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, afterEach } from "vitest";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { mkdirSync, existsSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { mkdirSync, existsSync, rmSync, readFileSync, readdirSync, writeFileSync, statSync } from "node:fs";
 import { run } from "../src/cli.js";
 
 function captureRun(args: string[]): { code: number; out: string; err: string } {
@@ -445,5 +445,36 @@ describe("ui init writes the model-adapter wrapper (spec 013 P1)", () => {
     expect(claudeManifest.modelAdapter?.mode).toBe("stdin");
     expect(agManifest.modelAdapter?.mode).toBe("arg");
     expect(codexManifest.modelAdapter?.mode).toBe("stdin");
+  });
+});
+
+describe("ui init --with-agents (opt-in roster at init time)", () => {
+  it("without a project DS → DS_NOT_FOUND before any file is written", () => {
+    const cwd = makeTmpDir();
+    const { code, out } = captureRun(["init", "--runtime", "claude", "--cwd", cwd, "--with-agents", "--json"]);
+    expect(code).toBe(1);
+    expect((JSON.parse(out) as { error: { code: string } }).error.code).toBe("DS_NOT_FOUND");
+    // Pre-flight: the failed combination must not leave a half-installed adapter tree.
+    expect(existsSync(join(cwd, ".claude"))).toBe(false);
+  });
+
+  it("with a non-claude runtime → BAD_ARG (agents are Claude Code subagents)", () => {
+    const cwd = makeTmpDir();
+    const { code, out } = captureRun(["init", "--runtime", "codex", "--cwd", cwd, "--with-agents", "--json"]);
+    expect(code).toBe(1);
+    expect((JSON.parse(out) as { error: { code: string } }).error.code).toBe("BAD_ARG");
+  });
+
+  it("with a project DS → adapters AND stamped agent files in one run", () => {
+    const cwd = makeTmpDir();
+    const personaData = new URL("../knowledge/personas/personas.json", import.meta.url).pathname;
+    expect(captureRun(["ds", "init", "proj-x", "--persona", "liquid-glass", "--intent", "with-agents test", "--dir", cwd, "--persona-data", personaData]).code).toBe(0);
+    const { code } = captureRun(["init", "--runtime", "claude", "--cwd", cwd, "--with-agents"]);
+    expect(code).toBe(0);
+    expect(existsSync(join(cwd, ".claude", "ease-design.json"))).toBe(true);
+    const agentsDir = join(cwd, ".claude", "agents");
+    expect(existsSync(agentsDir)).toBe(true);
+    const files = readFileSync(join(agentsDir, readdirSync(agentsDir).find((f) => f.startsWith("designer-")) ?? ""), "utf8");
+    expect(files).toContain("design-os agents · roster-role: designer");
   });
 });


### PR DESCRIPTION
Owner go: "Cook hết" (2026-08-20) — the `--with-agents` offer from the native-expert brainstorm (roster stays opt-in per ratified §4; this flag is the per-invocation opt-in).

## What
- `ui init --with-agents` runs `ui agents init` after the adapter tree lands, in one invocation.
- Pre-flight BEFORE any write: non-claude runtime → `BAD_ARG`; no `design/ds.manifest.json` → `DS_NOT_FOUND` with the order taught (`ui ds init` / `/ui:learn` first).
- Generation goes through `agentsCommand.run` (json seam) — EXISTS pre-flight, rollback, stamping stay one implementation. Inner failure after adapters are written is reported honestly (adapter tree written + remediation; `EXISTS` → `--force`).
- Help text + `COMMAND_SIGNATURES` updated in the same commit (schema-consistency invariant covers them).

## Verification
- 3 tests born red on the unknown flag, green after: DS-less pre-flight leaves no `.claude/`; codex+flag → BAD_ARG; DS present → adapters AND stamped agent files in one run.
- Full gates: typecheck / lint / build clean, suite **3639 passed / 204 files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)