### PR TITLE
release: 0.5.0 — the native-expert release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-08-20 - ease-design 0.5.0
+
+The native-expert release: a stated need is now enough. `knowledge/need-routing.md`
+ships the need→verb decision procedure (ordered gates over all 19 workflow verbs, three
+sanctioned asks, the composition rule, the decision-vs-construction tie-break), kept
+honest by the two-way parity gate in `ui knowledge check` — a new capability cannot
+merge until the routing knowledge teaches it. Generated agents point instead of
+enumerating (per-role command allowlist, born-red on real drift) and carry the absolute
+knowledge anchor so routing expertise resolves in consumer projects. `ui init
+--with-agents` exercises the roster opt-in in one run, fully pre-flighted. The doctrine
+is MEASURED: an 84-prompt blind benchmark (authored from frontmatter only, graded by
+the committed `eval/routing-grader.mjs`) caught two routing bugs and three label
+defects on its way to a fully clean board — verb 100%, must-ask 100%, selection-route
+100%, composite 100%, 0 taste interrogations. Published surfaces carry no confidential
+project names (one leftover example slug cleaned this release).
+
 ## 2026-08-20 - Canvas-cell adjudication: the routing board reaches 83/83
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ one job:
 
 The prefix is generic on purpose — every DESIGN:OS project has *a* designer, *a*
 curator, *a* figma hand — while the suffix carries the identity: a studio soul
-named `JANG` on the project `vsf-pcp` yields `designer-jang-vsf-pcp`.
+named `MERIDIAN` on the project `meridian-store` yields `designer-meridian-meridian-store`.
 
 ### Set it up
 
@@ -993,6 +993,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
+| 2026-08-20 | **`ease-design@0.5.0`** — the native-expert release: need→verb routing knowledge + the untaught-feature parity gate, pointing agents with the knowledge anchor, `ui init --with-agents`, and an 84-prompt blind benchmark that measured the doctrine to a fully clean board | `v0.5.0` |
 | 2026-08-20 | **Routing board clean** — the three canvas-cell misses adjudicated at their sources (`design.md` frontmatter regains the canvas condition; G2 gains the decision-vs-construction tie-break): one moved by doctrine and measured, two corrected labels; re-measured with no collateral flips | `#207` |
 | 2026-08-20 | **`ui init --with-agents`** — opt-in roster generation in the same init run (claude runtime + existing project DS required; pre-flights to `DS_NOT_FOUND` before any write) | `#205` |
 | 2026-08-20 | **Routing doctrine, measured** — an 83-prompt blind benchmark (authored from frontmatter only, routed by context-clean agents) caught two doctrine bugs at must-ask 58%; after the fixes a 16-prompt reference-path re-run graded 16/16, putting the merged figures at verb 96% / must-ask 100% / composite 100% / 0 taste interrogations | `#206` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ease-design",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Multi-runtime design-cli — describe what you want, get pro-taste UI.",
   "type": "module",
   "keywords": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,7 +64,7 @@ import { promptPlanCommand } from "./commands/prompt-plan.js";
 
 // Keep in sync with package.json "version". A test (tests/cli-version.test.ts)
 // asserts these match, so drift fails CI rather than shipping silently.
-const VERSION = "0.4.0";
+const VERSION = "0.5.0";
 
 // ─── Command registry ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Owner go: "Gom hết rồi ship" (2026-08-20). Version bump 0.4.0 → 0.5.0 (minor — new features, backwards compatible), gathering today's wave: #203 (need-routing knowledge + untaught-feature gate + pointing agents), #205 (`ui init --with-agents`), #206 (routing benchmark + 2 doctrine bugs fixed by measurement), #207 (canvas-cell adjudication, board 84/84).

Pre-ship completeness done:
- **Confidential sweep of the ACTUAL tarball**: grepped all 172 `npm pack` files — one leftover example slug found in README (missed by #202) and cleaned; tarball now 0 hits. The 0.4.0 tarball carried the name; 0.5.0 is the clean one.
- `package.json` + `src/cli.ts` VERSION in sync (cli-version test enforces); `--version` → 0.5.0.
- CHANGELOG release entry + README recent-wave row.

Gates: typecheck / lint / build clean, `ui knowledge check` 0 findings, full suite **3644 passed / 204 files**.

Post-merge: tag `v0.5.0` on main → `release.yml` publishes via npm OIDC Trusted Publishing (tag↔package.json guard); verify via registry JSON + tarball spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)