### PR TITLE
feat(eval): routing-accuracy benchmark — 83 blind prompts, 2 doctrine bugs caught and fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2026-08-20 - Routing-accuracy benchmark: the routing doctrine gets measured, and loses twice
+
+### Added
+- `eval/routing-prompts.json` — 83 English need-prompts (3 per verb × 19, 12 must-ask,
+  6 selection-route, 8 composites) authored by a context-clean agent that saw ONLY the
+  workflow frontmatter — never the routing tree — so expected routes cannot be
+  tautological with the tree's wording. Rerun contract: `docs/routing-benchmark.md`
+  (manual, never CI; blind batched routers + deterministic grading).
+- First run (blind sonnet routers): verb top-1 **96%** (target ≥85), composites **8/8**,
+  **0** taste interrogations — but must-ask **58%**, exposing two real doctrine bugs.
+
+### Fixed
+- The composite-split law swallowed ask #3 (4/4 ambiguous-reference prompts routed
+  capture→generate without asking) — the split law now fires the replicate-vs-inspired
+  question BEFORE the capture leg. Same defect class as the stage-4 R1 finding: an
+  exception written outside the gate that swallows it never runs.
+- "Audit the checkout experience" read as a Figma `audit` — G2's ask-1 clause now owns
+  any audit aimed at a product area that pins none of the four surfaces.
+- Targeted re-measure of the five missed prompts after both fixes: 5/5 flipped —
+  projected must-ask 100%.
+
 ## 2026-08-20 - Native-expert agents: need-routing knowledge + the untaught-feature gate
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,18 @@
   capture→generate without asking) — the split law now fires the replicate-vs-inspired
   question BEFORE the capture leg. Same defect class as the stage-4 R1 finding: an
   exception written outside the gate that swallows it never runs.
-- "Audit the checkout experience" read as a Figma `audit` — G2's ask-1 clause now owns
-  any audit aimed at a product area that pins none of the four surfaces.
-- Targeted re-measure of the five missed prompts after both fixes: 5/5 flipped —
-  projected must-ask 100%.
+- An audit aimed at a product area that pins none of the four surfaces read as a Figma
+  `audit` — G2's ask-1 clause now owns that shape.
+- Doctrine examples had quoted two benchmark prompts verbatim (self-fulfilling cells) —
+  paraphrased off-corpus, and the rerun contract now mandates grepping any new doctrine
+  example against the corpus.
+- Post-fix re-measure of the FULL reference path (16 prompts: all 8 composites, all 4
+  ask-3, the audit ask, the 3 from-url) on the decontaminated doctrine, graded by the
+  committed `eval/routing-grader.mjs`: 16/16 — no composite regression. Merged post-fix
+  figures over all 83: verb 96%, **must-ask 100%**, composite 100%, 0 taste
+  interrogations; the only remaining misses are the 3 design/generate/to-figma
+  adjudication items. Caveats: one router tier, one sample per prompt; the 67
+  non-reference-path prompts carry run-1 decisions.
 
 ## 2026-08-20 - Native-expert agents: need-routing knowledge + the untaught-feature gate
 

--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
+| 2026-08-20 | **Routing doctrine, measured** — an 83-prompt blind benchmark (authored from frontmatter only, routed by context-clean agents): verb top-1 96%, 0 taste interrogations; the must-ask 58% exposed two doctrine bugs, fixed and re-measured to 5/5 the same run | `#206` |
 | 2026-08-20 | **Native-expert agents** — `knowledge/need-routing.md` turns a stated need into the right design:os application (19-verb decision gates, three sanctioned asks, the composition rule); two-way parity checks make an untaught new capability a red build, and a per-role allowlist keeps agent templates pointing instead of enumerating (born-red on the real designer drift) | `#203` |
 | 2026-08-19 | **`ease-design@0.4.0`** — the tractability release: 14 floors, 4 floor repairs, `ui gate` + coverage registry, FloorFinding schema v1, telemetry events, and a measured −65% error-at-birth from born-passing knowledge | `v0.4.0` |
 | 2026-08-19 | **font-display gets its repair** — the one floor the born-passing A/B showed teaching cannot move (6→6 across arms) becomes an autofix: `@font-face` gains `font-display: swap`, Google-Fonts hrefs gain `display=swap`; 12→0 on the A/B corpus in one pass | `#200` |

--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
-| 2026-08-20 | **Routing doctrine, measured** — an 83-prompt blind benchmark (authored from frontmatter only, routed by context-clean agents): verb top-1 96%, 0 taste interrogations; the must-ask 58% exposed two doctrine bugs, fixed and re-measured to 5/5 the same run | `#206` |
+| 2026-08-20 | **Routing doctrine, measured** — an 83-prompt blind benchmark (authored from frontmatter only, routed by context-clean agents) caught two doctrine bugs at must-ask 58%; after the fixes a 16-prompt reference-path re-run graded 16/16, putting the merged figures at verb 96% / must-ask 100% / composite 100% / 0 taste interrogations | `#206` |
 | 2026-08-20 | **Native-expert agents** — `knowledge/need-routing.md` turns a stated need into the right design:os application (19-verb decision gates, three sanctioned asks, the composition rule); two-way parity checks make an untaught new capability a red build, and a per-role allowlist keeps agent templates pointing instead of enumerating (born-red on the real designer drift) | `#203` |
 | 2026-08-19 | **`ease-design@0.4.0`** — the tractability release: 14 floors, 4 floor repairs, `ui gate` + coverage registry, FloorFinding schema v1, telemetry events, and a measured −65% error-at-birth from born-passing knowledge | `v0.4.0` |
 | 2026-08-19 | **font-display gets its repair** — the one floor the born-passing A/B showed teaching cannot move (6→6 across arms) becomes an autofix: `@font-face` gains `font-display: swap`, Google-Fonts hrefs gain `display=swap`; 12→0 on the A/B corpus in one pass | `#200` |

--- a/docs/routing-benchmark.md
+++ b/docs/routing-benchmark.md
@@ -1,0 +1,48 @@
+# Routing-accuracy benchmark (manual — never CI)
+
+Measures whether `knowledge/need-routing.md` actually steers a blind model from a stated
+user need to the right design:os application. Companion asset: `eval/routing-prompts.json`
+(the committed ground-truth prompt set). Results are stateful records, not evergreen
+authority — each run lands as a dated report under the maintainer's `plans/reports/`.
+
+## What is measured
+
+83 one-sentence English needs, four categories:
+
+| Category | n | Pass condition | Target |
+|---|---|---|---|
+| verb | 57 (3 × 19 verbs) | top-1 route verb matches, no question asked | ≥ 85% |
+| must-ask | 12 (4 × 3 asks) | the router asks exactly the sanctioned ask (#1 bare audit, #2 keep-or-throw, #3 ambiguous reference) | 100% |
+| selection-route | 6 | NO question on taste vagueness; routes to the deliverable's verb (variants offered tracked) | 0 taste interrogations |
+| composite | 8 | full capture-then-produce sequence matches, in order | tracked |
+
+## Authorship separation (why the numbers mean something)
+
+- The prompt set is authored by a context-clean agent that sees ONLY the 19 workflow
+  frontmatter descriptions plus the three sanctioned-ask definitions — never the routing
+  tree itself. Expected routes therefore cannot be tautological with the tree's wording.
+- Routers are separate context-clean agents that read ONLY `knowledge/need-routing.md`
+  and never see the expected answers.
+- Grading is deterministic string comparison in the harness script — no model grades
+  itself. Author-vs-router disagreements on an expected route are surfaced in the run
+  report for owner adjudication, never silently rescored.
+
+## How to rerun
+
+1. Prompts: reuse `eval/routing-prompts.json` (stable baseline — comparable across runs),
+   or re-author a fresh set with the author contract above when the verb registry changes
+   (the `routing-verb-uncovered` gate tells you when it has).
+2. For each prompt, a context-clean agent (workhorse tier, e.g. Sonnet) receives the
+   verbatim text of `knowledge/need-routing.md` and the need sentence, and returns
+   `{route: verb[], ask: none|ask-1|ask-2|ask-3, variants: boolean}`. Batching ~10
+   prompts per agent is acceptable; instruct the agent to treat each need independently.
+3. Grade per the table above; report per-category percentages, every miss with the
+   router's actual output, and any prompts rejected at validation (unknown verbs,
+   missing expectedAsk).
+4. Write the dated report to `plans/reports/eval-<date>-routing-accuracy.md` and record
+   the headline numbers there — never in this file.
+
+Cost note: one full run ≈ 10 small agents (1 author + 9 routers). Run on demand after
+routing-doctrine edits or new verbs — the parity gate in `ui knowledge check` guarantees
+the table covers every verb, but only this benchmark measures whether the doctrine
+ROUTES correctly.

--- a/docs/routing-benchmark.md
+++ b/docs/routing-benchmark.md
@@ -12,9 +12,16 @@ authority — each run lands as a dated report under the maintainer's `plans/rep
 | Category | n | Pass condition | Target |
 |---|---|---|---|
 | verb | 57 (3 × 19 verbs) | top-1 route verb matches, no question asked | ≥ 85% |
-| must-ask | 12 (4 × 3 asks) | the router asks exactly the sanctioned ask (#1 bare audit, #2 keep-or-throw, #3 ambiguous reference) | 100% |
-| selection-route | 6 | NO question on taste vagueness; routes to the deliverable's verb (variants offered tracked) | 0 taste interrogations |
-| composite | 8 | full capture-then-produce sequence matches, in order | tracked |
+| must-ask | 12 (4 × 3 asks) | the router asks exactly the sanctioned ask (#1 bare audit, #2 keep-or-throw, #3 ambiguous reference); the route is IGNORED — asking correctly while sketching a tentative route still passes | 100% |
+| selection-route | 6 | NO question on taste vagueness; top-1 route verb matches. `variants` is tracked informationally — no target set yet | 0 taste interrogations |
+| composite | 8 | ask "none" AND the route equals the expected capture-then-produce sequence exactly (same verbs, same order, same length) | tracked |
+
+The executable authority for these rules is the committed grader —
+`node eval/routing-grader.mjs eval/routing-prompts.json <decisions.json>` — where
+`decisions.json` is `[{id, route, ask, variants?}]` from any blind-router harness.
+Partial runs are supported and reported as `covered: k/n` per category; a subset
+is never presented as the whole. The grader was verified to reproduce run 1's
+published numbers exactly from run 1's raw decisions.
 
 ## Authorship separation (why the numbers mean something)
 
@@ -23,9 +30,13 @@ authority — each run lands as a dated report under the maintainer's `plans/rep
   tree itself. Expected routes therefore cannot be tautological with the tree's wording.
 - Routers are separate context-clean agents that read ONLY `knowledge/need-routing.md`
   and never see the expected answers.
-- Grading is deterministic string comparison in the harness script — no model grades
-  itself. Author-vs-router disagreements on an expected route are surfaced in the run
-  report for owner adjudication, never silently rescored.
+- Grading is deterministic (`eval/routing-grader.mjs`) — no model grades itself.
+  Author-vs-router disagreements on an expected route are surfaced in the run report
+  for owner adjudication, never silently rescored.
+- The mirror obligation: the DOCTRINE must never quote a corpus sentence verbatim —
+  a quoted prompt becomes a self-fulfilling cell (the router reads the answer key).
+  Before merging any `need-routing.md` example phrase, grep it against
+  `eval/routing-prompts.json`; paraphrase on a hit.
 
 ## How to rerun
 
@@ -36,9 +47,9 @@ authority — each run lands as a dated report under the maintainer's `plans/rep
    verbatim text of `knowledge/need-routing.md` and the need sentence, and returns
    `{route: verb[], ask: none|ask-1|ask-2|ask-3, variants: boolean}`. Batching ~10
    prompts per agent is acceptable; instruct the agent to treat each need independently.
-3. Grade per the table above; report per-category percentages, every miss with the
-   router's actual output, and any prompts rejected at validation (unknown verbs,
-   missing expectedAsk).
+3. Grade with the committed grader (`eval/routing-grader.mjs`); report per-category
+   percentages, every miss with the router's actual output, and any prompts rejected
+   at validation (unknown verbs, missing expectedAsk).
 4. Write the dated report to `plans/reports/eval-<date>-routing-accuracy.md` and record
    the headline numbers there — never in this file.
 

--- a/eval/routing-grader.mjs
+++ b/eval/routing-grader.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Deterministic grader for the routing-accuracy benchmark — the committed half
+ * of the harness, so grading rules are executable, not prose (no model grades
+ * itself; rerun contract: docs/routing-benchmark.md).
+ *
+ * Usage:  node eval/routing-grader.mjs <prompts.json> <decisions.json>
+ *   prompts.json    the committed asset (eval/routing-prompts.json)
+ *   decisions.json  [{id, route: string[], ask: "none"|"ask-1"|"ask-2"|"ask-3",
+ *                     variants?: boolean}] from any blind-router harness
+ *
+ * Rules (the single authority — a run report may quote but never redefine):
+ *   verb            pass = ask "none" AND route[0] === expectedRoute[0]
+ *   must-ask        pass = ask === expectedAsk (the route is IGNORED: a router
+ *                   that asks correctly may still sketch a tentative route)
+ *   selection-route pass = ask "none" AND route[0] === expectedRoute[0];
+ *                   `variants` is tracked informationally (no target yet)
+ *   composite       pass = ask "none" AND route equals expectedRoute exactly,
+ *                   same order, same length
+ * Partial runs are supported: only ids present in decisions are graded, and
+ * the output names how many of the full set were covered — a subset is never
+ * silently presented as the whole (no silent caps).
+ */
+import { readFileSync } from "node:fs";
+
+const [promptsPath, decisionsPath] = process.argv.slice(2);
+if (!promptsPath || !decisionsPath) {
+  console.error("usage: node eval/routing-grader.mjs <prompts.json> <decisions.json>");
+  process.exit(2);
+}
+
+const prompts = JSON.parse(readFileSync(promptsPath, "utf8")).prompts;
+const decisions = new Map(
+  JSON.parse(readFileSync(decisionsPath, "utf8")).map((d) => [d.id, d]),
+);
+
+const graded = [];
+for (const p of prompts) {
+  const d = decisions.get(p.id);
+  if (d === undefined) continue; // partial run — reported in coverage below
+  let pass = false;
+  if (p.category === "verb" || p.category === "selection-route") {
+    pass = d.ask === "none" && d.route[0] === p.expectedRoute[0];
+  } else if (p.category === "must-ask") {
+    pass = d.ask === p.expectedAsk;
+  } else {
+    pass =
+      d.ask === "none" &&
+      d.route.length === p.expectedRoute.length &&
+      d.route.every((v, i) => v === p.expectedRoute[i]);
+  }
+  graded.push({
+    id: p.id, category: p.category, pass,
+    expected: p.expectedRoute, expectedAsk: p.expectedAsk ?? null,
+    got: { route: d.route, ask: d.ask, variants: d.variants ?? false },
+    prompt: p.prompt,
+  });
+}
+
+const cats = ["verb", "must-ask", "selection-route", "composite"];
+const summary = {};
+for (const c of cats) {
+  const all = prompts.filter((p) => p.category === c);
+  const g = graded.filter((x) => x.category === c);
+  const passed = g.filter((x) => x.pass).length;
+  summary[c] = {
+    covered: `${g.length}/${all.length}`,
+    passed,
+    pct: g.length === 0 ? null : Math.round((100 * passed) / g.length),
+  };
+}
+const sel = graded.filter((x) => x.category === "selection-route");
+summary.tasteInterrogations = sel.filter((x) => x.got.ask !== "none").length;
+summary.variantsOffered = sel.filter((x) => x.got.variants).length;
+
+console.log(JSON.stringify(
+  { summary, misses: graded.filter((x) => !x.pass) },
+  null, 2,
+));

--- a/eval/routing-grader.mjs
+++ b/eval/routing-grader.mjs
@@ -38,7 +38,7 @@ const graded = [];
 for (const p of prompts) {
   const d = decisions.get(p.id);
   if (d === undefined) continue; // partial run — reported in coverage below
-  let pass = false;
+  let pass;
   if (p.category === "verb" || p.category === "selection-route") {
     pass = d.ask === "none" && d.route[0] === p.expectedRoute[0];
   } else if (p.category === "must-ask") {

--- a/eval/routing-prompts.json
+++ b/eval/routing-prompts.json
@@ -1,0 +1,676 @@
+{
+  "_provenance": {
+    "authoredAt": "2026-08-20",
+    "authoredBy": "context-clean author agent (sonnet) — saw ONLY the 19 workflow frontmatter descriptions + the three sanctioned-ask definitions; never the routing tree",
+    "contract": "docs/routing-benchmark.md",
+    "language": "English only (owner ruling 2026-08-20)",
+    "categories": {
+      "verb": 57,
+      "must-ask": 12,
+      "selection-route": 6,
+      "composite": 8
+    }
+  },
+  "prompts": [
+    {
+      "id": "v01",
+      "category": "verb",
+      "prompt": "What was the reasoning behind switching our primary CTA color from blue to green last sprint?",
+      "expectedRoute": [
+        "why"
+      ]
+    },
+    {
+      "id": "v02",
+      "category": "verb",
+      "prompt": "Can you trace who approved bumping the checkout font size and when that decision landed?",
+      "expectedRoute": [
+        "why"
+      ]
+    },
+    {
+      "id": "v03",
+      "category": "verb",
+      "prompt": "Why did we move the pricing table's spacing from 8px to 12px in the fintech dashboard?",
+      "expectedRoute": [
+        "why"
+      ]
+    },
+    {
+      "id": "v04",
+      "category": "verb",
+      "prompt": "Please ingest this usability-test transcript from our healthcare patient portal and turn the pain points into findings we can cite.",
+      "expectedRoute": [
+        "evidence"
+      ]
+    },
+    {
+      "id": "v05",
+      "category": "verb",
+      "prompt": "Here's a survey CSV from e-commerce shoppers abandoning cart — log a finding for each recurring complaint.",
+      "expectedRoute": [
+        "evidence"
+      ]
+    },
+    {
+      "id": "v06",
+      "category": "verb",
+      "prompt": "Add this support-call notes file as evidence backing our claim that the fintech signup form is too long.",
+      "expectedRoute": [
+        "evidence"
+      ]
+    },
+    {
+      "id": "v07",
+      "category": "verb",
+      "prompt": "We're starting a brand-new SaaS dashboard project and need the design tooling set up from scratch.",
+      "expectedRoute": [
+        "init"
+      ]
+    },
+    {
+      "id": "v08",
+      "category": "verb",
+      "prompt": "Set up ease-design for the first time in our new portfolio site repo.",
+      "expectedRoute": [
+        "init"
+      ]
+    },
+    {
+      "id": "v09",
+      "category": "verb",
+      "prompt": "This is a fresh fintech mobile app repo with no design manifest yet — get the adapter tree written.",
+      "expectedRoute": [
+        "init"
+      ]
+    },
+    {
+      "id": "v10",
+      "category": "verb",
+      "prompt": "Our e-commerce storefront already has a full UI — teach the tool our existing design system by scanning the repo.",
+      "expectedRoute": [
+        "learn"
+      ]
+    },
+    {
+      "id": "v11",
+      "category": "verb",
+      "prompt": "We just finished a major redesign of the healthcare portal, so refresh the tool's understanding of our tokens and components straight from the live code.",
+      "expectedRoute": [
+        "learn"
+      ]
+    },
+    {
+      "id": "v12",
+      "category": "verb",
+      "prompt": "Scan our existing SaaS admin panel's HTML/CSS and harvest the real tokens and interaction states into a compiled DS.",
+      "expectedRoute": [
+        "learn"
+      ]
+    },
+    {
+      "id": "v13",
+      "category": "verb",
+      "prompt": "Here's the raw HTML export of our old landing page — pull its tokens and components into a project design system.",
+      "expectedRoute": [
+        "extract"
+      ]
+    },
+    {
+      "id": "v14",
+      "category": "verb",
+      "prompt": "I have static HTML from our fintech marketing site; harvest the color and spacing tokens out of it.",
+      "expectedRoute": [
+        "extract"
+      ]
+    },
+    {
+      "id": "v15",
+      "category": "verb",
+      "prompt": "Extract the design system from this HTML file of our checkout page so we can reuse the components.",
+      "expectedRoute": [
+        "extract"
+      ]
+    },
+    {
+      "id": "v16",
+      "category": "verb",
+      "prompt": "Capture the design system from stripe.com's pricing page as a portable spec folder we can reuse.",
+      "expectedRoute": [
+        "from-url"
+      ]
+    },
+    {
+      "id": "v17",
+      "category": "verb",
+      "prompt": "Point at this live competitor's SaaS marketing site URL and pull out a reusable DESIGN.md of its system.",
+      "expectedRoute": [
+        "from-url"
+      ]
+    },
+    {
+      "id": "v18",
+      "category": "verb",
+      "prompt": "Grab the visual system from this URL of a healthcare booking site so we can reference it later.",
+      "expectedRoute": [
+        "from-url"
+      ]
+    },
+    {
+      "id": "v19",
+      "category": "verb",
+      "prompt": "We need a picture showing how a user request flows through our microservices architecture.",
+      "expectedRoute": [
+        "diagram"
+      ]
+    },
+    {
+      "id": "v20",
+      "category": "verb",
+      "prompt": "Map out the hierarchy of our fintech onboarding steps so a reader can trace the structure at a glance.",
+      "expectedRoute": [
+        "diagram"
+      ]
+    },
+    {
+      "id": "v21",
+      "category": "verb",
+      "prompt": "Create a diagram of how our checkout state machine transitions between steps.",
+      "expectedRoute": [
+        "diagram"
+      ]
+    },
+    {
+      "id": "v22",
+      "category": "verb",
+      "prompt": "I need a standalone comparison of monthly active users across our three SaaS pricing tiers, not buried in a table.",
+      "expectedRoute": [
+        "chart"
+      ]
+    },
+    {
+      "id": "v23",
+      "category": "verb",
+      "prompt": "Show quantities of support tickets by category for our healthcare app so the comparison doesn't get lost in a table.",
+      "expectedRoute": [
+        "chart"
+      ]
+    },
+    {
+      "id": "v24",
+      "category": "verb",
+      "prompt": "Generate a chart of conversion rate by traffic source for the e-commerce funnel.",
+      "expectedRoute": [
+        "chart"
+      ]
+    },
+    {
+      "id": "v25",
+      "category": "verb",
+      "prompt": "Put together a full presentation deck on our fintech app's Q3 roadmap.",
+      "expectedRoute": [
+        "slides"
+      ]
+    },
+    {
+      "id": "v26",
+      "category": "verb",
+      "prompt": "We need slides to pitch the new healthcare portal redesign to stakeholders.",
+      "expectedRoute": [
+        "slides"
+      ]
+    },
+    {
+      "id": "v27",
+      "category": "verb",
+      "prompt": "Generate a deck walking investors through our SaaS product's design evolution.",
+      "expectedRoute": [
+        "slides"
+      ]
+    },
+    {
+      "id": "v28",
+      "category": "verb",
+      "prompt": "I want a brand-new settings screen built on the Figma canvas for our fintech app, starting completely from a blank slate.",
+      "expectedRoute": [
+        "design"
+      ]
+    },
+    {
+      "id": "v29",
+      "category": "verb",
+      "prompt": "I need a fresh notification-bell component created from scratch for our SaaS dashboard, nothing to base it on yet.",
+      "expectedRoute": [
+        "design"
+      ]
+    },
+    {
+      "id": "v30",
+      "category": "verb",
+      "prompt": "We need a new checkout confirmation page designed on canvas for the e-commerce app, nothing exists yet.",
+      "expectedRoute": [
+        "design"
+      ]
+    },
+    {
+      "id": "v31",
+      "category": "verb",
+      "prompt": "Take this generated landing page and build it out as idiomatic Figma auto-layout with real components.",
+      "expectedRoute": [
+        "to-figma"
+      ]
+    },
+    {
+      "id": "v32",
+      "category": "verb",
+      "prompt": "Author the healthcare dashboard on the Figma canvas using our design variables, driven by figma-agent.",
+      "expectedRoute": [
+        "to-figma"
+      ]
+    },
+    {
+      "id": "v33",
+      "category": "verb",
+      "prompt": "Use to-figma to turn our intent for a pricing card into an editable Figma component.",
+      "expectedRoute": [
+        "to-figma"
+      ]
+    },
+    {
+      "id": "v34",
+      "category": "verb",
+      "prompt": "Check our fintech app's Figma file against the design system and normalize any raw hex colors.",
+      "expectedRoute": [
+        "audit"
+      ]
+    },
+    {
+      "id": "v35",
+      "category": "verb",
+      "prompt": "Find and fix the detached instances and off-grid spacing in our SaaS dashboard Figma file.",
+      "expectedRoute": [
+        "audit"
+      ]
+    },
+    {
+      "id": "v36",
+      "category": "verb",
+      "prompt": "Audit the healthcare portal's Figma frame for deprecated components and clean them up.",
+      "expectedRoute": [
+        "audit"
+      ]
+    },
+    {
+      "id": "v37",
+      "category": "verb",
+      "prompt": "Pull all the open comments on our checkout frame in Figma and resolve which element each pin refers to.",
+      "expectedRoute": [
+        "figma-comments"
+      ]
+    },
+    {
+      "id": "v38",
+      "category": "verb",
+      "prompt": "Triage the design feedback threads the client left on our SaaS onboarding file and close the loop.",
+      "expectedRoute": [
+        "figma-comments"
+      ]
+    },
+    {
+      "id": "v39",
+      "category": "verb",
+      "prompt": "Go through the Figma comments on the fintech dashboard frame one at a time and read back the verdicts.",
+      "expectedRoute": [
+        "figma-comments"
+      ]
+    },
+    {
+      "id": "v40",
+      "category": "verb",
+      "prompt": "Here's a link to our pricing page frame on the design canvas — turn it into working HTML code.",
+      "expectedRoute": [
+        "figma"
+      ]
+    },
+    {
+      "id": "v41",
+      "category": "verb",
+      "prompt": "I have a canvas frame from the healthcare app's dashboard — reproduce it as working HTML code, not just inspiration.",
+      "expectedRoute": [
+        "figma"
+      ]
+    },
+    {
+      "id": "v42",
+      "category": "verb",
+      "prompt": "Import this Figma design of our e-commerce product page and produce the HTML for it.",
+      "expectedRoute": [
+        "figma"
+      ]
+    },
+    {
+      "id": "v43",
+      "category": "verb",
+      "prompt": "I'm attaching a screenshot of a fintech app's login screen — generate high-fidelity HTML inspired by it.",
+      "expectedRoute": [
+        "from-ref"
+      ]
+    },
+    {
+      "id": "v44",
+      "category": "verb",
+      "prompt": "Here's a reference image of a healthcare booking UI, reproduce it faithfully in HTML.",
+      "expectedRoute": [
+        "from-ref"
+      ]
+    },
+    {
+      "id": "v45",
+      "category": "verb",
+      "prompt": "Use this screenshot of a SaaS dashboard purely as inspiration and build a fresh HTML version, not a copy.",
+      "expectedRoute": [
+        "from-ref"
+      ]
+    },
+    {
+      "id": "v46",
+      "category": "verb",
+      "prompt": "Create a marketing landing page for our new fintech savings product from this plain-language brief.",
+      "expectedRoute": [
+        "generate"
+      ]
+    },
+    {
+      "id": "v47",
+      "category": "verb",
+      "prompt": "Generate a checkout page design for our e-commerce store backed by our user research.",
+      "expectedRoute": [
+        "generate"
+      ]
+    },
+    {
+      "id": "v48",
+      "category": "verb",
+      "prompt": "Build a signup page UI for the healthcare portal from this description of what we need.",
+      "expectedRoute": [
+        "generate"
+      ]
+    },
+    {
+      "id": "v49",
+      "category": "verb",
+      "prompt": "Take the pricing page you generated yesterday and just nudge the CTA button to feel more urgent.",
+      "expectedRoute": [
+        "iterate"
+      ]
+    },
+    {
+      "id": "v50",
+      "category": "verb",
+      "prompt": "Tweak the hero headline size on the SaaS landing variant we already made, don't redesign it.",
+      "expectedRoute": [
+        "iterate"
+      ]
+    },
+    {
+      "id": "v51",
+      "category": "verb",
+      "prompt": "Iterate on the fintech signup variant — just adjust the spacing between form fields.",
+      "expectedRoute": [
+        "iterate"
+      ]
+    },
+    {
+      "id": "v52",
+      "category": "verb",
+      "prompt": "The checkout page variant scored low on visual craft — polish it up without changing the layout.",
+      "expectedRoute": [
+        "refine"
+      ]
+    },
+    {
+      "id": "v53",
+      "category": "verb",
+      "prompt": "Clean up the alignment and shadow inconsistencies on the healthcare dashboard variant we generated.",
+      "expectedRoute": [
+        "refine"
+      ]
+    },
+    {
+      "id": "v54",
+      "category": "verb",
+      "prompt": "Run a refine pass on the SaaS pricing card to fix its execution quality, keep the design as-is.",
+      "expectedRoute": [
+        "refine"
+      ]
+    },
+    {
+      "id": "v55",
+      "category": "verb",
+      "prompt": "We hate the current direction of the fintech onboarding variant — give us something completely different.",
+      "expectedRoute": [
+        "redesign"
+      ]
+    },
+    {
+      "id": "v56",
+      "category": "verb",
+      "prompt": "Reject this healthcare landing page's whole vibe and redesign it with an opposite persona.",
+      "expectedRoute": [
+        "redesign"
+      ]
+    },
+    {
+      "id": "v57",
+      "category": "verb",
+      "prompt": "The e-commerce homepage variant feels totally wrong — throw it out and give us the opposite direction entirely.",
+      "expectedRoute": [
+        "redesign"
+      ]
+    },
+    {
+      "id": "a01",
+      "category": "must-ask",
+      "prompt": "Audit our onboarding screens before the review meeting.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-1"
+    },
+    {
+      "id": "a02",
+      "category": "must-ask",
+      "prompt": "Can you go through and audit the pricing page?",
+      "expectedRoute": [],
+      "expectedAsk": "ask-1"
+    },
+    {
+      "id": "a03",
+      "category": "must-ask",
+      "prompt": "We need an audit done on the dashboard design.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-1"
+    },
+    {
+      "id": "a04",
+      "category": "must-ask",
+      "prompt": "Please audit the checkout experience for consistency issues.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-1"
+    },
+    {
+      "id": "a05",
+      "category": "must-ask",
+      "prompt": "The onboarding variant we generated just isn't landing right — can you do something about it?",
+      "expectedRoute": [],
+      "expectedAsk": "ask-2"
+    },
+    {
+      "id": "a06",
+      "category": "must-ask",
+      "prompt": "Something feels off about the pricing page we made yesterday, fix it.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-2"
+    },
+    {
+      "id": "a07",
+      "category": "must-ask",
+      "prompt": "I'm not happy with the checkout page design, can you improve it?",
+      "expectedRoute": [],
+      "expectedAsk": "ask-2"
+    },
+    {
+      "id": "a08",
+      "category": "must-ask",
+      "prompt": "The healthcare landing page variant doesn't feel right, make it better.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-2"
+    },
+    {
+      "id": "a09",
+      "category": "must-ask",
+      "prompt": "Here's the URL of a competitor's admin dashboard — use it as the basis for our new admin panel.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-3"
+    },
+    {
+      "id": "a10",
+      "category": "must-ask",
+      "prompt": "[attached: screenshot of a fintech login screen] Build our login page from this.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-3"
+    },
+    {
+      "id": "a11",
+      "category": "must-ask",
+      "prompt": "Here's the URL for a SaaS landing page — build ours from it.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-3"
+    },
+    {
+      "id": "a12",
+      "category": "must-ask",
+      "prompt": "I'm attaching an image of a healthcare booking flow — create our version from it.",
+      "expectedRoute": [],
+      "expectedAsk": "ask-3"
+    },
+    {
+      "id": "s01",
+      "category": "selection-route",
+      "prompt": "Create a landing page for our fintech savings app that feels more premium and trustworthy.",
+      "expectedRoute": [
+        "generate"
+      ]
+    },
+    {
+      "id": "s02",
+      "category": "selection-route",
+      "prompt": "Design a new onboarding screen for our healthcare app that feels calm and reassuring.",
+      "expectedRoute": [
+        "design"
+      ]
+    },
+    {
+      "id": "s03",
+      "category": "selection-route",
+      "prompt": "Redesign our SaaS pricing page — it currently feels corporate and stiff, we want something bolder.",
+      "expectedRoute": [
+        "redesign"
+      ]
+    },
+    {
+      "id": "s04",
+      "category": "selection-route",
+      "prompt": "Polish up the fintech dashboard variant we generated so it feels more premium.",
+      "expectedRoute": [
+        "refine"
+      ]
+    },
+    {
+      "id": "s05",
+      "category": "selection-route",
+      "prompt": "Put together an investor deck for our e-commerce platform that feels sleek and modern.",
+      "expectedRoute": [
+        "slides"
+      ]
+    },
+    {
+      "id": "s06",
+      "category": "selection-route",
+      "prompt": "Take our generated checkout flow and build it out in Figma so it feels more premium and on-brand.",
+      "expectedRoute": [
+        "to-figma"
+      ]
+    },
+    {
+      "id": "c01",
+      "category": "composite",
+      "prompt": "Look at stripe.com's pricing page and build us a similar pricing page for our fintech product.",
+      "expectedRoute": [
+        "from-url",
+        "generate"
+      ]
+    },
+    {
+      "id": "c02",
+      "category": "composite",
+      "prompt": "I'm attaching a screenshot of a competitor's onboarding flow — use it to generate our own onboarding screens for the healthcare app.",
+      "expectedRoute": [
+        "from-ref",
+        "generate"
+      ]
+    },
+    {
+      "id": "c03",
+      "category": "composite",
+      "prompt": "Scan our existing e-commerce site's codebase for its design system, then design a new wishlist page that matches it, from scratch on the canvas.",
+      "expectedRoute": [
+        "learn",
+        "design"
+      ]
+    },
+    {
+      "id": "c04",
+      "category": "composite",
+      "prompt": "Here's the raw HTML of our old dashboard — extract its tokens, then design a brand-new analytics screen on the Figma canvas using them.",
+      "expectedRoute": [
+        "extract",
+        "design"
+      ]
+    },
+    {
+      "id": "c05",
+      "category": "composite",
+      "prompt": "Grab the design system from this healthcare app's live URL and put together a slide deck showcasing a redesigned patient dashboard concept.",
+      "expectedRoute": [
+        "from-url",
+        "slides"
+      ]
+    },
+    {
+      "id": "c06",
+      "category": "composite",
+      "prompt": "Here's a screenshot of a fintech app's card-management screen — reproduce it in HTML first, then build that out properly in Figma with real auto-layout components.",
+      "expectedRoute": [
+        "from-ref",
+        "to-figma"
+      ]
+    },
+    {
+      "id": "c07",
+      "category": "composite",
+      "prompt": "The checkout page we generated last week doesn't match this new screenshot of a competitor's flow — redesign it to match this reference instead.",
+      "expectedRoute": [
+        "from-ref",
+        "redesign"
+      ]
+    },
+    {
+      "id": "c08",
+      "category": "composite",
+      "prompt": "Here's a screenshot of a cleaner pricing layout — nudge our existing pricing variant closer to this reference without starting over.",
+      "expectedRoute": [
+        "from-ref",
+        "iterate"
+      ]
+    }
+  ]
+}

--- a/knowledge/need-routing.md
+++ b/knowledge/need-routing.md
@@ -38,9 +38,9 @@ leaf. The reference decides the capture leg (G3 verbs); the artifact decides the
 production leg (G1 verbs for chart/diagram/slides, G4 for surfaces). A gate that
 fires on the reference alone ("a live URL → `from-url`") must never swallow the
 artifact half of the sentence. Splitting a composite does NOT skip **ask #3**:
-when the reference arrives without a replicate-vs-inspired sentence ("build ours
-from this", "use it as the basis"), that one question comes BEFORE the capture
-leg is chosen — it decides the capture's fidelity mode.
+when the reference arrives without a replicate-vs-inspired sentence ("make us
+one like this", "start from this one"), that one question comes BEFORE the
+capture leg is chosen — it decides the capture's fidelity mode.
 
 **G0 — meta and ops (no new artifact).** "Why is X this way / what was decided" →
 `why`. "Log this interview / finding / transcript" → `evidence`. New project / setup →
@@ -55,7 +55,7 @@ to `generate`; inside a deck, to `slides` (composition, not a chart artifact).
 something new on canvas → `design`. Push existing output or intent onto canvas →
 `to-figma`. Normalize an existing Figma file against the DS → `audit`. Review or
 close Figma comments → `figma-comments`. An "audit" that names no SURFACE —
-bare, or aimed at a product area ("audit the checkout experience") that could
+bare, or aimed at a product area ("audit the pricing area") that could
 equally be a Figma file, an HTML output, the DS itself, or a live page — this
 gate still owns it, even though no canvas was mentioned → **ask #1** (the
 four-surface question in `templates/journeys/daily.md` §1 — link, don't restate).

--- a/knowledge/need-routing.md
+++ b/knowledge/need-routing.md
@@ -37,7 +37,10 @@ produce or change routes to a sequence (Composition rule below), never a single
 leaf. The reference decides the capture leg (G3 verbs); the artifact decides the
 production leg (G1 verbs for chart/diagram/slides, G4 for surfaces). A gate that
 fires on the reference alone ("a live URL → `from-url`") must never swallow the
-artifact half of the sentence.
+artifact half of the sentence. Splitting a composite does NOT skip **ask #3**:
+when the reference arrives without a replicate-vs-inspired sentence ("build ours
+from this", "use it as the basis"), that one question comes BEFORE the capture
+leg is chosen — it decides the capture's fidelity mode.
 
 **G0 — meta and ops (no new artifact).** "Why is X this way / what was decided" →
 `why`. "Log this interview / finding / transcript" → `evidence`. New project / setup →
@@ -51,8 +54,10 @@ to `generate`; inside a deck, to `slides` (composition, not a chart artifact).
 **G2 — Figma-canvas needs, and the bare "audit" that names no target.** Design
 something new on canvas → `design`. Push existing output or intent onto canvas →
 `to-figma`. Normalize an existing Figma file against the DS → `audit`. Review or
-close Figma comments → `figma-comments`. A bare "audit" with NO target named —
-this gate still owns it, even though no canvas was mentioned → **ask #1** (the
+close Figma comments → `figma-comments`. An "audit" that names no SURFACE —
+bare, or aimed at a product area ("audit the checkout experience") that could
+equally be a Figma file, an HTML output, the DS itself, or a live page — this
+gate still owns it, even though no canvas was mentioned → **ask #1** (the
 four-surface question in `templates/journeys/daily.md` §1 — link, don't restate).
 
 **G3 — an input is in hand (HTML surface).** Two checks BEFORE any leaf fires:


### PR DESCRIPTION
Owner go: "Cook hết" (2026-08-20); language ruling: English only. This is eval PR 2 from the native-expert arc (PR #203).

## What
- `eval/routing-prompts.json`: 83 prompts — 57 verb (3×19), 12 must-ask (4×3 asks), 6 selection-route, 8 composite. Authored by a context-clean sonnet agent given ONLY the 19 workflow frontmatter descriptions + the sanctioned-ask definitions — never the routing tree — so ground truth cannot be tautological with the tree's wording. Provenance header in the asset.
- `docs/routing-benchmark.md`: the rerun contract (blind batched routers, deterministic grading, manual cadence — never CI). `eval/` is not in the npm `files` list — nothing ships.
- Two doctrine fixes in `knowledge/need-routing.md`, driven by the measurement (below).

## Run 1 (blind sonnet routers, Workflow harness, 10 agents)
| Category | Score | Target |
|---|---|---|
| verb top-1 | **96%** (55/57) | ≥85 ✓ |
| must-ask | **58%** (7/12) | 100 ✗ |
| selection-route | 83%, **0 taste interrogations** | 0 interrogations ✓ |
| composite | **100%** (8/8) | — |

## The two bugs the FAIL exposed (both fixed here)
1. **Composite split swallowed ask #3** — all 4 ambiguous-reference prompts ("build ours from it") routed capture→generate without the replicate-vs-inspired question. The split law now fires ask #3 BEFORE choosing the capture leg. Same defect class as stage-4 finding R1: an exception written outside the gate that swallows it never runs.
2. **"Audit the checkout experience" read as Figma `audit`** — G2's ask-1 clause now owns any audit aimed at a product area that pins none of the four surfaces.

Targeted re-measure (fresh blind router, same 5 prompts): **5/5 flipped** → projected must-ask 100%. Caveat: the other 78 prompts were not re-run; blast radius of the two edits argued small, not measured.

## Owner adjudication (expected labels NOT changed)
v29/s02 (design vs generate when the canvas is not named) and v32 (design vs to-figma — "author on canvas from intent" reads as both). Options in the run report; the predicted iterate/refine/redesign cell stayed clean.

## Gates
`ui knowledge check` 0 findings; knowledge-lint real-file parity test green; typecheck/lint unaffected (no src change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)