### PR TITLE
feat: pin MengTo web technique source ledger

### DIFF
--- a/knowledge/sources/mengto-web-techniques--202608.json
+++ b/knowledge/sources/mengto-web-techniques--202608.json
@@ -1,0 +1,431 @@
+{
+  "schemaVersion": 1,
+  "id": "mengto-web-techniques--202608",
+  "upstream": {
+    "repository": "https://github.com/MengTo/Skills.git",
+    "revision": "4c716b516b6b0143f3037631306b3730d2832344",
+    "capturedAt": "2026-08-21T00:27:35Z",
+    "rootLicense": "MIT",
+    "rootLicenseEvidence": {
+      "path": "LICENSE",
+      "mode": "100644",
+      "gitObjectId": "b3a5f823a69b4b010f92930ac09e8a776daf65c6",
+      "byteCount": 1064,
+      "sha256": "b2a071ba22fefd803f4e9d1f5c777dd79c62d191695586a1a73fd4d0ebd051c6"
+    }
+  },
+  "enumeration": {
+    "scope": "agent-skills/web-design",
+    "command": "git ls-tree -r -t -l --full-tree <revision> -- agent-skills/web-design"
+  },
+  "treeRecordCount": 926,
+  "blobRecordCount": 669,
+  "textArtifactCount": 373,
+  "duplicateBlobGroups": [
+    {
+      "sha256": "0d71068ad67cbdbfca87b5e5f57f21fbb47fb29148e2ae8d2e1a5df136ea5cfc",
+      "paths": [
+        "agent-skills/web-design/agency-grid-layout-minimal/demo/assets/page-01-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp",
+        "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-03-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp",
+        "agent-skills/web-design/gooey-blob-system/demo/assets/page-01-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-02-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp"
+      ]
+    },
+    {
+      "sha256": "184da411f3d660fc3cb9ec2f428e7d9b832c4d84da3e2dcef0e5caf106662759",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/index.html",
+        "agent-skills/web-design/number-details/demo/index.html"
+      ]
+    },
+    {
+      "sha256": "1e06aaa12c3395215a1f292f228f502281f2bb2b45970ab6982d59a1fe760008",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/number-details/demo/assets/source-preview.jpg"
+      ]
+    },
+    {
+      "sha256": "1ec8f6ee2750554b4bc59ff0b507d316a82a7ba37e0e5bebc41d3bd9b9faad46",
+      "paths": [
+        "agent-skills/web-design/add-mouse-driven-orbit/demo/assets/lexend-latin.woff2",
+        "agent-skills/web-design/build-interactive-particle-trail/demo/assets/lexend-latin.woff2",
+        "agent-skills/web-design/build-wireframe-scan-reveal/demo/assets/lexend-latin.woff2"
+      ]
+    },
+    {
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "paths": [
+        "agent-skills/web-design/background-grid-webgl/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+        "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-06-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+        "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+        "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+        "agent-skills/web-design/nested-container-frames/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-14-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+        "agent-skills/web-design/solar-duotone-bold/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+        "agent-skills/web-design/webgl-laser/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "21f51f52256cc0c08deb82e954ba0418fa8319ed9a36277902c005842b105b96",
+      "paths": [
+        "agent-skills/web-design/beautiful-shadows/demo/index.html",
+        "agent-skills/web-design/corner-diagonals/demo/index.html"
+      ]
+    },
+    {
+      "sha256": "32a1f0a3fb3b604920ea7d8301e69eedd747d85a299c9e7a40f354360f0cbbc8",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-03-photo-1596394516093-501ba68a0ba6.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-03-photo-1596394516093-501ba68a0ba6.jpg"
+      ]
+    },
+    {
+      "sha256": "337627390f499b3ae272cec9e2f83c817694a82f42e1aa10a7b26a2c7d679dff",
+      "paths": [
+        "agent-skills/web-design/add-mouse-driven-orbit/demo/assets/card-ethos.jpg",
+        "agent-skills/web-design/build-interactive-particle-trail/demo/assets/card-ethos.jpg",
+        "agent-skills/web-design/build-wireframe-scan-reveal/demo/assets/card-ethos.jpg"
+      ]
+    },
+    {
+      "sha256": "3bfb70e2fd5359c261e9268583aca339d4d360fd774854977af109d3ab3edc6d",
+      "paths": [
+        "agent-skills/web-design/dither-background/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/framed-grid-layout/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/glass-dark-mode-clock/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/assets/source-preview.jpg"
+      ]
+    },
+    {
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "paths": [
+        "agent-skills/web-design/background-grid-webgl/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+        "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+        "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+        "agent-skills/web-design/nested-container-frames/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-10-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+        "agent-skills/web-design/solar-duotone-bold/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+        "agent-skills/web-design/webgl-laser/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "3ecad5d2605bbf56d3f02c0a2a4673d574d405a5d830e45b43d6a34c01cbe992",
+      "paths": [
+        "agent-skills/web-design/container-lines/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/css-border-gradient/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/image-first-grid-layout/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/masked-reveal/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/skeuomorphic-ui/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/split-layout-technical/demo/assets/source-preview.jpg"
+      ]
+    },
+    {
+      "sha256": "4526a25eb7c0b86d945cf5e43ed53e85be9821edb8dc26017ed372b1450ae6f6",
+      "paths": [
+        "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-02-eca707cc-a5b7-439a-b4fd-247f6106c2e1-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-08-eca707cc-a5b7-439a-b4fd-247f6106c2e1-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "4559d22599d5ed733eb14ba074e37de12e8db297571b70be93b898a347274658",
+      "paths": [
+        "agent-skills/web-design/container-lines/demo/index.html",
+        "agent-skills/web-design/css-border-gradient/demo/index.html",
+        "agent-skills/web-design/image-first-grid-layout/demo/index.html",
+        "agent-skills/web-design/masked-reveal/demo/index.html",
+        "agent-skills/web-design/skeuomorphic-ui/demo/index.html",
+        "agent-skills/web-design/split-layout-technical/demo/index.html"
+      ]
+    },
+    {
+      "sha256": "47dc6ced9e3d2354583a2dec0adba4c2d7da55e6325f48b38cbfb28c39f6e2cf",
+      "paths": [
+        "agent-skills/web-design/css-border-gradient/demo/preview.jpg",
+        "agent-skills/web-design/image-first-grid-layout/demo/preview.jpg",
+        "agent-skills/web-design/masked-reveal/demo/preview.jpg"
+      ]
+    },
+    {
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "paths": [
+        "agent-skills/web-design/container-lines/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+        "agent-skills/web-design/css-border-gradient/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+        "agent-skills/web-design/image-first-grid-layout/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+        "agent-skills/web-design/masked-reveal/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-03-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+        "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+        "agent-skills/web-design/split-layout-technical/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+        "agent-skills/web-design/webgl-3d-object/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "5ebc42216d0cd25fef1caa8510c6972388744fd513de2b2f9ada053145e4c3d1",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-08-photo-1555396273-367ea4eb4db5.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-08-photo-1555396273-367ea4eb4db5.jpg"
+      ]
+    },
+    {
+      "sha256": "6a0ea1bc48598dd6b7848a1a718b87c93a2f15600c32eafa0d3e13138b3516cf",
+      "paths": [
+        "agent-skills/web-design/progressive-blur/demo/assets/page-11-5ee0a38a-b5d3-4531-8793-98beed4af162-1600w.jpg",
+        "agent-skills/web-design/webgl-3d-object/demo/assets/page-05-5ee0a38a-b5d3-4531-8793-98beed4af162-1600w.jpg",
+        "agent-skills/web-design/webgl-3d-object/demo/assets/page-06-5ee0a38a-b5d3-4531-8793-98beed4af162-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "6a7bb45fc2ab13660d9c66de569563e928ffaaa526d6f44f5d3147d5c35699f7",
+      "paths": [
+        "agent-skills/web-design/editorial-tech/demo/assets/page-01-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg",
+        "agent-skills/web-design/globe-particles/demo/assets/page-01-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg",
+        "agent-skills/web-design/technical-wireframe-info-layout/demo/assets/page-01-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg",
+        "agent-skills/web-design/webgl-3d-object/demo/assets/page-03-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "paths": [
+        "agent-skills/web-design/book-serif-index/demo/assets/page-01-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+        "agent-skills/web-design/container-lines/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+        "agent-skills/web-design/css-border-gradient/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+        "agent-skills/web-design/image-first-grid-layout/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+        "agent-skills/web-design/masked-reveal/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-15-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+        "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+        "agent-skills/web-design/split-layout-technical/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "7abbd51e4c973de2df8ce06f7b1f24f9c20cbfc4cabb0438b88e80177d26f50e",
+      "paths": [
+        "agent-skills/web-design/background-grid-webgl/demo/index.html",
+        "agent-skills/web-design/light-mode-paper-technical/demo/index.html",
+        "agent-skills/web-design/nested-container-clean-agency/demo/index.html",
+        "agent-skills/web-design/nested-container-frames/demo/index.html",
+        "agent-skills/web-design/solar-duotone-bold/demo/index.html",
+        "agent-skills/web-design/webgl-laser/demo/index.html"
+      ]
+    },
+    {
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "paths": [
+        "agent-skills/web-design/container-lines/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+        "agent-skills/web-design/css-border-gradient/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+        "agent-skills/web-design/image-first-grid-layout/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+        "agent-skills/web-design/masked-reveal/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-09-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+        "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+        "agent-skills/web-design/split-layout-technical/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+        "agent-skills/web-design/webgl-3d-object/demo/assets/page-01-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "7cd43cddf21947985f32ffefd02d2f2f4273cf79c438b0fa9dadc089fd35b329",
+      "paths": [
+        "agent-skills/web-design/dither-background/demo/index.html",
+        "agent-skills/web-design/framed-grid-layout/demo/index.html",
+        "agent-skills/web-design/glass-dark-mode-clock/demo/index.html",
+        "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/index.html"
+      ]
+    },
+    {
+      "sha256": "852496aebbe37c983c885d9aa20b3520e0c0244472703e3c2925b9c56f749a2c",
+      "paths": [
+        "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-01-3186f9ea-5f5a-49f7-8fcf-568ad52f515e-3840w.webp",
+        "agent-skills/web-design/gooey-blob-system/demo/assets/page-02-3186f9ea-5f5a-49f7-8fcf-568ad52f515e-3840w.webp",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-04-3186f9ea-5f5a-49f7-8fcf-568ad52f515e-3840w.webp"
+      ]
+    },
+    {
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "paths": [
+        "agent-skills/web-design/background-grid-webgl/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/editorial-tech/demo/assets/page-03-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/globe-particles/demo/assets/page-03-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/gooey-blob-system/demo/assets/page-03-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/nested-container-frames/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-16-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/solar-duotone-bold/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+        "agent-skills/web-design/webgl-laser/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "paths": [
+        "agent-skills/web-design/add-mouse-driven-orbit/demo/assets/three.min.js",
+        "agent-skills/web-design/build-interactive-particle-trail/demo/assets/three.min.js",
+        "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/three.min.js",
+        "agent-skills/web-design/build-wireframe-scan-reveal/demo/assets/three.min.js",
+        "agent-skills/web-design/threejs-landscape/demo/assets/three.min.js",
+        "agent-skills/web-design/threejs-towers/demo/assets/three.min.js",
+        "agent-skills/web-design/threejs-weather/demo/assets/three.min.js"
+      ]
+    },
+    {
+      "sha256": "8c60a544ff48b3e2900418d6098efe1c72b5541ed41cb44ea70cd9d2b03a2f20",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-01-photo-1542224566-6e85f2e6772f.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-01-photo-1542224566-6e85f2e6772f.jpg"
+      ]
+    },
+    {
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "paths": [
+        "agent-skills/web-design/background-grid-webgl/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/editorial-tech/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/globe-particles/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/marquee-loop/demo/assets/page-04-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/nested-container-frames/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-06-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/solar-duotone-bold/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+        "agent-skills/web-design/webgl-laser/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "97c65569d294acbb5072f963eec2f67f57fd3e8fbba84cfa9a1bfe5042e92d54",
+      "paths": [
+        "agent-skills/web-design/background-grid-webgl/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/light-mode-paper-technical/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/nested-container-clean-agency/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/nested-container-frames/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/solar-duotone-bold/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/webgl-laser/demo/assets/source-preview.jpg"
+      ]
+    },
+    {
+      "sha256": "a5705dd6a81f41b53984155db8648b5325b7ac40aa100158a4a44b03cc07f0ea",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-05-photo-1522708323590-d24dbb6b0267.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-05-photo-1522708323590-d24dbb6b0267.jpg"
+      ]
+    },
+    {
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "paths": [
+        "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-05-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/container-lines/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/css-border-gradient/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/gooey-blob-system/demo/assets/page-04-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/image-first-grid-layout/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/masked-reveal/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-12-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+        "agent-skills/web-design/split-layout-technical/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp"
+      ]
+    },
+    {
+      "sha256": "b7cbd83537c98728b3d59f720bd93f6a9037e564587cb4a117dbbb5e813248c1",
+      "paths": [
+        "agent-skills/web-design/editorial-tech/demo/index.html",
+        "agent-skills/web-design/globe-particles/demo/index.html"
+      ]
+    },
+    {
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "paths": [
+        "agent-skills/web-design/container-lines/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+        "agent-skills/web-design/css-border-gradient/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+        "agent-skills/web-design/image-first-grid-layout/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+        "agent-skills/web-design/masked-reveal/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-13-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+        "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+        "agent-skills/web-design/split-layout-technical/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "bbe08c5a657202eed3200ef00f2ba3bcd7ead0be207bf1b0d67d0eee118e4fc0",
+      "paths": [
+        "agent-skills/web-design/solar-duotone-bold/demo/preview.jpg",
+        "agent-skills/web-design/webgl-laser/demo/preview.jpg"
+      ]
+    },
+    {
+      "sha256": "bf39595522ac70a092bb41991e20e03f93c9ad9025a3176ed9a534aa66fa4895",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-06-photo-1464822759023-fed622ff2c3b.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-06-photo-1464822759023-fed622ff2c3b.jpg"
+      ]
+    },
+    {
+      "sha256": "ca99771790e92886557b657ef1f4d4d213d0d58d102207edd4bc26987dbd146b",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-07-photo-1544161515-4ab6ce6db874.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-07-photo-1544161515-4ab6ce6db874.jpg"
+      ]
+    },
+    {
+      "sha256": "cea85a39224a0cac5523629063a71ff13a173ffce2d347f029ea567e994472a6",
+      "paths": [
+        "agent-skills/web-design/beautiful-shadows/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/corner-diagonals/demo/assets/source-preview.jpg"
+      ]
+    },
+    {
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "paths": [
+        "agent-skills/web-design/book-serif-index/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/container-lines/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/corner-lasers/demo/assets/page-03-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/css-border-gradient/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/image-first-grid-layout/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/masked-reveal/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/progressive-blur/demo/assets/page-01-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/split-layout-technical/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+        "agent-skills/web-design/webgl-3d-object/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg"
+      ]
+    },
+    {
+      "sha256": "d1cf2835a4411c20236c5b9b4c27599768e45c87ae3bea2332e35d0c0519085f",
+      "paths": [
+        "agent-skills/web-design/editorial-tech/demo/assets/source-preview.jpg",
+        "agent-skills/web-design/globe-particles/demo/assets/source-preview.jpg"
+      ]
+    },
+    {
+      "sha256": "dd5ea24c41f638a247ceb9a4b4277be9a3ce571525778352ede1b40b9c33e53c",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-04-photo-1587061949409-02df41d5e562.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-04-photo-1587061949409-02df41d5e562.jpg"
+      ]
+    },
+    {
+      "sha256": "fdc05d807596db69affad0b516142dd3267d9918e3f5e7c36af5807cec7c783f",
+      "paths": [
+        "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-02-photo-1518732714860-b62714ce0c59.jpg",
+        "agent-skills/web-design/number-details/demo/assets/page-02-photo-1518732714860-b62714ce0c59.jpg"
+      ]
+    }
+  ],
+  "skillRecordCount": 88,
+  "categoryCounts": {
+    "core": 37,
+    "style": 27,
+    "vendor": 15,
+    "composite": 9
+  },
+  "dispositionCounts": {
+    "adopted": 34,
+    "covered-existing": 41,
+    "rejected": 13
+  },
+  "parts": [
+    {
+      "kind": "tree",
+      "path": "mengto-web-techniques--202608/tree.json",
+      "sha256": "8553ba239196550dd825f979cb78001cf3f5b67bb96538256c5f46ce63c90909",
+      "recordCount": 926
+    },
+    {
+      "kind": "skills",
+      "path": "mengto-web-techniques--202608/skills.json",
+      "sha256": "26f28a0ee7df41af36984c4eb64e8c128097852453e9194927128dcd9b7139fb",
+      "recordCount": 88
+    }
+  ]
+}

--- a/knowledge/sources/mengto-web-techniques--202608/skills.json
+++ b/knowledge/sources/mengto-web-techniques--202608/skills.json
@@ -1,0 +1,1038 @@
+{
+  "expected": {
+    "skillRecordCount": 88,
+    "categoryCounts": {
+      "core": 37,
+      "style": 27,
+      "vendor": 15,
+      "composite": 9
+    },
+    "dispositionCounts": {
+      "adopted": 34,
+      "covered-existing": 41,
+      "rejected": 13
+    }
+  },
+  "schemaVersion": 1,
+  "skills": [
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles.",
+      "skill": "add-mouse-driven-orbit",
+      "techniqueIds": [
+        "MOT-07"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract.",
+      "skill": "add-shader-cursor-trail",
+      "techniqueIds": []
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection.",
+      "skill": "agency-grid-layout-minimal",
+      "techniqueIds": [
+        "LAY-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt bounded canvas ambient particles with density and lifecycle constraints.",
+      "skill": "ambient-section-particles",
+      "techniqueIds": [
+        "MOT-10"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by viewport reveal motion primitive and entrance motion floor.",
+      "skill": "animation-on-scroll",
+      "techniqueIds": [
+        "MOT-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by existing motion selection system and tier ladder choreography.",
+      "skill": "animation-systems",
+      "techniqueIds": [
+        "SYS-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt layered atmospheric light background device with static fallback.",
+      "skill": "atmosphere-background",
+      "techniqueIds": [
+        "SUR-09"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps.",
+      "skill": "background-grid-webgl",
+      "techniqueIds": [
+        "FX-01"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor package snapshot and state decoration without core design value.",
+      "skill": "beam-glow-states",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by elevation ramp surface device and depth rubric.",
+      "skill": "beautiful-shadows",
+      "techniqueIds": [
+        "SUR-04"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by atmospheric light device and standard page structures.",
+      "skill": "blue-cloudy-clean-modern",
+      "techniqueIds": [
+        "SUR-09"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by glass surface and laser accent signature devices.",
+      "skill": "blue-laser-clean-glass-layout",
+      "techniqueIds": [
+        "SUR-05",
+        "DET-03"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns.",
+      "skill": "book-serif-index",
+      "techniqueIds": []
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and lit 3D object effect.",
+      "skill": "bright-green-tech-system-webgl",
+      "techniqueIds": [
+        "FX-04"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Subjective quality label and over-broad bundle without concrete primitives.",
+      "skill": "build-awwwards-quality-sites",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling.",
+      "skill": "build-interactive-particle-trail",
+      "techniqueIds": [
+        "MOT-09"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor.",
+      "skill": "build-threejs-scroll-worlds",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression.",
+      "skill": "build-wireframe-scan-reveal",
+      "techniqueIds": [
+        "MOT-11"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by motion selection system and GSAP scene direction.",
+      "skill": "cinematic-gsap-lenis-motion-system",
+      "techniqueIds": [
+        "SYS-01",
+        "STR-02"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by cinematic chapters page structure and existing motion contracts.",
+      "skill": "cinematic-scroll-storytelling",
+      "techniqueIds": [
+        "STR-02"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure.",
+      "skill": "clean-minimal-beige-light-mode",
+      "techniqueIds": []
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and no distinct contract.",
+      "skill": "cobejs",
+      "techniqueIds": []
+    },
+    {
+      "category": "vendor",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/generation-craft-defaults.md"
+      ],
+      "reason": "Covered by logo truth and sourcing craft defaults.",
+      "skill": "company-logos",
+      "techniqueIds": [
+        "AST-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules.",
+      "skill": "container-lines",
+      "techniqueIds": [
+        "LAY-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt chamfered surface device with clip-path and focus constraints.",
+      "skill": "corner-diagonals",
+      "techniqueIds": [
+        "SUR-07"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices.",
+      "skill": "corner-lasers",
+      "techniqueIds": [
+        "DET-03"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt CSS alpha mask surface device with horizontal and vertical variants.",
+      "skill": "css-alpha-masking",
+      "techniqueIds": [
+        "SUR-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback.",
+      "skill": "css-border-gradient",
+      "techniqueIds": [
+        "SUR-02"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by persona styling, gradient edge, and atmospheric light.",
+      "skill": "dark-blue-contrasting-clean",
+      "techniqueIds": [
+        "SUR-02",
+        "SUR-09"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and glass surface device.",
+      "skill": "dark-glass-clean-layout",
+      "techniqueIds": [
+        "SUR-05"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ordered dither field effect with Bayer thresholding and DPR scaling.",
+      "skill": "dither-background",
+      "techniqueIds": [
+        "SUR-08",
+        "FX-10"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition.",
+      "skill": "dither-laser-dark-mode",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt documentary portfolio story structure with irregular collages and chapter alternation.",
+      "skill": "documentary-brutalist-agency",
+      "techniqueIds": [
+        "STR-09"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions.",
+      "skill": "editorial-portfolio-chapters",
+      "techniqueIds": [
+        "STR-03"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt service booking story structure with truthful operational and error states.",
+      "skill": "editorial-service-booking",
+      "techniqueIds": [
+        "STR-04"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions.",
+      "skill": "editorial-tech",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ambient particle foliage specialization with coupled tumble and slip.",
+      "skill": "falling-leaves",
+      "techniqueIds": [
+        "MOT-10"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and corner bracket detail devices.",
+      "skill": "framed-grid-layout",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and gradient edge surface devices.",
+      "skill": "framed-tech-dark-border-gradient",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-02"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout combined with color persona tokens.",
+      "skill": "funky-purple-container-tech",
+      "techniqueIds": [
+        "LAY-01"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by glass surface device and specimen page structure.",
+      "skill": "glass-dark-mode-clock",
+      "techniqueIds": [
+        "SUR-05"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by glass surface, gradient edge, and depth rubric constraints.",
+      "skill": "glass-dark-ui",
+      "techniqueIds": [
+        "SUR-05",
+        "SUR-02"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and redundant runtime dependencies.",
+      "skill": "globe-gl",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal.",
+      "skill": "globe-particles",
+      "techniqueIds": [
+        "FX-03"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms.",
+      "skill": "gooey-blob-system",
+      "techniqueIds": [
+        "SUR-10"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance.",
+      "skill": "gsap",
+      "techniqueIds": []
+    },
+    {
+      "category": "composite",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts.",
+      "skill": "gsap-scrolltrigger-storytelling",
+      "techniqueIds": [
+        "STR-02"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection.",
+      "skill": "high-contrast-skeuomorphic-clean",
+      "techniqueIds": [
+        "SUR-06"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures.",
+      "skill": "image-first-grid-layout",
+      "techniqueIds": [
+        "LAY-01"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by single-offer page structure and conversion evidence hierarchy.",
+      "skill": "landing-page",
+      "techniqueIds": [
+        "STR-07"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens.",
+      "skill": "light-mode-paper-technical",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Package-specific costly decorative shader without general architectural value.",
+      "skill": "liquid-metal-border",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules.",
+      "skill": "marquee-loop",
+      "techniqueIds": [
+        "MOT-04"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics.",
+      "skill": "masked-reveal",
+      "techniqueIds": [
+        "MOT-02"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Physics engine wrapper lacking a justified design system gap.",
+      "skill": "matterjs",
+      "techniqueIds": []
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/shader-gradient-direction.md"
+      ],
+      "reason": "Covered by shader gradient direction and brand persona styling.",
+      "skill": "mesh-gradient-dark-blue-clean",
+      "techniqueIds": []
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules.",
+      "skill": "nested-container-clean-agency",
+      "techniqueIds": [
+        "LAY-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints.",
+      "skill": "nested-container-frames",
+      "techniqueIds": [
+        "LAY-01"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices.",
+      "skill": "number-details",
+      "techniqueIds": [
+        "DET-01"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt enterprise proof story structure with audit and rollback workflows.",
+      "skill": "operational-enterprise-ai",
+      "techniqueIds": [
+        "STR-05"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by feature stack structure and paper persona token palette.",
+      "skill": "orange-clean-paper-saas",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter motion primitive with ring-buffer and idle breath.",
+      "skill": "pointer-trail-emitter",
+      "techniqueIds": [
+        "MOT-09"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt pricing comparison story structure with honest table fallbacks.",
+      "skill": "pricing-page",
+      "techniqueIds": [
+        "STR-08"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt product proof story structure with deterministic hero demonstrations.",
+      "skill": "product-proof-saas",
+      "techniqueIds": [
+        "STR-06"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands.",
+      "skill": "progressive-blur",
+      "techniqueIds": [
+        "SUR-03"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant.",
+      "skill": "reveal-hover-effect",
+      "techniqueIds": [
+        "MOT-08"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt progress story motion primitive with semantic ordered-list baseline.",
+      "skill": "scroll-progress-timeline",
+      "techniqueIds": [
+        "MOT-05"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt reversible sequence motion primitive with normalized progress and preloading.",
+      "skill": "scroll-scrubbed-visual-sequence",
+      "techniqueIds": [
+        "MOT-06"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt scrubbed semantic text primitive preserving inline formatting and rewrapping.",
+      "skill": "scroll-scrubbed-word-reveal",
+      "techniqueIds": [
+        "MOT-03"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM.",
+      "skill": "scroll-world-storytelling",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Component-specific WebGPU shader wrapper without core design abstraction.",
+      "skill": "shaders-cursor-ripples",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation.",
+      "skill": "skeuomorphic-ui",
+      "techniqueIds": [
+        "SUR-06"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules.",
+      "skill": "solar-duotone-bold",
+      "techniqueIds": []
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures.",
+      "skill": "split-layout-technical",
+      "techniqueIds": [
+        "LAY-02"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt staggered semantic text primitive with DOM-safe word reveal.",
+      "skill": "staggered-word-reveal",
+      "techniqueIds": [
+        "MOT-02"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Framework implementation wrapper belonging outside core design knowledge.",
+      "skill": "tailwindcss",
+      "techniqueIds": []
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, atmospheric light, and persona tokens.",
+      "skill": "tech-green-dark-mode-modern",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-09"
+      ]
+    },
+    {
+      "category": "style",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion.",
+      "skill": "technical-wireframe-info-layout",
+      "techniqueIds": [
+        "MOT-11"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Package wrapper for status states covered by general accessibility.",
+      "skill": "thinking-orbs",
+      "techniqueIds": []
+    },
+    {
+      "category": "vendor",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Covered by existing Three.js scene contracts and effect guidance.",
+      "skill": "threejs",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt landscape canvas effect with polar-grid LOD and time transitions.",
+      "skill": "threejs-landscape",
+      "techniqueIds": [
+        "FX-05"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt procedural architecture effect with clipping plane assembly sequences.",
+      "skill": "threejs-towers",
+      "techniqueIds": [
+        "FX-06"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt weather system canvas effect with frustum-anchored precipitation models.",
+      "skill": "threejs-weather",
+      "techniqueIds": [
+        "FX-07"
+      ]
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Hosted embed runtime wrapper violating self-contained knowledge architecture.",
+      "skill": "unicorn-studio",
+      "techniqueIds": []
+    },
+    {
+      "category": "vendor",
+      "disposition": "rejected",
+      "existingKnowledgeRefs": [],
+      "reason": "Preset library wrapper causing dependency drift and generic outputs.",
+      "skill": "vantajs",
+      "techniqueIds": []
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks.",
+      "skill": "webgl-3d-object",
+      "techniqueIds": [
+        "FX-04"
+      ]
+    },
+    {
+      "category": "composite",
+      "disposition": "covered-existing",
+      "existingKnowledgeRefs": [
+        "knowledge/prompt-plan-orchestration.md"
+      ],
+      "reason": "Covered by effect budgeting and orchestrator quality governor contracts.",
+      "skill": "webgl-landing-steering",
+      "techniqueIds": [
+        "SYS-01",
+        "SYS-04",
+        "SYS-06"
+      ]
+    },
+    {
+      "category": "core",
+      "disposition": "adopted",
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls.",
+      "skill": "webgl-laser",
+      "techniqueIds": [
+        "FX-09"
+      ]
+    }
+  ],
+  "upstream": {
+    "repository": "https://github.com/MengTo/Skills.git",
+    "revision": "4c716b516b6b0143f3037631306b3730d2832344",
+    "capturedAt": "2026-08-21T00:27:35Z",
+    "rootLicense": "MIT",
+    "rootLicenseEvidence": {
+      "path": "LICENSE",
+      "mode": "100644",
+      "gitObjectId": "b3a5f823a69b4b010f92930ac09e8a776daf65c6",
+      "byteCount": 1064,
+      "sha256": "b2a071ba22fefd803f4e9d1f5c777dd79c62d191695586a1a73fd4d0ebd051c6"
+    }
+  }
+}

--- a/knowledge/sources/mengto-web-techniques--202608/tree.json
+++ b/knowledge/sources/mengto-web-techniques--202608/tree.json
@@ -1,0 +1,17063 @@
+{
+  "schemaVersion": 1,
+  "kind": "tree",
+  "records": [
+    {
+      "path": "agent-skills/web-design/README.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e0c3fc7704eba238b088ba8e592c46044d77beb4",
+      "byteCount": 275,
+      "sha256": "766e4d870e8940b48e8f640fc96b94f2d3997d0210ef361181be7d0a43f1b78b",
+      "artifactClass": "root-support",
+      "ownerSkill": null,
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-support-only",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Root support metadata only"
+    },
+    {
+      "path": "agent-skills/web-design/WEB-DESIGN-SKILLS.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "40c0319d22f1e14261d20c2c776fcfeeb285c43d",
+      "byteCount": 1130,
+      "sha256": "221e2980bb6b0a4d9f0b56f1989aaa0f6f2a23848c4650472dbbb9d6c1ad3bd9",
+      "artifactClass": "root-support",
+      "ownerSkill": null,
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-support-only",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Root support metadata only"
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7d9d5de0626dfa438f16dfdc076a4a1f7911b8c3"
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e045843d41df7bd8e3aa00eab8e51b19ae85bb5d",
+      "byteCount": 5960,
+      "sha256": "1f470eb9a8086d1083d20d9c8bc3558ad9d6e4207d9e5bedb3560d7ddac494d7",
+      "artifactClass": "skill",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ac945b58fe175bf29230c7335392c134ce8c7e32"
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b66b1325ad00f15fe6da446b75bc7c34f513f073",
+      "byteCount": 244,
+      "sha256": "23140121088c38b3fb445ed5b49dc59982d46aef824a93790076bfe684548b2c",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "314d890b12cf3fa4bd2c8cd79e539dcea33ac90b"
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3c98a3c3354b511bc69bdcac9dcf9179043bd425",
+      "byteCount": 1743,
+      "sha256": "fba31cc71de007c345c59af7a6f225b403e9f14d86ebee8fe355a5d197ee5ec4",
+      "artifactClass": "prompt",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cc05cedde114c5a13d842fc6bf964ea773b900db"
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo/assets/card-ethos.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e4162efb93c89d1d20ffa0cde746dfdceeb537ea",
+      "byteCount": 316720,
+      "sha256": "337627390f499b3ae272cec9e2f83c817694a82f42e1aa10a7b26a2c7d679dff",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo/assets/lexend-latin.woff2",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0968c152f1c0d617a90bd843fa3d510c336af085",
+      "byteCount": 39692,
+      "sha256": "1ec8f6ee2750554b4bc59ff0b507d316a82a7ba37e0e5bebc41d3bd9b9faad46",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo/assets/three.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4494cf4e8d37049896b6051da6edfe44a83355af",
+      "byteCount": 608081,
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ee5ef5890bd8d3cbde79c0ecf641aeeb8425654a",
+      "byteCount": 13364,
+      "sha256": "bb20ee38c79574fdc2578d4a6a3c04696b874f1f955651354a58da652402d0a5",
+      "artifactClass": "demo-html",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-mouse-driven-orbit/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1c7b8203594c81ec803c07619cb9b3b9e7fb2b1b",
+      "byteCount": 109507,
+      "sha256": "da32d2566298afa234a66671f5f0910521c190851cfedc3dbb03241362225522",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "add-mouse-driven-orbit",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt damped pointer parallax and clamp mechanics from first principles."
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ab4263f9111eba088cf7483211a9ce3cb0cc67f4"
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8292c5e8518d3d547f1cda690408f69c7c6ca4e3",
+      "byteCount": 3038,
+      "sha256": "b2d32575e2a433145200c3f466d46aa4692f726efbfe32db39c0524caa7e107d",
+      "artifactClass": "skill",
+      "ownerSkill": "add-shader-cursor-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract."
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cfd8a4bdd19ff4423b7f69a5612dab9ac988dbd3"
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9e9773166bf80b7dc518981f39dfc71f124e2816",
+      "byteCount": 251,
+      "sha256": "5d5ae7c31a6169290de75f1aa67978b09c772f4137b4a5818d038c3dfd639e00",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "add-shader-cursor-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract."
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "22e14097b024fe3189ddd2dbdf3ec7bf05988a74"
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/assets/react",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "14d105e0caec2f4140dfc461624435ae95fc9aea"
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/assets/react/CursorTrailGate.tsx",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "aef2d73690d4d9fd5d55bd820ad9d897c72b9dfa",
+      "byteCount": 2923,
+      "sha256": "43caefb93182f28be89d9acc6b196c6b6e86856a08e11368502ba0de29cd6b20",
+      "artifactClass": "authored-code",
+      "ownerSkill": "add-shader-cursor-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract."
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/assets/react/CursorTrailShader.tsx",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cbf6dc2342d6b5c84a2e42ffdf81e43360fc0467",
+      "byteCount": 1829,
+      "sha256": "799bc4fb30f27034c09eac2ef22be63a00058813f0fd6e82cdd84de29518f414",
+      "artifactClass": "authored-code",
+      "ownerSkill": "add-shader-cursor-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract."
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/assets/react/cursor-trail.css",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d14d3bd6dbf8efbbf9067eed93d26188b2f64db3",
+      "byteCount": 817,
+      "sha256": "5f3edf392ef95ff77e53d2b7af4d1e58bebae8fba259d37afb4cb4eb33fa798a",
+      "artifactClass": "authored-code",
+      "ownerSkill": "add-shader-cursor-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract."
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/references",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fcf5789184f4b52170a5f5a61be2b73e2cb1db36"
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/references/implementation.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "27af78cc5c61fbc4720d6c472deb97b0e2b9915b",
+      "byteCount": 5402,
+      "sha256": "614796c67477d5b3cab564023ba7284c92fc0ad1f9acaa6eed3c368666324b91",
+      "artifactClass": "reference/article",
+      "ownerSkill": "add-shader-cursor-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract."
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/scripts",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "aec1c2e6a390331cb68d1be0a98e997225c3a547"
+    },
+    {
+      "path": "agent-skills/web-design/add-shader-cursor-trail/scripts/verify-cursor-trail.mjs",
+      "mode": "100755",
+      "objectType": "blob",
+      "gitObjectId": "0673c0f62bb62244857f65dac6c7fdf5a98c1806",
+      "byteCount": 2945,
+      "sha256": "543f870ee86ba7689ef659f2072aafc993b16b1e1438ce2500488b51ffccd590",
+      "artifactClass": "authored-code",
+      "ownerSkill": "add-shader-cursor-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor-specific WebGPU shader graph without a general design contract."
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "dea998d08b722c70f482c67a63861ad30685559e"
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2731b7a5aec6177e4162f2ab1e54c0793434c96b",
+      "byteCount": 4115,
+      "sha256": "1787eba87fef34cf72219d0016de89910e19e383f6b01d250a11e9490a93018e",
+      "artifactClass": "skill",
+      "ownerSkill": "agency-grid-layout-minimal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "704c7a74ec07744ecd40a13f851a319e5415f901"
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7d6f429e392383a3e7c36271e3caab2d7e56cf25",
+      "byteCount": 3316,
+      "sha256": "63b7443a9c97cf2aeb51b581ddfdca648f4c628d096a386b09e156befedb9fbb",
+      "artifactClass": "prompt",
+      "ownerSkill": "agency-grid-layout-minimal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6bb638416d79f5fd4c63ca53cf44d3cb160af0e6"
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo/assets/page-01-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2d791d66906a67e0bbd80e16d8a37f577798a7dd",
+      "byteCount": 282854,
+      "sha256": "0d71068ad67cbdbfca87b5e5f57f21fbb47fb29148e2ae8d2e1a5df136ea5cfc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "agency-grid-layout-minimal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5abde1b0b2bc2657b8f52e23bcff4bf6f0fa80a3",
+      "byteCount": 69211,
+      "sha256": "73225f81abf91a821597aae8b6e93cc7cab2e919b7e840007be17180f0a8c2e3",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "agency-grid-layout-minimal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "00c9c6414eb4e01a1796109e8c9757a3a45ad4f6",
+      "byteCount": 17148,
+      "sha256": "e40b8d26e3081ab6d7992d2a54ea97ff08773c8f35eed1fb4880a1c74d3b1c9e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "agency-grid-layout-minimal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e9aaf446ea00b4f44532b5b2bdf7f2eae74459e1",
+      "byteCount": 76863,
+      "sha256": "3d0ddb8e0fa6c6f9fc8fd6969f4234a538ae568d71cfa68146ff81b09601f0e6",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "agency-grid-layout-minimal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/agency-grid-layout-minimal/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c82dae7250e279208fdad09beb10bf4fdd166eae",
+      "byteCount": 2596,
+      "sha256": "8a303c502d044ca50eb8f8c3f8454544964775c48199b361612566c9d2342eef",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "agency-grid-layout-minimal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and existing persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cdaea7a1aa476ecbc80557676eab7a73e4c4c7f3"
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7b415a697779c05ed5adfe215bcefd8c6a9abd82",
+      "byteCount": 507,
+      "sha256": "1d6184ba2de8743af698f3a9278f781018a2cd47ae5cacbdb44e9ac8b51afd19",
+      "artifactClass": "reference/article",
+      "ownerSkill": "ambient-section-particles",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt bounded canvas ambient particles with density and lifecycle constraints."
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4beca95ab7da396a3aeb8cbe0a1dc192751bd48d",
+      "byteCount": 4081,
+      "sha256": "b6fcbde40049c0bae9a8b0e5a9249717b828bb7d64b816fd4ac1d29c5318bb48",
+      "artifactClass": "skill",
+      "ownerSkill": "ambient-section-particles",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt bounded canvas ambient particles with density and lifecycle constraints."
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "14bc76a5779813edd234f1c382b2bf78a9b5ef15"
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6a069bf104a6f8a9464b5fc3a67f1b225d2568a7",
+      "byteCount": 244,
+      "sha256": "67a288457ccfa9b816b6634b888d66db578787451dc1791b3257d98a8321d832",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "ambient-section-particles",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt bounded canvas ambient particles with density and lifecycle constraints."
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2c73051243bdb890e6e54ee7a16d59e0f5d2b270"
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "331ba7021d2f8b43afc1e7b225d6f54c747b463a",
+      "byteCount": 1888,
+      "sha256": "f39f5c22ba63ce89a7f6fdf7feb9b3efc8af0b5b57477b1ccf15f4ae81ee1ecb",
+      "artifactClass": "prompt",
+      "ownerSkill": "ambient-section-particles",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt bounded canvas ambient particles with density and lifecycle constraints."
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "510cda2f2de506dfbb52cb784cd42b9f953ac56f",
+      "byteCount": 11030,
+      "sha256": "9a94aa6e8c888ac67f544de4e6cdf8e86d8314ab09aadf4d84fc330fb669626b",
+      "artifactClass": "demo-html",
+      "ownerSkill": "ambient-section-particles",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt bounded canvas ambient particles with density and lifecycle constraints."
+    },
+    {
+      "path": "agent-skills/web-design/ambient-section-particles/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3393714dede863f7ac7d72435de3b43f35d23f77",
+      "byteCount": 82557,
+      "sha256": "b11b2b6e2b3430e7e5b1b45215e49c0408ace515e80e395ba3d19757cbd2179a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "ambient-section-particles",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt bounded canvas ambient particles with density and lifecycle constraints."
+    },
+    {
+      "path": "agent-skills/web-design/animation-on-scroll",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "08dea165fd3356b8d720179d7a86488af54b90f4"
+    },
+    {
+      "path": "agent-skills/web-design/animation-on-scroll/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "86cdba41dee9eeb27ae7b7dcced46ade232f1b0e",
+      "byteCount": 3549,
+      "sha256": "4c9c795a9d5d8f7baf0b141394ebc0a4fd30e22234b37ff63fbf38e7cceefadf",
+      "artifactClass": "skill",
+      "ownerSkill": "animation-on-scroll",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by viewport reveal motion primitive and entrance motion floor."
+    },
+    {
+      "path": "agent-skills/web-design/animation-on-scroll/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "282414f3bf52235af73d531d0c18b79376905643"
+    },
+    {
+      "path": "agent-skills/web-design/animation-on-scroll/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2f5496000307fac6f8da87f71285125e160f2621",
+      "byteCount": 1963,
+      "sha256": "e18776ff915b4df2e8e7dc6bea74f842f0c1010d54a4aa8093cfa957ca004388",
+      "artifactClass": "prompt",
+      "ownerSkill": "animation-on-scroll",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by viewport reveal motion primitive and entrance motion floor."
+    },
+    {
+      "path": "agent-skills/web-design/animation-on-scroll/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e9b0a915eb134696dcf572cfc30c7e7df14649d1",
+      "byteCount": 16448,
+      "sha256": "c7b4a8edd4169600cf4bb16fd21063e65518b5798e7dc1778d1186d343e4b28c",
+      "artifactClass": "demo-html",
+      "ownerSkill": "animation-on-scroll",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by viewport reveal motion primitive and entrance motion floor."
+    },
+    {
+      "path": "agent-skills/web-design/animation-on-scroll/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a7d6bfbba6c8099e7435d0ab1f71669d3874d6fa",
+      "byteCount": 63365,
+      "sha256": "e09d7c0297d0653c35b19ac3fb846197493e6f2d23a8be719080ba77f1ba12d2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "animation-on-scroll",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by viewport reveal motion primitive and entrance motion floor."
+    },
+    {
+      "path": "agent-skills/web-design/animation-systems",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "bf996794e50c4796a24974410dbf92bb88add677"
+    },
+    {
+      "path": "agent-skills/web-design/animation-systems/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bfba54e968cc09d063e8d60765b24022d998cf31",
+      "byteCount": 5237,
+      "sha256": "ae1e51b8eede6f4d05fda5388f61bbc1d29ea88b7a5d7a488c3ecfed5f18e262",
+      "artifactClass": "skill",
+      "ownerSkill": "animation-systems",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by existing motion selection system and tier ladder choreography."
+    },
+    {
+      "path": "agent-skills/web-design/animation-systems/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "38ab3357ef356ef6befa5b69c463431722978778"
+    },
+    {
+      "path": "agent-skills/web-design/animation-systems/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "05d7306f3dc5fa93d927474d9181493a8442d1c8",
+      "byteCount": 1994,
+      "sha256": "ba893eb277a327426b7944723862b7f86341f7f516ee10d95312a1a14d2004d5",
+      "artifactClass": "prompt",
+      "ownerSkill": "animation-systems",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by existing motion selection system and tier ladder choreography."
+    },
+    {
+      "path": "agent-skills/web-design/animation-systems/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "006ae8c1cf378dbdb0fc953e95fe2cee08d47dd4",
+      "byteCount": 16478,
+      "sha256": "0a341940fb3a7b25bca336bcbce79cdacc4bfb0d1d18f93ce60348c591b36b37",
+      "artifactClass": "demo-html",
+      "ownerSkill": "animation-systems",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by existing motion selection system and tier ladder choreography."
+    },
+    {
+      "path": "agent-skills/web-design/animation-systems/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b88a1799b09dd126f9b19011f93adbca763b228f",
+      "byteCount": 65371,
+      "sha256": "24822f450b86b08340694a6d690fe06ffbb758c745181b803b91da940c3232d7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "animation-systems",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Covered by existing motion selection system and tier ladder choreography."
+    },
+    {
+      "path": "agent-skills/web-design/atmosphere-background",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4b56ef313e1fffdb4984c9c5ec1a0fe2e70e6ac3"
+    },
+    {
+      "path": "agent-skills/web-design/atmosphere-background/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e2c6893fd8ee9d944ebf70f072e66567fda512c3",
+      "byteCount": 3026,
+      "sha256": "ded4a155cf5676f2aab3f1873634e08766ad31aa6ae1107e5a29c114dc1cf213",
+      "artifactClass": "skill",
+      "ownerSkill": "atmosphere-background",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt layered atmospheric light background device with static fallback."
+    },
+    {
+      "path": "agent-skills/web-design/atmosphere-background/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d8e87d2c4a53583947f9bd6d0337dc100597c1ed"
+    },
+    {
+      "path": "agent-skills/web-design/atmosphere-background/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "90acb256fe8e30527a051ef8027d8249188dd5f2",
+      "byteCount": 1887,
+      "sha256": "9f7588d7aa5f72f9e3a0975ee633ea4215a3d23b516edf913713c5d808b7e854",
+      "artifactClass": "prompt",
+      "ownerSkill": "atmosphere-background",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt layered atmospheric light background device with static fallback."
+    },
+    {
+      "path": "agent-skills/web-design/atmosphere-background/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e0e57f3e6e9ae2117e4d461ffef8f20f92b02e3a",
+      "byteCount": 16276,
+      "sha256": "f53b781e08d77c2d8ae88df62d684197c7b1d37c4aeffb6ff3480b1d2536f14f",
+      "artifactClass": "demo-html",
+      "ownerSkill": "atmosphere-background",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt layered atmospheric light background device with static fallback."
+    },
+    {
+      "path": "agent-skills/web-design/atmosphere-background/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d54808f65020cbea2ea3d10b8e913df66009816b",
+      "byteCount": 54008,
+      "sha256": "78c2f784b997defd1b6da94da8d40db77cff2e7ff4ae2ff6528b512166e301e2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "atmosphere-background",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt layered atmospheric light background device with static fallback."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4dfbeb61a4d057140da6ab6793f2cb452a3ff94d"
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8bd40421adcbaf7600550d252e1c7618dd272be0",
+      "byteCount": 2622,
+      "sha256": "07c155855b67a96cbb4d51d82696fe9550c2670a13a30fb6b71506d5c0685457",
+      "artifactClass": "skill",
+      "ownerSkill": "background-grid-webgl",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ccc87e62d05cc7a1df4832d8cd151a6be3cc32b8"
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9bc8875fd07d4e46302e10273aff9a4154d3d413",
+      "byteCount": 3265,
+      "sha256": "a281b1e611d3c019e2ca0ba318c2d2ebd08cee5d3ab1f9a3855b0919e43040d9",
+      "artifactClass": "prompt",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9ccc59f2c87b29a47c003048cf6c0d26f944029f"
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "764233ff37fe552c54ee65be0329754f008a9577",
+      "byteCount": 362749,
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "072de2e20e298844fb880a2cf82fec2cca237d75",
+      "byteCount": 73780,
+      "sha256": "97c65569d294acbb5072f963eec2f67f57fd3e8fbba84cfa9a1bfe5042e92d54",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c038b784376e3d3e62eb2dbcfc1133ff787344c9",
+      "byteCount": 21909,
+      "sha256": "7abbd51e4c973de2df8ce06f7b1f24f9c20cbfc4cabb0438b88e80177d26f50e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "51293b8a90effa1345cb2b18244184b97468cee8",
+      "byteCount": 55602,
+      "sha256": "8d00a113ca7d02f5f2159d618c48355835efbacc641292cafa9761bdbdb8ab27",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/background-grid-webgl/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d613c99102562cbd83a0fe498c5bfec1fef41154",
+      "byteCount": 3291,
+      "sha256": "9f63564b403e2373f62a1838e72f2d8f433ded4536f375ac0ac6ab52f1747555",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "background-grid-webgl",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt perspective grid canvas effect with fog fade and DPR caps."
+    },
+    {
+      "path": "agent-skills/web-design/beam-glow-states",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d1d07fef87627aab454de86776ffb5d354151606"
+    },
+    {
+      "path": "agent-skills/web-design/beam-glow-states/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "560fb1f51a5331e0adbfa7dde4106d7524a852c3",
+      "byteCount": 1169,
+      "sha256": "a09f565e34ffd576b6ad616e6548fa604887cd57f15fd13eb13f85d4a2612e08",
+      "artifactClass": "reference/article",
+      "ownerSkill": "beam-glow-states",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor package snapshot and state decoration without core design value."
+    },
+    {
+      "path": "agent-skills/web-design/beam-glow-states/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "aa65bee487b9733c748795f79b6b27895bb5640b",
+      "byteCount": 12750,
+      "sha256": "64f45d22ad8288e2716fddc4375df9f34e9655a26e3cbb3d1ed6da3fd25d3f49",
+      "artifactClass": "skill",
+      "ownerSkill": "beam-glow-states",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor package snapshot and state decoration without core design value."
+    },
+    {
+      "path": "agent-skills/web-design/beam-glow-states/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fbc1d68532fb780670ca2c9dfe561badb23d0f7b"
+    },
+    {
+      "path": "agent-skills/web-design/beam-glow-states/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "72c8a854258ecd9306284a416f7a41285dc035aa",
+      "byteCount": 228,
+      "sha256": "18d026672c34cc03d4c4e00794dd46b874c9fddb97e86645bca8b695eed7d2cb",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "beam-glow-states",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor package snapshot and state decoration without core design value."
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "66dd37b22e364fac3d312023123da3dc2b342188"
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "384699e2e4c3dc0bc979f9ad3f1aea811fb4ab94",
+      "byteCount": 2540,
+      "sha256": "10b6cc0964919118218ffe0845e4a00954f39788d89d4ec29827d100f254e135",
+      "artifactClass": "skill",
+      "ownerSkill": "beautiful-shadows",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by elevation ramp surface device and depth rubric."
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cbd1d830b6a082ffde0e90ac0279242eaa6101b9"
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3b17f27fad07c095f5012bc8bb6f06be2ec4fd6f",
+      "byteCount": 3447,
+      "sha256": "b466829825dc77354b05c3ec6e21da024ca8494b8e2468dafee470b63490f5c6",
+      "artifactClass": "prompt",
+      "ownerSkill": "beautiful-shadows",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by elevation ramp surface device and depth rubric."
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fef98744e0a572e289ed1b820c9dfa806564f9d2"
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6c85ab398913b55fa406929309aab5a17492c4ab",
+      "byteCount": 96070,
+      "sha256": "cea85a39224a0cac5523629063a71ff13a173ffce2d347f029ea567e994472a6",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "beautiful-shadows",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by elevation ramp surface device and depth rubric."
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "719809cf2531c9529d0b5bd2e4c0443757a98fa3",
+      "byteCount": 27386,
+      "sha256": "21f51f52256cc0c08deb82e954ba0418fa8319ed9a36277902c005842b105b96",
+      "artifactClass": "demo-html",
+      "ownerSkill": "beautiful-shadows",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by elevation ramp surface device and depth rubric."
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e0f96e915b01c505bc9abe0a49b213557fe57e1f",
+      "byteCount": 56266,
+      "sha256": "b5ab94f9f1b16aa7b52d7ef9d9168ad696b9eb0ad53a812ff8517a33c3af4903",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "beautiful-shadows",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by elevation ramp surface device and depth rubric."
+    },
+    {
+      "path": "agent-skills/web-design/beautiful-shadows/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "31721e2cf12343c86063359a37a2c0bb3075a9cd",
+      "byteCount": 3054,
+      "sha256": "05cc0ff186d5c3990033a2f00a08bb1bc19805998984be7a74a0e6be0a100585",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "beautiful-shadows",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by elevation ramp surface device and depth rubric."
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "0a152ad5b3ddd46f556386881df485df2765fa2a"
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c738b8edbcd5efebfe0cc3f180e5cf1a75eb2b87",
+      "byteCount": 4170,
+      "sha256": "212618080012349f13e1c8819048e62e9c6193b8b2d2a5e33d219ce487c5e305",
+      "artifactClass": "skill",
+      "ownerSkill": "blue-cloudy-clean-modern",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by atmospheric light device and standard page structures."
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2cab4602570726211d7ec571cab3ccfa2da4b1f9"
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "670cb4ddf830a1304746e54cedf7b16ba85408c8",
+      "byteCount": 3316,
+      "sha256": "93e4318f2594bd708fbccc1620452803d11382430c496e5fc89d7ff6d6317259",
+      "artifactClass": "prompt",
+      "ownerSkill": "blue-cloudy-clean-modern",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by atmospheric light device and standard page structures."
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "07a4f009763507b3926bdd438995f441701c2a3d"
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "964fa5c4accb3f7f634c7e61977e81e52f8f6340",
+      "byteCount": 82586,
+      "sha256": "69b42df6877524620ccceafc9107dbe5d8dc18385d3a52425c981b12b95e7def",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "blue-cloudy-clean-modern",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by atmospheric light device and standard page structures."
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a8c76035d8ef32d20d8207d321afd72586f476ed",
+      "byteCount": 41430,
+      "sha256": "76137223e114d4b62228c0bea1c60abcd2feb3b63f0fe80c68110cb4b9616e07",
+      "artifactClass": "demo-html",
+      "ownerSkill": "blue-cloudy-clean-modern",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by atmospheric light device and standard page structures."
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "54346e36cf79a46ad4e03915ddcd93c02b840152",
+      "byteCount": 62518,
+      "sha256": "ff89eb22e9190578b4ca8ee774d89fd83fcb852a35331317c222a26ac250d17a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "blue-cloudy-clean-modern",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by atmospheric light device and standard page structures."
+    },
+    {
+      "path": "agent-skills/web-design/blue-cloudy-clean-modern/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fdafed8912c0a4a7ec333d7ddc728f7899c9437d",
+      "byteCount": 2111,
+      "sha256": "aaba424c6682df1897a9c778b7f551927c8eb7da8998b72aaddab46b00f006dc",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "blue-cloudy-clean-modern",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by atmospheric light device and standard page structures."
+    },
+    {
+      "path": "agent-skills/web-design/blue-laser-clean-glass-layout",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ffe78d96af6382408fc8cd0620c9a109d8cfe42c"
+    },
+    {
+      "path": "agent-skills/web-design/blue-laser-clean-glass-layout/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0720e0f192220d4d96379530e43e81caf39851fa",
+      "byteCount": 4379,
+      "sha256": "63cbabae394a24c1b8c4cc98dafc3bfe8c045652b20713f8a3d8edc1061530e0",
+      "artifactClass": "skill",
+      "ownerSkill": "blue-laser-clean-glass-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by glass surface and laser accent signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/blue-laser-clean-glass-layout/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "72bfbbcb9e3593d4d5f40fde2b836b3642d7d7e4"
+    },
+    {
+      "path": "agent-skills/web-design/blue-laser-clean-glass-layout/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5d86003a6eeb8086ff14b5b8ac6b304e3a082abe",
+      "byteCount": 1902,
+      "sha256": "09c24c759807c879ca88611316f2bafd39a6ae7c8b333a4957fe2e8848d91a8d",
+      "artifactClass": "prompt",
+      "ownerSkill": "blue-laser-clean-glass-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by glass surface and laser accent signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/blue-laser-clean-glass-layout/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "59843d49fa990487f4b2c8612c8f878b0748412e",
+      "byteCount": 16855,
+      "sha256": "c6a72513ff1f6ff747ff0cc0714a231593f552887bfe59fcbfada9769dc2d0db",
+      "artifactClass": "demo-html",
+      "ownerSkill": "blue-laser-clean-glass-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by glass surface and laser accent signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/blue-laser-clean-glass-layout/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cae458c537d335e7d0d7772cac476aba422e39b3",
+      "byteCount": 68273,
+      "sha256": "566514e385f32f52b0d93d2e6901096f37a47ecfcebff839273f2a5746a369fc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "blue-laser-clean-glass-layout",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by glass surface and laser accent signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "653e04c4757f99579d3017adcd8eae500686e08e"
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "48dfcfeb20e99051f326ec696c40365484a1142e",
+      "byteCount": 4526,
+      "sha256": "d53a95a47bb0fc7b047445a15e59a2b4bb126d6c8d9caac163378b19bf3948be",
+      "artifactClass": "skill",
+      "ownerSkill": "book-serif-index",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "293ba95b9a110fc9bdcb10fbdc5961eb0152a931"
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "34c38b82abc5204b009eb17822d188b7d080d6b4",
+      "byteCount": 3480,
+      "sha256": "bde5cd58602773f06197c4806ec9769679a85fe21cdb9e19e6cf0460692a1a6f",
+      "artifactClass": "prompt",
+      "ownerSkill": "book-serif-index",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "33a6d67f5a89cd9b13bf6dc15f5a0cf6b365aa58"
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/assets/page-01-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "book-serif-index",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "book-serif-index",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b03b4c0473feb050fe744717c47e12ad85e4d20e",
+      "byteCount": 77990,
+      "sha256": "139418224848e1ef4bd500146a84bb4aea866bd1f42ef59ed30fa5c9ed772fd7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "book-serif-index",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "09e1334c2a5847a2c90c241043d916caf7ba997e",
+      "byteCount": 60033,
+      "sha256": "7dd05e3387c187b35c0cb75a6be200bb8f63ca1f56b62fa1f5c30c93dba731f4",
+      "artifactClass": "demo-html",
+      "ownerSkill": "book-serif-index",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "551f87c5ef504452fc0b8b35c5c6167ee1ca960e",
+      "byteCount": 61720,
+      "sha256": "a5cf0fa729b4a920fd6c2edcb365391095aea2768ae3ff7ad95c76174dcfd580",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "book-serif-index",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/book-serif-index/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0bac40c8d85114cde0b9a56230f81f4c88d5f689",
+      "byteCount": 3697,
+      "sha256": "109238a1d4fd74fc1e558a6f94ef13eafcdce07a539944db4c9cb122aeb2306f",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "book-serif-index",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by index-first and long-document structural page patterns."
+    },
+    {
+      "path": "agent-skills/web-design/bright-green-tech-system-webgl",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "59da149b6a4687de867d99d6bb209c7d93bd9fea"
+    },
+    {
+      "path": "agent-skills/web-design/bright-green-tech-system-webgl/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b83858a6f5e82162ac9434ef7718843de075f5dd",
+      "byteCount": 4430,
+      "sha256": "ba4cf84328189502dbd9c95f42bba68346d303f9b3f41cbc6c922f52fdec2fbf",
+      "artifactClass": "skill",
+      "ownerSkill": "bright-green-tech-system-webgl",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and lit 3D object effect."
+    },
+    {
+      "path": "agent-skills/web-design/bright-green-tech-system-webgl/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f0c0ea63b2cb3b7e059651913a06aba24b13bf94"
+    },
+    {
+      "path": "agent-skills/web-design/bright-green-tech-system-webgl/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74e45c3c5bda929897a86c6fe9927dc3c4cbfbb4",
+      "byteCount": 1940,
+      "sha256": "f2cfdd56e6a7bb6e827256018e6fa3469e14d965482c9f4141f2c9b02db3acfa",
+      "artifactClass": "prompt",
+      "ownerSkill": "bright-green-tech-system-webgl",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and lit 3D object effect."
+    },
+    {
+      "path": "agent-skills/web-design/bright-green-tech-system-webgl/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b4502ba6f0e0b401a25d9e080fcba2f3e7fc4d36",
+      "byteCount": 16496,
+      "sha256": "9fa4ef58ce9409458918373069e81023b848469e726fe469fd04800bb3571328",
+      "artifactClass": "demo-html",
+      "ownerSkill": "bright-green-tech-system-webgl",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and lit 3D object effect."
+    },
+    {
+      "path": "agent-skills/web-design/bright-green-tech-system-webgl/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8bbf11bc171c1ee0ee399429fe2642d92e12e843",
+      "byteCount": 73494,
+      "sha256": "b5e377e70de77a536532c7d1fcb9f98b2fb8e2172f7fabe48cb8b6596da55ccd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "bright-green-tech-system-webgl",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and lit 3D object effect."
+    },
+    {
+      "path": "agent-skills/web-design/build-awwwards-quality-sites",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "542d01c832988b7db2ace8032a7cf94b0c11d6bb"
+    },
+    {
+      "path": "agent-skills/web-design/build-awwwards-quality-sites/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cdf06063574a31b9f7b1b39673a5eff866d931dc",
+      "byteCount": 7216,
+      "sha256": "1568e003d112e72df0ea2ec925829a5039b762c27174e063c192d7ccf7f4f9e6",
+      "artifactClass": "skill",
+      "ownerSkill": "build-awwwards-quality-sites",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Subjective quality label and over-broad bundle without concrete primitives."
+    },
+    {
+      "path": "agent-skills/web-design/build-awwwards-quality-sites/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "edc4396bf203cd5d81fdca4ce8343cdb7bdff140"
+    },
+    {
+      "path": "agent-skills/web-design/build-awwwards-quality-sites/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ccb8017b3faeab322f8393406666a87bff9dabdc",
+      "byteCount": 274,
+      "sha256": "65f0a30266377d7fd32928ed50171f1bd8dbd38b40dedcb2eadb0801e34d42de",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "build-awwwards-quality-sites",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Subjective quality label and over-broad bundle without concrete primitives."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "a3038b07d413e035412d137fc52b942e6d627354"
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "429e5c683dc7e169ac327e89f9195f77562a1663",
+      "byteCount": 6042,
+      "sha256": "53d32efbd2e9d6dc20ccb877d324124aa8e8481967e4404685718afc67aa4b9e",
+      "artifactClass": "skill",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "1de0be15f33061feb17b22d77725c267b0b0013b"
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "aee8dc861d1efe1c4b9997a566a54e5da177688b",
+      "byteCount": 246,
+      "sha256": "24dcaccb55c2e7263618d80de3ab871a919c7a91605881e3a1e34ce488afac1b",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "33fef1c1ad0f0d4e36368a8456e1c5fd3620a3e3"
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7dad866980757d35de6b006424bf79b00f1a809e",
+      "byteCount": 1810,
+      "sha256": "9a03321d8d6ea4236cfb6fd87677892e4cb6df9f1f99c071f12f6d68a78b31e2",
+      "artifactClass": "prompt",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cc05cedde114c5a13d842fc6bf964ea773b900db"
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo/assets/card-ethos.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e4162efb93c89d1d20ffa0cde746dfdceeb537ea",
+      "byteCount": 316720,
+      "sha256": "337627390f499b3ae272cec9e2f83c817694a82f42e1aa10a7b26a2c7d679dff",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo/assets/lexend-latin.woff2",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0968c152f1c0d617a90bd843fa3d510c336af085",
+      "byteCount": 39692,
+      "sha256": "1ec8f6ee2750554b4bc59ff0b507d316a82a7ba37e0e5bebc41d3bd9b9faad46",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo/assets/three.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4494cf4e8d37049896b6051da6edfe44a83355af",
+      "byteCount": 608081,
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2497466999c907c4946df30e13c2b4277511305f",
+      "byteCount": 16731,
+      "sha256": "1cf14394c5721f6a3c4071901cd88a5750ea2f1b2462d00f59c5736ada977eb5",
+      "artifactClass": "demo-html",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-interactive-particle-trail/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0c84ef51ee039c0adbb2c90518eb59d3c39c481f",
+      "byteCount": 104343,
+      "sha256": "fbb059b4501b80403873586635361f61bcb38da7b2f3d504ad923646de3dd4b1",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-interactive-particle-trail",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter particle trail with segment interpolation and pooling."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2822a2cc5f7179f4fd3126929a1a8a189309ecfa"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8996aca04d8d0df3311e0b1e2d1208176a18ede9",
+      "byteCount": 18658,
+      "sha256": "bb36c79ff435045f57a7f3ec3f50c27d37087c2e5a5ab1b17b6ba219d3f2c091",
+      "artifactClass": "skill",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d7103f3520cf83f170f780176773bb63f996ac2c"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "64d9b285ed24fcd6f1e269a713acad08429e54cd",
+      "byteCount": 294,
+      "sha256": "e02a650cc1806a10b257a6efba4bc9e7a591ed511ed4e7bcd5903bdd116890a5",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "10fbfd243bae99b69d76c4296a4c4a69e8ed1350"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "94606378a4dafadde09fca120918e4c32fd544ab",
+      "byteCount": 4204,
+      "sha256": "dcfb1aa8fa1d87e290ce54375673597c2524f3709268a49f776ecbcd628aa976",
+      "artifactClass": "prompt",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3e413558af469fd827893e548c74749190d8cbf0",
+      "byteCount": 238698,
+      "sha256": "1e0a6ec6daff50a5fdb393193325edf3bfb074a51beff2b53dfe4e73880d3fba",
+      "artifactClass": "demo-html",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ce766781422b82142c78bd407429965f8c24018e",
+      "byteCount": 144402,
+      "sha256": "bfb0bec8b9e22fb1f4b14402a3f3e4b93db19acc99dc96969a29e07036167c1c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8e4860696e448a40819fa5f8237eebae9c9dc3b8"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/fonts.css",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e07ce8ec6d5a0906e1071b71a4bab84d26dd6352",
+      "byteCount": 99356,
+      "sha256": "985f85a904a4096f92c06552b06f42a45973ac004af4780d68f18af65ddcc1b0",
+      "artifactClass": "authored-code",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8b9a1e8718e340c33174945ff7bb7b2d4dd6e8f4"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f78d45c17fad4301ab18e9969b538fa7bc85f517"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/basalt-stones.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b29131e95e6a4274223d4d5f520cd0d1860198cd",
+      "byteCount": 167866,
+      "sha256": "150f1c87e181d651c318168c271bb65c9c8abac6dea6f2421fdd081c5b740471",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/garden-bush.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3fdb89d4d99389016e2a7c0e3bed3325c446f2a7",
+      "byteCount": 286406,
+      "sha256": "707e2516ebc0108041fe0ddc26d8bff0a69dc9700641f837765018b64e9ff15e",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/hill.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6571e69c8e2961fd07aa75ef3783a2d16ba2fc2d",
+      "byteCount": 84142,
+      "sha256": "ffba816244bcba98e4e33c6ee56165edfe4048db4af122ef3f5822180a85edbc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/maple-leaves.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1cb9a21637b0a2028dcca768e5e2282a1b1abe2f",
+      "byteCount": 178208,
+      "sha256": "35a90fec62c1a6bbfbbe73cd5d7b1acb889e80546d404182ef9a45fe417b531f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/pine-tree.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fa5eaede8e9ee9eb0ca6ffa4c33c40298bf2621e",
+      "byteCount": 195918,
+      "sha256": "79b233716d067bbc64c1507f79e4a30ba5f445995158c78562cc5b81f607ede7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/sakura-branch.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fb3c72af4c693a3d74c170bbfb63369298a28e50",
+      "byteCount": 252528,
+      "sha256": "48564194d40496090dbf3bba2a68785cf91fafb655dc8d43ac16f6678aff196d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/shrine-ruins.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d636371982e96c3c8f35d53ae05173f9ca8717b0",
+      "byteCount": 145814,
+      "sha256": "77006e58f2066e6fa9bfc504df396db49b1c7977858fa52d34dd2dad5feced77",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/stone-lantern.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0367190c76ebdfcb297038055dbe444fe6503d76",
+      "byteCount": 150108,
+      "sha256": "d5f3c881bc9d92b72eaaff2b709614d66e21a19e14025d2b9b16a15ab52df3bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/tall-grass.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e162f75077b04846b5cc0a5fd45383bb9c5e42af",
+      "byteCount": 351644,
+      "sha256": "8db0b5fbd160a7225391a6283a99681e346e205f24191031657285ef85ef12d2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/foreground/png/temple-wall.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1e714d1ff42368fc0bd16197f29a03bacdda5151",
+      "byteCount": 86466,
+      "sha256": "41c00f017e4ecf2147ee468d74da955bb4e2dad773f75a575022842eaf7609ce",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/generated",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "86a438f02685a4456de629e904f7e3d0fe7a6049"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/generated/kage-approach.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "807f8d573cf8f044008127adcc9ad9cdbd78116f",
+      "byteCount": 180064,
+      "sha256": "39ff338936097e1bde0c4eadcf09805b9890862703186e67314942de7e0bc36c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/generated/kage-lantern-court.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7d86997bf3f1728c1be059d7591062cbee0f1ab9",
+      "byteCount": 197940,
+      "sha256": "c0a6ff7da1cd6909d66e2f3f690b0d524a693e01d2222ab846d0074a90f47471",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/generated/kage-moonwater.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "093e7cb1ecb8b20d6a4a05c8bdeeb2bf0e76407b",
+      "byteCount": 102234,
+      "sha256": "b8c8060c51c87a103bae619b3a4cc8b8b80632649d83f1f2c2299051e7f9b400",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/generated/kage-sanmon-preview.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4facc7efa7115285a173081f8ea12f356aaec165",
+      "byteCount": 186398,
+      "sha256": "23937f8c8350c55730c3bd17066a250548b2d29aad0e6ffb96218c1354b6db43",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/demo/secret-pathways-assets/three.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4494cf4e8d37049896b6051da6edfe44a83355af",
+      "byteCount": 608081,
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/references",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9d3b8d1dd26d1ee989e323219a193076c1b06efe"
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/references/kage-anatomy.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f3fa9a7ba5f956365190e4236bd4e259abaea447",
+      "byteCount": 7732,
+      "sha256": "0f14a21eef2fcac4d9e43be42ca93c049d82e2fdf3430857d7fe5b0d8080651e",
+      "artifactClass": "reference/article",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/references/quality-and-qa.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f51175e200c1750c4f998005552e2addbd888ad8",
+      "byteCount": 11414,
+      "sha256": "4f422973f46d4ec3a9eead3e4816998a33fd5ba78ddff0c3dbd17b5ebf204eaf",
+      "artifactClass": "reference/article",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/references/realtime-architecture.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0393793dfce11ed030aa30d2c6eafb6bb499131d",
+      "byteCount": 15791,
+      "sha256": "1f4bcb2ed0f1bbf5f48d8b7372e1296894f1e99148b5376455eada0c51ad5c63",
+      "artifactClass": "reference/article",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/references/scroll-conductor.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "895fcde3925179d1261cdd39848218804d9a4dd3",
+      "byteCount": 7665,
+      "sha256": "d72cb6da9f4ad5cdfb1ea42678a073a74f590154f639cf66737d194d1d63c103",
+      "artifactClass": "authored-code",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-threejs-scroll-worlds/references/world-bible.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "28e53918a8afd448ddce0446df5bab185b187801",
+      "byteCount": 12682,
+      "sha256": "292600301358e93e20794eae093f539348358aa0db433fab84633fdae9d08f65",
+      "artifactClass": "reference/article",
+      "ownerSkill": "build-threejs-scroll-worlds",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "SYS-02",
+        "SYS-05",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt persistent world structure with continuity ledgers and quality governor."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3b6ab0a620bc0671f95c011a14f0fd10239aea3a"
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a89ba27aafc449f3da1c65fdfd24a733dfd07af8",
+      "byteCount": 6307,
+      "sha256": "daaa8ef15435580ae7934fb1c9d8797d2d71038b90be707e3edd49e9c8c1cb54",
+      "artifactClass": "skill",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "692724c00b622f201709d2bac6d19fce8b5da63e"
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2b04238a91964288a2626e9d9549c87ac1cdd66a",
+      "byteCount": 235,
+      "sha256": "59d47727b7debac57cc759517999e37fd98505bff8c13ea34f17d40ae236b6e1",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "953f35e5027128bd30c18c2e75fabd7670b6ddeb"
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5915eb59bef36e8685462764b867363aeb543c7f",
+      "byteCount": 1777,
+      "sha256": "d70a25dfbbbd14e499ddca22ea653be2d43c0dc6780f7718ac54477cf06da617",
+      "artifactClass": "prompt",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cc05cedde114c5a13d842fc6bf964ea773b900db"
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo/assets/card-ethos.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e4162efb93c89d1d20ffa0cde746dfdceeb537ea",
+      "byteCount": 316720,
+      "sha256": "337627390f499b3ae272cec9e2f83c817694a82f42e1aa10a7b26a2c7d679dff",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo/assets/lexend-latin.woff2",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0968c152f1c0d617a90bd843fa3d510c336af085",
+      "byteCount": 39692,
+      "sha256": "1ec8f6ee2750554b4bc59ff0b507d316a82a7ba37e0e5bebc41d3bd9b9faad46",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo/assets/three.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4494cf4e8d37049896b6051da6edfe44a83355af",
+      "byteCount": 608081,
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "913d2ee603e53b1577632432f52385db7fa7390c",
+      "byteCount": 13594,
+      "sha256": "ae726f5203abf38c9d931ebb410073254b15f3db422202bc148018bbbd4bc848",
+      "artifactClass": "demo-html",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/build-wireframe-scan-reveal/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "41c5e754628a89d75b51b7d9f55afea288d23ad8",
+      "byteCount": 158115,
+      "sha256": "d973db811f79ab1994dc68cce502e771b7bd8975f40a55f47096856c9318f484",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "build-wireframe-scan-reveal",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt scan assembly reveal effect with world-space front progression."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-gsap-lenis-motion-system",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2a0c41365a25fe08a0383ad26d43ce6a5d09e3bd"
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-gsap-lenis-motion-system/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0fcc6ca5daa209ecd3e483384a3c8cb2be00eeb5",
+      "byteCount": 165,
+      "sha256": "0f4bf70304d3011b22b4f06a27cc13b006a92212857b010850126b2ee50e9c3c",
+      "artifactClass": "reference/article",
+      "ownerSkill": "cinematic-gsap-lenis-motion-system",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by motion selection system and GSAP scene direction."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-gsap-lenis-motion-system/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1aa69da8460ce0db325765de5ff14c1d6b92960f",
+      "byteCount": 17600,
+      "sha256": "7b8f5745f34ef4ba507e19fabd6acf9cd3b8d70efda81746d0f4090af0f84e06",
+      "artifactClass": "skill",
+      "ownerSkill": "cinematic-gsap-lenis-motion-system",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by motion selection system and GSAP scene direction."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-gsap-lenis-motion-system/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "54e37614c3b4b1392bd499fa4696170dbcf0d933"
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-gsap-lenis-motion-system/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fcfdd088df05f47984dcc764581e9c00d7dae3ee",
+      "byteCount": 2101,
+      "sha256": "9c9a8412a745d819e0f4db118740196f7db378f9e12a66e854f072bf437f8bdd",
+      "artifactClass": "prompt",
+      "ownerSkill": "cinematic-gsap-lenis-motion-system",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by motion selection system and GSAP scene direction."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-gsap-lenis-motion-system/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "33182228a5e412add7fa333de31baaf7b083081b",
+      "byteCount": 16602,
+      "sha256": "89559d94e96fd929ba01931006aa61ee0301faacef1a515bb4d8059da59c817a",
+      "artifactClass": "demo-html",
+      "ownerSkill": "cinematic-gsap-lenis-motion-system",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by motion selection system and GSAP scene direction."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-gsap-lenis-motion-system/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a153f85004d72ac346c2574de5fdf177ec5e48ce",
+      "byteCount": 73996,
+      "sha256": "344cfb19abdbf23de2fbb73cf60d2f51d309a7a064778515a7cc653b786472cd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "cinematic-gsap-lenis-motion-system",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by motion selection system and GSAP scene direction."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-scroll-storytelling",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "421071f24e9cd73c7ded930fd7664650a2b53781"
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-scroll-storytelling/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9daf9931b4938bb8d212d4127b376786b3641f04",
+      "byteCount": 93,
+      "sha256": "3081cc44be9af770a61db6db13c6cd0d73f650caecd9ac7ac10bc70866705d2b",
+      "artifactClass": "reference/article",
+      "ownerSkill": "cinematic-scroll-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by cinematic chapters page structure and existing motion contracts."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-scroll-storytelling/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "050b9044e21809d8398bd1a78e8c0e7348488bd6",
+      "byteCount": 11982,
+      "sha256": "3e203d1a38917004396f07b5887418e9e13dc832506754f5a4ad6303525b1572",
+      "artifactClass": "skill",
+      "ownerSkill": "cinematic-scroll-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by cinematic chapters page structure and existing motion contracts."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-scroll-storytelling/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fb1261278aee58138cbd0324030c65a5482fcde7"
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-scroll-storytelling/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "dfe4950dace515db2a4a34d3664e4d341923baeb",
+      "byteCount": 2172,
+      "sha256": "59944947ba1d89939a7f70d29c06158076d776abc76645412a3725d325f3c463",
+      "artifactClass": "prompt",
+      "ownerSkill": "cinematic-scroll-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by cinematic chapters page structure and existing motion contracts."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-scroll-storytelling/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9221e5e1a245aaa8f07ddae4da59eebfa00a44aa",
+      "byteCount": 16668,
+      "sha256": "18a38d84d3195aba81ab44232ffba135c6361620dcc5dfbf2ab528863bf43031",
+      "artifactClass": "demo-html",
+      "ownerSkill": "cinematic-scroll-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by cinematic chapters page structure and existing motion contracts."
+    },
+    {
+      "path": "agent-skills/web-design/cinematic-scroll-storytelling/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b4c7aeff4cd76ad2aef22853461c95ba018f9068",
+      "byteCount": 78320,
+      "sha256": "a22721afce2c4a90920f10d311cd0e5b2258ca754eba5004d01b565fc74f2cd2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "cinematic-scroll-storytelling",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by cinematic chapters page structure and existing motion contracts."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d84fa4bbfd02fa9713d0e2908bf2fef370f24dda"
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2c3b15e7941c7f9f399d4e8bef97249777ee6229",
+      "byteCount": 3791,
+      "sha256": "675e5d268ae36ae4aa59ff06cdaf19f67169defedc7a2cf5e7ca03a8f3eadb05",
+      "artifactClass": "skill",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "1a5ee0b47bc2f83b5a473be0b739162b83a64f31"
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "da3b39fd2f5c83f56464889b5d7b54c0b784fbbe",
+      "byteCount": 3393,
+      "sha256": "bfb2daa34ed6cec7cfb85301967e2ed9352096460b4da9caae5bc9e9dd62a081",
+      "artifactClass": "prompt",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "01e285b465082ae6fc7ffd397bfc60045c62f5b9"
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-01-3186f9ea-5f5a-49f7-8fcf-568ad52f515e-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "53ac591b09701e0ea83163e97db2663ed881a526",
+      "byteCount": 599390,
+      "sha256": "852496aebbe37c983c885d9aa20b3520e0c0244472703e3c2925b9c56f749a2c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-02-eca707cc-a5b7-439a-b4fd-247f6106c2e1-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "edaa940e355711470dd198749ed0905e38775bcf",
+      "byteCount": 249675,
+      "sha256": "4526a25eb7c0b86d945cf5e43ed53e85be9821edb8dc26017ed372b1450ae6f6",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-03-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2d791d66906a67e0bbd80e16d8a37f577798a7dd",
+      "byteCount": 282854,
+      "sha256": "0d71068ad67cbdbfca87b5e5f57f21fbb47fb29148e2ae8d2e1a5df136ea5cfc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-04-582afef4-b810-47b8-a047-8b3597c323e1-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "da10a7a4b828339ffd3c4f97647471264894c457",
+      "byteCount": 511242,
+      "sha256": "d253077e6bed483d9bb0124125f4dee494f243642416d44ab7bfbd11a11bb255",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-05-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/page-06-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "263350dfcc17ee6dfd15ae4feca8e636d964cd65",
+      "byteCount": 98847,
+      "sha256": "6302b4a9f319432ed7db6d47aeacca255bdbf2c388d51a64b21c4777adb8b63c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "13aa3592d719aed25a82f5de8eb3e681657fc32c",
+      "byteCount": 71082,
+      "sha256": "92d010a9eadd4901c31c462917bdbc5973d10dce15a5e8b169f14ae9fcce776d",
+      "artifactClass": "demo-html",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fc296f069f498a02e2df968f7f89c26f2fdaf487",
+      "byteCount": 95986,
+      "sha256": "b50aa5ec8da5f3113bae9641e7cba1a7964bba6a6fe68c5654bc33df0f4c992d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/clean-minimal-beige-light-mode/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a620ed77f85893aef12afd5316a06a108ab62429",
+      "byteCount": 4409,
+      "sha256": "f7874e5d29ae6452bd318dd1d1cf1f4ec5db42a386a1a7020e26da7658271435",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "clean-minimal-beige-light-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by existing persona selection and feature stack page structure."
+    },
+    {
+      "path": "agent-skills/web-design/cobejs",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ba776030dd6299dc039c1eec6dae588517fde3bc"
+    },
+    {
+      "path": "agent-skills/web-design/cobejs/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "619cd44a0876f9db6143c0c28c53510e19c72723",
+      "byteCount": 70,
+      "sha256": "0fcec250ba83e82beb0c702bfebb99c81231ef832518c872f47f628916cb922c",
+      "artifactClass": "reference/article",
+      "ownerSkill": "cobejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and no distinct contract."
+    },
+    {
+      "path": "agent-skills/web-design/cobejs/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3abc281324065dbaf8fee51b7de3d44b7995875d",
+      "byteCount": 2276,
+      "sha256": "4f050b7495a5b19d05fb89736c6c61df4feacab07f23aae20cf8a8a79a53bbef",
+      "artifactClass": "skill",
+      "ownerSkill": "cobejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and no distinct contract."
+    },
+    {
+      "path": "agent-skills/web-design/cobejs/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7acd3cb52c50ccbc87c55256ea0003ed6ac1be0c"
+    },
+    {
+      "path": "agent-skills/web-design/cobejs/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1545feb47e3ff4f4c7ec51400a6f231b18d4b224",
+      "byteCount": 1791,
+      "sha256": "85dd5d6a7a9cf0074ec99cd9e3976256a8dc1b88b4c59db8cd025d3481624a99",
+      "artifactClass": "prompt",
+      "ownerSkill": "cobejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and no distinct contract."
+    },
+    {
+      "path": "agent-skills/web-design/cobejs/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1b3a31ab7a410f5e0634a95341cb94525807d4ca",
+      "byteCount": 16180,
+      "sha256": "304bfbb3379da789d242ce0a2bd06d60ab28584fae171430c6b698a03dee1f47",
+      "artifactClass": "demo-html",
+      "ownerSkill": "cobejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and no distinct contract."
+    },
+    {
+      "path": "agent-skills/web-design/cobejs/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a11e1d02940435b69ec71b4c7d4953bea64a5529",
+      "byteCount": 39267,
+      "sha256": "affd81d298abd6581b4f00a5daa41de73bfa4f277de4c5d2108b137c3d3782e3",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "cobejs",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and no distinct contract."
+    },
+    {
+      "path": "agent-skills/web-design/company-logos",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "94ff11a25c1afea43627386a8d4c32891eacc394"
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "40b6897eda4f088f958e2f20d5326f7cceabb032",
+      "byteCount": 1066,
+      "sha256": "d089dd870e8f4012acc3bc1bf55855346a7e39fa4e975868f6ed2d495eb82729",
+      "artifactClass": "skill",
+      "ownerSkill": "company-logos",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "AST-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/generation-craft-defaults.md"
+      ],
+      "reason": "Covered by logo truth and sourcing craft defaults."
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4973cd7463cc6aa9e1af2bf23ddf7d4bb9df8ee8"
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d301e4c9f4664b6caa40a79bc13aebde772c8ef0",
+      "byteCount": 2737,
+      "sha256": "3a616bddde84877158408a8e4b7b3d77c3f67b50bfacd2f7372edfff5040e203",
+      "artifactClass": "prompt",
+      "ownerSkill": "company-logos",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "AST-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/generation-craft-defaults.md"
+      ],
+      "reason": "Covered by logo truth and sourcing craft defaults."
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3c05a6fcfaf79d524f169361ce0e1e57ed91c6b3"
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d9220ff1f3fccb56ee151797c4abb37360368710",
+      "byteCount": 82710,
+      "sha256": "290b150d824e72706f5ea846ec0fa8f8a27e333b77bb3a37232f22d166b5d277",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "company-logos",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "AST-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/generation-craft-defaults.md"
+      ],
+      "reason": "Covered by logo truth and sourcing craft defaults."
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "93ff72caab4c531de6d45874144544bb2cd0867f",
+      "byteCount": 44242,
+      "sha256": "d3b409fbefb7c453ee8701e0ef40fc79551da3d7db96a4691a4e859f69df5ba1",
+      "artifactClass": "demo-html",
+      "ownerSkill": "company-logos",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "AST-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/generation-craft-defaults.md"
+      ],
+      "reason": "Covered by logo truth and sourcing craft defaults."
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "378c92488fe5f5b0201b282c97985f5dc8c8435d",
+      "byteCount": 62306,
+      "sha256": "bd0a1829d9f7e2baf722095a9959fcbdaf101d2b1448b352c471e5eb2d6f431b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "company-logos",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "AST-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/generation-craft-defaults.md"
+      ],
+      "reason": "Covered by logo truth and sourcing craft defaults."
+    },
+    {
+      "path": "agent-skills/web-design/company-logos/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9959f8a3fb88b73dc279c71b4a1d62b884a46669",
+      "byteCount": 3147,
+      "sha256": "2041bc25c55d29312d3dcf72c2a530e5753662dad0bdce7569d24177a5c8b279",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "company-logos",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "AST-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/generation-craft-defaults.md"
+      ],
+      "reason": "Covered by logo truth and sourcing craft defaults."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fec0e3973e6f175b54f05ffd50837f3ba6182cf9"
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fcc283c6b2a6f46f01e8e5551d7fb0c39304b1e6",
+      "byteCount": 3611,
+      "sha256": "b2eb19356c14c034d8e077452ede319835b841b7aa046ec3cd0a4460cc7911b6",
+      "artifactClass": "skill",
+      "ownerSkill": "container-lines",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "a77e731ae6496e8f69f9760c1e4aaafac1591444"
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ba89011e6a44fd1617e4d3834b2ac5c8d22bc431",
+      "byteCount": 2520,
+      "sha256": "57a9715d769375b67d8e6b57d6ff5c810d8ad07bde259fc6e7f8409764cd952a",
+      "artifactClass": "prompt",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "48b414490df3573bff95f7d8871eccfa88eba267"
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c17c9ed9481fe26fe7fdfca9a0a8dab4dd3a771d",
+      "byteCount": 201962,
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f77fe5bede25677fe105589063c8b434ac5215e2",
+      "byteCount": 139542,
+      "sha256": "3ecad5d2605bbf56d3f02c0a2a4673d574d405a5d830e45b43d6a34c01cbe992",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ea0c87673cd6f78aa82acd6bcbacfb81d4c24047",
+      "byteCount": 45479,
+      "sha256": "4559d22599d5ed733eb14ba074e37de12e8db297571b70be93b898a347274658",
+      "artifactClass": "demo-html",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c4b176d6e7e8b0c15fbb551dc5435b0c36d24b76",
+      "byteCount": 98185,
+      "sha256": "1f47c92dd8338695e9b2fd29886ab0298c3b2937bb99ff42a48099baeb6ea17e",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/container-lines/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8ea2dfb8d929a524eaa182cc499aaf5883bb4b2d",
+      "byteCount": 4518,
+      "sha256": "b9c1510427a1a9fff4499b2da39a74304e185fe632caa94f2b6105f671714325",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "container-lines",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout device and boundary guide rules."
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f67d9b39e2cba2e66af78d1c69a0820ae022ab54"
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "295f1405ccda0680d27c9cbfc3c4ed4d28675024",
+      "byteCount": 5546,
+      "sha256": "ffb61cc0a8fae762d6ff59e526aa26e7b18349ae040f125502811b63c289a310",
+      "artifactClass": "skill",
+      "ownerSkill": "corner-diagonals",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt chamfered surface device with clip-path and focus constraints."
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "1ed06de7a6dbc63c8b78696f080aeb5acc05ecce"
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6bb7884b010d06fa294c58f63cc0cd658c0f4801",
+      "byteCount": 3252,
+      "sha256": "c77395a936a9fef506d065cb345622131b16f5b91b559e67852b44e60cf728d2",
+      "artifactClass": "prompt",
+      "ownerSkill": "corner-diagonals",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt chamfered surface device with clip-path and focus constraints."
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fef98744e0a572e289ed1b820c9dfa806564f9d2"
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6c85ab398913b55fa406929309aab5a17492c4ab",
+      "byteCount": 96070,
+      "sha256": "cea85a39224a0cac5523629063a71ff13a173ffce2d347f029ea567e994472a6",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "corner-diagonals",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt chamfered surface device with clip-path and focus constraints."
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "719809cf2531c9529d0b5bd2e4c0443757a98fa3",
+      "byteCount": 27386,
+      "sha256": "21f51f52256cc0c08deb82e954ba0418fa8319ed9a36277902c005842b105b96",
+      "artifactClass": "demo-html",
+      "ownerSkill": "corner-diagonals",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt chamfered surface device with clip-path and focus constraints."
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "16f5d692f288e512e06a9cb0942f6bc2c711df93",
+      "byteCount": 55801,
+      "sha256": "9f138955b14b53358b102b9a627c626926d3281c924a4ed553dbad1acc289af1",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "corner-diagonals",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt chamfered surface device with clip-path and focus constraints."
+    },
+    {
+      "path": "agent-skills/web-design/corner-diagonals/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d0c3d7b0cd5bb9277817edaad92cfde4a9bc6057",
+      "byteCount": 3050,
+      "sha256": "55a0ec0c45c398507c5fe523c4b259865437dc25cc275df8cf4baf55681300a1",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "corner-diagonals",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt chamfered surface device with clip-path and focus constraints."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "c7c32b7721a187e2f44178892a10c8267d90153c"
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "725234a45f59ff3d382c9cda93d3bd9ad217af5f",
+      "byteCount": 2850,
+      "sha256": "7a6766480ca8f5aa98d7f8dd92ccd378c8b32db139cb5ef0f3fd1c9930aee565",
+      "artifactClass": "skill",
+      "ownerSkill": "corner-lasers",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3872ce8062d4e87c7880542ff596227b3424a3d7"
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "724448d268a5844cdd390622225253b8915603a0",
+      "byteCount": 3414,
+      "sha256": "2fbe3e1d9dadea4913dec2a47574302d75e8a56e57214f6ed154dc97a7e26b8e",
+      "artifactClass": "prompt",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8f911a9da0468f9f3f1965c2610354f0304d4568"
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "93d9323099c69a0f094d20a49045f7aca4ed92ed",
+      "byteCount": 76549,
+      "sha256": "bba3220f058938fca64a658ed7bc7e88e92151754b572a90a2a3634979517541",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/assets/page-02-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c9bf7ba0b9d2c1b6ea28dc5109a19dcc5cdc1c23",
+      "byteCount": 17835,
+      "sha256": "82305f69c5e57263ad4526b1e46b85f61b7dc6748e606dce7bbc1d5dc86183f7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/assets/page-03-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7e4ba751e7a922d314a23b16c354e39ba1716276",
+      "byteCount": 77649,
+      "sha256": "23d2d22487876b2bd8504eeaef867be471f025862ec31450f9b0bf71c8dbb185",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c6ce120261d7c20d741526108e149c14b1b1602a",
+      "byteCount": 60931,
+      "sha256": "17847c3da7efdfaab2267703d64dea88bfae27c7367e2299617fa27b8c075090",
+      "artifactClass": "demo-html",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "45b718933e3b0e87b5fdec9711fbdc63ebced444",
+      "byteCount": 58625,
+      "sha256": "af4e7550aed6314330beb5194e9daadff7f3b2d3c6ead60fc48ea5854b8cac5b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/corner-lasers/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d0459fe1eced1338bd3f063a105f4c2af3199fb8",
+      "byteCount": 3986,
+      "sha256": "6bbf455381a3766e63406e20b73dab3c0e404556cdff220d6d37f3faefc822b5",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "corner-lasers",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by laser accent detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/css-alpha-masking",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "c1794c5a2a39186267e65138034c424f98ca336c"
+    },
+    {
+      "path": "agent-skills/web-design/css-alpha-masking/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "061a09c5d06203fb5e3a2a404ca63cb426b1591a",
+      "byteCount": 1780,
+      "sha256": "049241d4c086b0f95af2ab68857435f604fee07e5744a856b385e3c212a638e1",
+      "artifactClass": "skill",
+      "ownerSkill": "css-alpha-masking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt CSS alpha mask surface device with horizontal and vertical variants."
+    },
+    {
+      "path": "agent-skills/web-design/css-alpha-masking/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "81eab873d4aed2f21429b138de03c688c6ff55e1"
+    },
+    {
+      "path": "agent-skills/web-design/css-alpha-masking/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9455b422cb88f335f6c9508abcdadf56e1ac18c6",
+      "byteCount": 1938,
+      "sha256": "d44357ec4fa7f78be6f4da58b4909df8fb1e8ed3537394dcf79fac957a404b98",
+      "artifactClass": "prompt",
+      "ownerSkill": "css-alpha-masking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt CSS alpha mask surface device with horizontal and vertical variants."
+    },
+    {
+      "path": "agent-skills/web-design/css-alpha-masking/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4ea4129cbd0cf585190412caa2ac4753e24edc5f",
+      "byteCount": 16556,
+      "sha256": "7725743b0c6cabd0b7a48871c92287b12c847597472cbaa719f0ba5ba63172b7",
+      "artifactClass": "demo-html",
+      "ownerSkill": "css-alpha-masking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt CSS alpha mask surface device with horizontal and vertical variants."
+    },
+    {
+      "path": "agent-skills/web-design/css-alpha-masking/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "47676cbb9512046ee9cba4b525b873e38bf4f8ba",
+      "byteCount": 48814,
+      "sha256": "da1b9774fcb273235efb3828f33eedc41a5ce4e5b83e35c6912ae7881ccc64f4",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-alpha-masking",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt CSS alpha mask surface device with horizontal and vertical variants."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "5b3701d0c5bd451da5d2b32699a1b428b4fcde1b"
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c5287d620e6f64e1e994e7497d4512c864506acc",
+      "byteCount": 2931,
+      "sha256": "6c5e1924a7ec55044aca52801cd30efb06cb922fa47e4c4b85d16b39471c922a",
+      "artifactClass": "skill",
+      "ownerSkill": "css-border-gradient",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ef18b397cd295a5fb3853d081a14fb18a34e803d"
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c78657963c310b5cbb4c8c09d9849a975ec2e9a5",
+      "byteCount": 2539,
+      "sha256": "7edaeb04d1de172e6c83373e5128f185859f592fe48c0825b5b0ee72b5926663",
+      "artifactClass": "prompt",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "48b414490df3573bff95f7d8871eccfa88eba267"
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c17c9ed9481fe26fe7fdfca9a0a8dab4dd3a771d",
+      "byteCount": 201962,
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f77fe5bede25677fe105589063c8b434ac5215e2",
+      "byteCount": 139542,
+      "sha256": "3ecad5d2605bbf56d3f02c0a2a4673d574d405a5d830e45b43d6a34c01cbe992",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ea0c87673cd6f78aa82acd6bcbacfb81d4c24047",
+      "byteCount": 45479,
+      "sha256": "4559d22599d5ed733eb14ba074e37de12e8db297571b70be93b898a347274658",
+      "artifactClass": "demo-html",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f2ea35d29c64fa36635ad78123be5627f1035be0",
+      "byteCount": 98145,
+      "sha256": "47dc6ced9e3d2354583a2dec0adba4c2d7da55e6325f48b38cbfb28c39f6e2cf",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/css-border-gradient/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "105637f8fec51532b7f89d725c0d91899990f7b5",
+      "byteCount": 4528,
+      "sha256": "d0ad9492aa49c630e0f0871fb2b78c0c101dfedfdc30a582a58cc75d9f99c1c2",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "css-border-gradient",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gradient edge surface device with pseudo-element mask fallback."
+    },
+    {
+      "path": "agent-skills/web-design/dark-blue-contrasting-clean",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "636624f901499d9717a7d078cb114cff45cbbfbb"
+    },
+    {
+      "path": "agent-skills/web-design/dark-blue-contrasting-clean/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f8ce4815ef7cd50852c5b85b4a90416d211fc75c",
+      "byteCount": 4385,
+      "sha256": "d92603c74fc0835e1ca4ed1c8b367ea453e67c5f4c990e60d3e2c3178c341aeb",
+      "artifactClass": "skill",
+      "ownerSkill": "dark-blue-contrasting-clean",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-02",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by persona styling, gradient edge, and atmospheric light."
+    },
+    {
+      "path": "agent-skills/web-design/dark-blue-contrasting-clean/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "508f82334a198c970e5b4a1f1ad108f4d329ce7a"
+    },
+    {
+      "path": "agent-skills/web-design/dark-blue-contrasting-clean/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c6acc5160ea192351fd1b11d7b556a4d9ac10875",
+      "byteCount": 1920,
+      "sha256": "7cdcc38509379252c318f21efe24cb5ce1f2241e024331488e1e152af7d41ca6",
+      "artifactClass": "prompt",
+      "ownerSkill": "dark-blue-contrasting-clean",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-02",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by persona styling, gradient edge, and atmospheric light."
+    },
+    {
+      "path": "agent-skills/web-design/dark-blue-contrasting-clean/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8d4df67c500202cf72d8b9a0e5ee2d9ac2973fc2",
+      "byteCount": 16608,
+      "sha256": "55bd3169664c081c953636b85d2f0b8be1b2c027aeff8640dff3ff13d4cb72c9",
+      "artifactClass": "demo-html",
+      "ownerSkill": "dark-blue-contrasting-clean",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-02",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by persona styling, gradient edge, and atmospheric light."
+    },
+    {
+      "path": "agent-skills/web-design/dark-blue-contrasting-clean/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "27ced068dc05ebc67e25676e1cbdc86432f8ea8c",
+      "byteCount": 73542,
+      "sha256": "de3eaf644e6f4aba8a4f1bcd585b9565f148ab11a8f6f36f33deefb9589b06ad",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dark-blue-contrasting-clean",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-02",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by persona styling, gradient edge, and atmospheric light."
+    },
+    {
+      "path": "agent-skills/web-design/dark-glass-clean-layout",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3e1dcd2702113543562606cd63cce4603820ffd2"
+    },
+    {
+      "path": "agent-skills/web-design/dark-glass-clean-layout/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "756e9e4012f3353f3176dc7307dc1da2d0986f8c",
+      "byteCount": 4865,
+      "sha256": "e51661080ce76a5386f2490406c95d5ad8e50f0d44ef55b0d972fb87a0baa560",
+      "artifactClass": "skill",
+      "ownerSkill": "dark-glass-clean-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and glass surface device."
+    },
+    {
+      "path": "agent-skills/web-design/dark-glass-clean-layout/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2e37a00bca3017aa009e98ead50d55321d73b6c0"
+    },
+    {
+      "path": "agent-skills/web-design/dark-glass-clean-layout/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ae748fc2f5179d8c4302985bea0368600931f71e",
+      "byteCount": 1933,
+      "sha256": "8adc35f538cc8422b26df6c8fc86c16bedccf194fd02eb7fc8324d9dddacb10f",
+      "artifactClass": "prompt",
+      "ownerSkill": "dark-glass-clean-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and glass surface device."
+    },
+    {
+      "path": "agent-skills/web-design/dark-glass-clean-layout/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d7cf42ab09806688ec496eab5c60e11eadcd3b1e",
+      "byteCount": 16577,
+      "sha256": "15d7e553dafb353331e0a3865ba77296b6206cc60ade5ab4d74fd09810d1ddf2",
+      "artifactClass": "demo-html",
+      "ownerSkill": "dark-glass-clean-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and glass surface device."
+    },
+    {
+      "path": "agent-skills/web-design/dark-glass-clean-layout/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bfdf1aee4a27c3f4e8a18c7ab7fa932f0853807b",
+      "byteCount": 50285,
+      "sha256": "2053332650e19105c667cf80fbc6f6ed4cb48232b723ceeb7d91021e3c73bc60",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dark-glass-clean-layout",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and glass surface device."
+    },
+    {
+      "path": "agent-skills/web-design/dither-background",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8ff890d1ef6c7c162b907d6bea6a5974c1843d15"
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "68b847c28b4c9b54b3871662f6b385af11a4f502",
+      "byteCount": 6921,
+      "sha256": "aa6520dc7dcb8dc3dc9a382a4363b57cad01a6745fbc05ce609539d38663c40b",
+      "artifactClass": "skill",
+      "ownerSkill": "dither-background",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-08",
+        "FX-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ordered dither field effect with Bayer thresholding and DPR scaling."
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "529d5ca68a453019355de3538fe1cea94e3c1d94"
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3e0ffb5c8d7d5ee56e285add8a2c284668c9a744",
+      "byteCount": 2989,
+      "sha256": "74a59679bbcf10e8662bf7bbcf16d529bd201a3e8fa120492f5c76945124c228",
+      "artifactClass": "prompt",
+      "ownerSkill": "dither-background",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-08",
+        "FX-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ordered dither field effect with Bayer thresholding and DPR scaling."
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4c9f7edcd98f9ebec0da212754fa61b86f165607"
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b1fbd79f1cbb72b4908bf956970bd18537ef80b7",
+      "byteCount": 26881,
+      "sha256": "3bfb70e2fd5359c261e9268583aca339d4d360fd774854977af109d3ab3edc6d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-background",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-08",
+        "FX-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ordered dither field effect with Bayer thresholding and DPR scaling."
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2803ba602bc466b0ebcae2fa8e7921a98ca701ed",
+      "byteCount": 27066,
+      "sha256": "7cd43cddf21947985f32ffefd02d2f2f4273cf79c438b0fa9dadc089fd35b329",
+      "artifactClass": "demo-html",
+      "ownerSkill": "dither-background",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-08",
+        "FX-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ordered dither field effect with Bayer thresholding and DPR scaling."
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "87b50b177d0f1003f2daa0e69ef7ec53b06fb4ce",
+      "byteCount": 28379,
+      "sha256": "574d6c3a99755c406166aeee5bc9cbe8ea65254b06371158fdb25fa1c848243d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-background",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-08",
+        "FX-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ordered dither field effect with Bayer thresholding and DPR scaling."
+    },
+    {
+      "path": "agent-skills/web-design/dither-background/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7b25666d686b4b1c97604ec2398d1f6ac3cc03d1",
+      "byteCount": 2006,
+      "sha256": "bf5c623252b149f88ed7a34573584f584c95faba31de94103cf43026761c3b78",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "dither-background",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-08",
+        "FX-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ordered dither field effect with Bayer thresholding and DPR scaling."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "b7a1658fdaeb461f4acf18738ca87cdef9896477"
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "48978533806319c89082d157015be624f80df040",
+      "byteCount": 4294,
+      "sha256": "afbf1b3161ea8c5b92f69fef0abdeb299f128aaa055730998cae32d1896d7e57",
+      "artifactClass": "skill",
+      "ownerSkill": "dither-laser-dark-mode",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "a4f92af40aab5e1b6a983b3f4e58aca8e4ec695b"
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c7d01a6d243f41f3711e3cf8a9f7774b50510980",
+      "byteCount": 3420,
+      "sha256": "98fbe032a9bcad46680f7a1de98096de2da5cfacfc14f47ea2452a64a1739a3b",
+      "artifactClass": "prompt",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6ac18cfaac5d1354a08a4398400824f357c4e04f"
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-01-photo-1542224566-6e85f2e6772f.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ec725394ac8fc953053a5e0b7b15ab16bff39047",
+      "byteCount": 1238234,
+      "sha256": "8c60a544ff48b3e2900418d6098efe1c72b5541ed41cb44ea70cd9d2b03a2f20",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-02-photo-1518732714860-b62714ce0c59.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2395f1899e90eb8f5ff25fb033dda15e1f334f5f",
+      "byteCount": 186731,
+      "sha256": "fdc05d807596db69affad0b516142dd3267d9918e3f5e7c36af5807cec7c783f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-03-photo-1596394516093-501ba68a0ba6.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f2456d9dad368297149f3a3c9c73b6e33391c7d0",
+      "byteCount": 262867,
+      "sha256": "32a1f0a3fb3b604920ea7d8301e69eedd747d85a299c9e7a40f354360f0cbbc8",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-04-photo-1587061949409-02df41d5e562.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "85f1f0e3234310e144f735a9c3fc497b875ab153",
+      "byteCount": 533313,
+      "sha256": "dd5ea24c41f638a247ceb9a4b4277be9a3ce571525778352ede1b40b9c33e53c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-05-photo-1522708323590-d24dbb6b0267.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2e2f489743cd3526b2250f8ef66aabaf07cf46f6",
+      "byteCount": 238376,
+      "sha256": "a5705dd6a81f41b53984155db8648b5325b7ac40aa100158a4a44b03cc07f0ea",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-06-photo-1464822759023-fed622ff2c3b.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "492dd971afac789fee9f029417382b71fdab0d6e",
+      "byteCount": 439306,
+      "sha256": "bf39595522ac70a092bb41991e20e03f93c9ad9025a3176ed9a534aa66fa4895",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-07-photo-1544161515-4ab6ce6db874.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c5f52fd0b620fe766373d6018ea2935fe17c9e35",
+      "byteCount": 192865,
+      "sha256": "ca99771790e92886557b657ef1f4d4d213d0d58d102207edd4bc26987dbd146b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/page-08-photo-1555396273-367ea4eb4db5.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "95da7ef5e7a4c6d5d94abe108078e9b4cc0b0b79",
+      "byteCount": 576747,
+      "sha256": "5ebc42216d0cd25fef1caa8510c6972388744fd513de2b2f9ada053145e4c3d1",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6f25cf15f118ef1f6b8e8cc19d4f8088334c4e23",
+      "byteCount": 27628,
+      "sha256": "1e06aaa12c3395215a1f292f228f502281f2bb2b45970ab6982d59a1fe760008",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fbf2c8bd9298d6167655e74f16ea93b197ec2def",
+      "byteCount": 60416,
+      "sha256": "184da411f3d660fc3cb9ec2f428e7d9b832c4d84da3e2dcef0e5caf106662759",
+      "artifactClass": "demo-html",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "27fc38b572ccbb95eacb61256ec41db80d273a54",
+      "byteCount": 141616,
+      "sha256": "a7ab5369eb81d8ed44248a315a23a2da5207cf2c18c6d67d73244a7e6bbed373",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/dither-laser-dark-mode/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "58ca304e38a5b9c1a37fc22e244734b22416a3d9",
+      "byteCount": 4834,
+      "sha256": "16c71513e6073e28a991ca237cfd4ef638c587479eedf4fc80cc4febfe278d98",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "dither-laser-dark-mode",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-08",
+        "DET-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by dither surface and laser accent device composition."
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6395323afe757ccb4f932449c66f212d449f3742"
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4ce445d51fb3d81281c740a5ba14db3855831cc1",
+      "byteCount": 150,
+      "sha256": "d1e9aa8dee567d777ef148b9e82dbc360664dbd3edfec4f87ea0a82d019a7ff0",
+      "artifactClass": "reference/article",
+      "ownerSkill": "documentary-brutalist-agency",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt documentary portfolio story structure with irregular collages and chapter alternation."
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4f29ed300937970996af719935f1abd4f50cce65",
+      "byteCount": 4159,
+      "sha256": "0659ce40f776437f419ed66506e318c38ac8003bb735cfaff12664899dfa903b",
+      "artifactClass": "skill",
+      "ownerSkill": "documentary-brutalist-agency",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt documentary portfolio story structure with irregular collages and chapter alternation."
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fe463b6d976523516e281434a59fc2aa03e18544"
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ade0e80dfe9df1c0abb8fc0d1f990ec4a7341e96",
+      "byteCount": 269,
+      "sha256": "f6b07c41a7ed19fb364a9901555ef5dc65e4abb900d1021e14fab8ad1f37e07f",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "documentary-brutalist-agency",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt documentary portfolio story structure with irregular collages and chapter alternation."
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "a2320b68c000639f2d6777a292ab9679a41006a8"
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8005337df3bf113acf5b894fac272c63d04f1283",
+      "byteCount": 1923,
+      "sha256": "19e8abdbc750f34d34fa93f6f132602e3b422f8a89df560e3a20563ce65172f5",
+      "artifactClass": "prompt",
+      "ownerSkill": "documentary-brutalist-agency",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt documentary portfolio story structure with irregular collages and chapter alternation."
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fc72b0a81118342598ea3e227d183cffdcc5dc42",
+      "byteCount": 5692,
+      "sha256": "e65731aa92cf09d8e2448de161cb2eee2e1e3a66a419fed84a1fb83dfd42bcca",
+      "artifactClass": "demo-html",
+      "ownerSkill": "documentary-brutalist-agency",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt documentary portfolio story structure with irregular collages and chapter alternation."
+    },
+    {
+      "path": "agent-skills/web-design/documentary-brutalist-agency/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "06504fe6269177f119a37c9ffb1eae83831912be",
+      "byteCount": 89498,
+      "sha256": "f3b7976ebf2e9a052c688c95eabf019a5676529d576f33fe55167c5de275d5d3",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "documentary-brutalist-agency",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt documentary portfolio story structure with irregular collages and chapter alternation."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8a4a94a14972da88b538338144e856cf6a37b540"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/ARTICLE.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "08e50cfeb24d4fcd5ede8e01f12d1e9cac032796",
+      "byteCount": 19274,
+      "sha256": "8a8f5895b6df25810f09e58f8d3100a099acec0b129cafca6e67c38e28f7a256",
+      "artifactClass": "reference/article",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "356c749ec9658c3e69b81a18f9b53dc9b72df398",
+      "byteCount": 150,
+      "sha256": "00b5d9e1c573197518f15afd475afb489d5855e1b05e84da5d247ec4356c2c23",
+      "artifactClass": "reference/article",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "db7a77571ecbeea09ccb4fb6d218618071328d15",
+      "byteCount": 4506,
+      "sha256": "763b2eb851228aee7af65914b2f45f062677e03a17f8d2dd50441bdd733b5d8e",
+      "artifactClass": "skill",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f6c0f92ef269237cbfdb17a0ba9ebb44d4daaf4e"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "37b57d492c72703fb56fa510118985bbe8489884",
+      "byteCount": 259,
+      "sha256": "6995009f08a0c76c668f46bc2df04838d5961d20eb03a2eb611d3d2f068d1a7a",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f6f8717a7eb712909393aa06c8e6bbc72dfe8a54"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-01-signal-loader.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cab9805560713ea52698bd0c1c0baf13b9853838",
+      "byteCount": 9022,
+      "sha256": "e6d3a87b890d165d217e3b56e2b7978eaebce96de260e420fa6b898b9f3c3580",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-02-decoded-hero.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0e86b14de55c8d1dd5f34d4ab6474a3152daa295",
+      "byteCount": 56263,
+      "sha256": "3f71916930994254d3045bd34b397ae532f2c6c0f9d2782780e92365f1990680",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-03-split-door-handoff.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5011ab298463892d5d3b87b39bcfbe37c1906808",
+      "byteCount": 38459,
+      "sha256": "b96f67f387f7d2faff6bd00febdf91fb0b9764b2efc34e3d46ee7e93a50f6a26",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-04-pinned-bio-illumination.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5aa51c24c39e7e0726a96dfdc06a08d971d64abe",
+      "byteCount": 73830,
+      "sha256": "b4f345e10d7c4aee7d92f474c435a54bc02b4c5e972cabb48003dca55e55c45c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-05-archive-playhead-player.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6e0239fbcb0f91f573346529f37d2f0e6adb5809",
+      "byteCount": 62955,
+      "sha256": "2e07ab25b20c764749f7d4b864fd77853b8f514d65628d3de49470cb2aba752e",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-06-chapter-wipe-ledger.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e33575f76d63704044296182835d709840ac9eec",
+      "byteCount": 17841,
+      "sha256": "c74f4477fa4519beafb4092f4bbf4134c35dfd8800720a839590f9dbabede021",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-07-pinned-counter-index.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "71c2dec1b956cd40e2d63aaf07f5a1052b321a83",
+      "byteCount": 34120,
+      "sha256": "70b22b7fb99579e2a9662c7b5dc6627ea589ebe4ac6bad981f09b78d5206a74a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-08-sticky-recording-stack.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9ad2e218f295a9fd78c9d7d1bd63f1fe9fa24238",
+      "byteCount": 60970,
+      "sha256": "43a29c094ab43aec7c38536033b66c6f4aedd7d9dc87c24ecfb97352204d3419",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-09-inspection-light-table.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "be28207b9ba9efc33fbac7ac1d7f627a89df9c3b",
+      "byteCount": 65709,
+      "sha256": "c1247a922eff0b2980890943741aa452bda591dd16f539e2a57d886c654d9643",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-10-final-entry-dissolve.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cf99d95a4c3c8c13a9a8553120cf4d869b4aa57d",
+      "byteCount": 111653,
+      "sha256": "a30f73210d88e953403da5926943b10b9aeca14001cd6ad619edc9d14007d0ba",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-11-silence-dark-room.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a4ea4bd4f80805aa3474ace02acfd2f65a8bac11",
+      "byteCount": 25968,
+      "sha256": "887ac904efc9a9eb045c0c54e2a45ddf55398f6693bc0686095bbb4949dbb2fb",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-12-field-log-reveal.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7589b7a3aa86cff87b6a34ca0d69a4c793ca93f3",
+      "byteCount": 47269,
+      "sha256": "af003f95ae4b50648db156748c3d36c8782d5abda35386f460fa2d9f1781e3ea",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/assets/mara-voss-13-magnetic-footer-utilities.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f8fa8258d78cb8fb6bf1da0eb321c7ca06391cce",
+      "byteCount": 32706,
+      "sha256": "8a13cfb75eebbadea33b3a39e96440e0b6854086a5b2e359c1aaf4edd9680600",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "c9972508d02746fece7c51129af21644b54ef719"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "345f5a0bc7006fe291694781616a742bcc3d75d0",
+      "byteCount": 1888,
+      "sha256": "0bac43a0aed4dc1600c5e1ba580dac49843a81087f3de667b5f9bff9e078c101",
+      "artifactClass": "prompt",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bdfb44e7f840fb2857301ffa668ab512e091ca3c",
+      "byteCount": 5132,
+      "sha256": "7fe8812ae8e811b7850134ea4f38cbca2a25b42cfd04b00b4866cb5f817e7c43",
+      "artifactClass": "demo-html",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-portfolio-chapters/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fbc4e8635bf7b8edca30ce2647ba0c456de2cc88",
+      "byteCount": 88585,
+      "sha256": "0c93374ea2f6ff40eef73e0bc9c65e6235737a9f53ef0e4f40c2092475125184",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-portfolio-chapters",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt editorial portfolio chapters story structure with curated section interactions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d1ab2fbc1fac0e7c5ba69db2b4ecbe7776309599"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "89ee2f28a8ae14f780423fd853226e62f38c5806",
+      "byteCount": 158,
+      "sha256": "4cabc1e4840241134331854ffa0884e2693d252a747093ef464a20da3d79081c",
+      "artifactClass": "reference/article",
+      "ownerSkill": "editorial-service-booking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt service booking story structure with truthful operational and error states."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "02eac7b8c0f910e14b6df6799232f526ad1355b6",
+      "byteCount": 4419,
+      "sha256": "a02695cff83e0c419f17a9ace237ac543f677a75e3242c51ce9f16c801eccbd2",
+      "artifactClass": "skill",
+      "ownerSkill": "editorial-service-booking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt service booking story structure with truthful operational and error states."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "01f8e972deb3d2d44774847de26ccaaee7cbf0c3"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3b4ed9207d353f69ad8884c85cc0560d64b4d05d",
+      "byteCount": 275,
+      "sha256": "cc512351bf171b3ed5d55f5130092edb56e65b258b296aaa4fb56c67667f2773",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "editorial-service-booking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt service booking story structure with truthful operational and error states."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "b8e267d2b53b00d7b177e2ac0c51f02fb370fa53"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "03078c2e03d696c2dc606329d808653d6eadc6e8",
+      "byteCount": 2000,
+      "sha256": "a3d02fd555b85fb1fd68ba1c8b78c5f138bac3d3827d0525e7b49107bad78b32",
+      "artifactClass": "prompt",
+      "ownerSkill": "editorial-service-booking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt service booking story structure with truthful operational and error states."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cafe7cbb7179d9e32b49453ac6e416fcb66fbe05",
+      "byteCount": 6826,
+      "sha256": "ef46b990f8c4c3f79f2559d91db6849c9f331d7e25c809c5fed24e8f35b61727",
+      "artifactClass": "demo-html",
+      "ownerSkill": "editorial-service-booking",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt service booking story structure with truthful operational and error states."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-service-booking/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0381a70aa5cbb210358763f40eea07df72af1b5c",
+      "byteCount": 86277,
+      "sha256": "8f1ee6683d19006ddbb085e3968044424f1b785a234f224810215430e97c21c2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-service-booking",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt service booking story structure with truthful operational and error states."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6f6767c5b79190ffda6e11e36e9b9c7470999444"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "db607f4a7dc52ae386cf60a634eff008906ec7ca",
+      "byteCount": 4261,
+      "sha256": "9f032de321c81b2e7ae7fa451d6b3c7bdb7dfbf082ff735e5af4868e3a0b9300",
+      "artifactClass": "skill",
+      "ownerSkill": "editorial-tech",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "bb59f91e042283b0c2610c7b87918c476ca7fb69"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b160561c85f229bed0994203d21f598685d28707",
+      "byteCount": 3268,
+      "sha256": "bdc274676ef0f84d3495a000b5d0518c2662cd83979f1bae3f20d6627854b353",
+      "artifactClass": "prompt",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "e323fbdb0b7440aa8ec6c905182b5613df63073c"
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/assets/page-01-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cb7656849d3d492e5a7dfbfc84a8ba4affb433d0",
+      "byteCount": 47486,
+      "sha256": "6a7bb45fc2ab13660d9c66de569563e928ffaaa526d6f44f5d3147d5c35699f7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/assets/page-03-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5fcee093507f32bb37ed1d6f3e3b98822d2704b0",
+      "byteCount": 111548,
+      "sha256": "d1cf2835a4411c20236c5b9b4c27599768e45c87ae3bea2332e35d0c0519085f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b4c0e50d5e437fc7d0e8458f760abb960d92d742",
+      "byteCount": 47005,
+      "sha256": "b7cbd83537c98728b3d59f720bd93f6a9037e564587cb4a117dbbb5e813248c1",
+      "artifactClass": "demo-html",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5f37bb9074177c805d192bc8f6dce8370e0d67af",
+      "byteCount": 60398,
+      "sha256": "5938e6f38a7a813c0aafc96ffca5ce9265ddbf52f3ea4b677207943bc8ffb57b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/editorial-tech/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3397d09560593f7a9e22f6633742eb18b74a18a8",
+      "byteCount": 3987,
+      "sha256": "a1ab3cda5efe39c5597c4ad3fbc870e8cebdc5f3a8cdaf17d420de5e70565d17",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "editorial-tech",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio structure and existing persona definitions."
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "a5a6b332b779ff849c87c85a8c67a3c912ba192f"
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ad257dd19843298c91b0fb253cdf3cb44a29abc3",
+      "byteCount": 7896,
+      "sha256": "8776f677ccb9e5a18d7950cffe960b32f1c1e1c9aff1c2be0868316a1f1c7ace",
+      "artifactClass": "skill",
+      "ownerSkill": "falling-leaves",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ambient particle foliage specialization with coupled tumble and slip."
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "e8f3f6aad3f3ed54dffdfd2505e049584c693591"
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bd59d3e230544ba670896306650a373f91b2bd21",
+      "byteCount": 258,
+      "sha256": "0e007b1fb89aa12cf6bbb0561abe422f93ea1a90ec12ca42b80d4627a363c2b0",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "falling-leaves",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ambient particle foliage specialization with coupled tumble and slip."
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2b5f6f0c00551d60600f7834a4e1168f5ecc330c"
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "eaccfb34a04c10cb25f2f16836fb796a393bfcfa",
+      "byteCount": 2800,
+      "sha256": "7371d9ec25d5fa820a5fc9d14746829415165bb56a1a90a4a7ad1ad7aee214fb",
+      "artifactClass": "prompt",
+      "ownerSkill": "falling-leaves",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ambient particle foliage specialization with coupled tumble and slip."
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fa3bb183925c4e26451284afe18929b5ba379910",
+      "byteCount": 17612,
+      "sha256": "a5f97c2fb5a19e7a441af6468c4f7976cfa4e5e2677f009a371fcd55d965ceda",
+      "artifactClass": "demo-html",
+      "ownerSkill": "falling-leaves",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ambient particle foliage specialization with coupled tumble and slip."
+    },
+    {
+      "path": "agent-skills/web-design/falling-leaves/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "05abf0eeb37c62ec2f350b24550331994f8076b6",
+      "byteCount": 68745,
+      "sha256": "71a740b61f6f53c9ed2f8cb11c2f1841392129b0920ae83a7f0a8b9680b0094e",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "falling-leaves",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt ambient particle foliage specialization with coupled tumble and slip."
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "e9bb594178cba40e0e7415c57bc0eb48daffffeb"
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3604314f873d744d097bb78a3e2d35f65763c562",
+      "byteCount": 4784,
+      "sha256": "0888e311ada1a4d8967a26a3650b5a521cce54bb2aad627f6c32ff12b3b03da9",
+      "artifactClass": "skill",
+      "ownerSkill": "framed-grid-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and corner bracket detail devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "c4ea389144169bd35b7868071ef9d3c670d05440"
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f37663dc34382956cde832134dc49048be47db00",
+      "byteCount": 2794,
+      "sha256": "a45b7cfe9d51c40c36f1f33c428835b3338ce58a85b426309e649e1954890d52",
+      "artifactClass": "prompt",
+      "ownerSkill": "framed-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and corner bracket detail devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4c9f7edcd98f9ebec0da212754fa61b86f165607"
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b1fbd79f1cbb72b4908bf956970bd18537ef80b7",
+      "byteCount": 26881,
+      "sha256": "3bfb70e2fd5359c261e9268583aca339d4d360fd774854977af109d3ab3edc6d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "framed-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and corner bracket detail devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2803ba602bc466b0ebcae2fa8e7921a98ca701ed",
+      "byteCount": 27066,
+      "sha256": "7cd43cddf21947985f32ffefd02d2f2f4273cf79c438b0fa9dadc089fd35b329",
+      "artifactClass": "demo-html",
+      "ownerSkill": "framed-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and corner bracket detail devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5e161c89892e4189aa3538cd0e7029057c550bb3",
+      "byteCount": 27949,
+      "sha256": "b10f42b251e127513db9ed4e124adce7ebee04101be446294a38e2e495d828a9",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "framed-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and corner bracket detail devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-grid-layout/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3fe835c7c58d7fd08f205acb1aa9f1348fc4278d",
+      "byteCount": 2009,
+      "sha256": "5453827d3eb58bab160b676af5b6446e0d09ef378d0faf343f7983ec8f2e9f72",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "framed-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and corner bracket detail devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-tech-dark-border-gradient",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "0d782a41f701d5d7b10e8a44e5ae62131b7b7bc8"
+    },
+    {
+      "path": "agent-skills/web-design/framed-tech-dark-border-gradient/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3f162fccd9e9a99a1dc24fc6b4ec28df9edbf8b1",
+      "byteCount": 4879,
+      "sha256": "ab553a6dceadfc4b391d4e3927a64b9c408eb60f41468d02d0d153902295c154",
+      "artifactClass": "skill",
+      "ownerSkill": "framed-tech-dark-border-gradient",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and gradient edge surface devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-tech-dark-border-gradient/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "e5f02423f7b5f59422586c78f399f92196459f3f"
+    },
+    {
+      "path": "agent-skills/web-design/framed-tech-dark-border-gradient/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "eb7e7fb54bccb1b032f594709b507a157f35be62",
+      "byteCount": 1972,
+      "sha256": "6c9cd22e44f08be21c3ed72a29041e623cfbeda52f0cec303018b5ebf0a0cd21",
+      "artifactClass": "prompt",
+      "ownerSkill": "framed-tech-dark-border-gradient",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and gradient edge surface devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-tech-dark-border-gradient/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1b8cd79c0ee658ebec7d8a67bec7c6e115deddde",
+      "byteCount": 17092,
+      "sha256": "444c24819bcf0ede80ce857b6e614c7a44ebe251d33a6c7e9e2349bc79b161ec",
+      "artifactClass": "demo-html",
+      "ownerSkill": "framed-tech-dark-border-gradient",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and gradient edge surface devices."
+    },
+    {
+      "path": "agent-skills/web-design/framed-tech-dark-border-gradient/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fe20fa13a78f392d67a7c6c405f4d8bdfe60565b",
+      "byteCount": 62249,
+      "sha256": "cb97de856b8b249fa848acf80789c83f611ffeb89d66001aa02fe4c601980e83",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "framed-tech-dark-border-gradient",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and gradient edge surface devices."
+    },
+    {
+      "path": "agent-skills/web-design/funky-purple-container-tech",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "92b08f4b6e1fe8d341b0ea042126be4bb11a79c9"
+    },
+    {
+      "path": "agent-skills/web-design/funky-purple-container-tech/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "48b9f75b8d2cd73fe7e834703c80e0accefb2fd6",
+      "byteCount": 4451,
+      "sha256": "101e990d553e0cb13c6aeb485865e706e5fa7456a105a039f2439554b0a31dae",
+      "artifactClass": "skill",
+      "ownerSkill": "funky-purple-container-tech",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout combined with color persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/funky-purple-container-tech/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8514f35f164275bcf1ecffb1c88654442c75fbcc"
+    },
+    {
+      "path": "agent-skills/web-design/funky-purple-container-tech/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1d19f7fb2a7c73d1fb2015002d16b46f5388dd2a",
+      "byteCount": 1936,
+      "sha256": "e5fc6f01d3594d04e3c4150fc4fd372a6eb050eff5db7595fe29fdd54e7d702a",
+      "artifactClass": "prompt",
+      "ownerSkill": "funky-purple-container-tech",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout combined with color persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/funky-purple-container-tech/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e157d8eddbb08a5c9e913e750468608ed43a2ba6",
+      "byteCount": 16838,
+      "sha256": "889729e90cf2adf7cbd2364d6fbd1a129a9d4b93f5ac852313cc7c278e4345cb",
+      "artifactClass": "demo-html",
+      "ownerSkill": "funky-purple-container-tech",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout combined with color persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/funky-purple-container-tech/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ec27a1a01f90f039d115e30ba663e03cfc517001",
+      "byteCount": 74083,
+      "sha256": "311bcc28241126b1ab41650c0af2b6bc65a7c7ec0b25bf374dad9939f2ea3926",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "funky-purple-container-tech",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout combined with color persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "1acb553d5ac7f4c350b0ce58f4dbad678c36630c"
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "57b3d88eb995748c9a781e5e5449bfcb54bd13ce",
+      "byteCount": 4151,
+      "sha256": "7be1a8d076cd1e940f33ae6a6f5b9aaaa91c1078c15b511623a38da30b3397ce",
+      "artifactClass": "skill",
+      "ownerSkill": "glass-dark-mode-clock",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by glass surface device and specimen page structure."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "750e77962bb9ffb2935857831bf71d17bc58ca91"
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "12e0ef588e63e3fe72c99dc1cf69008472632aa9",
+      "byteCount": 3258,
+      "sha256": "a8fe35f00958bc4ad187b32dfb514d0d5113ae80c4e8cbbba627a0f12d2e1f3b",
+      "artifactClass": "prompt",
+      "ownerSkill": "glass-dark-mode-clock",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by glass surface device and specimen page structure."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4c9f7edcd98f9ebec0da212754fa61b86f165607"
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b1fbd79f1cbb72b4908bf956970bd18537ef80b7",
+      "byteCount": 26881,
+      "sha256": "3bfb70e2fd5359c261e9268583aca339d4d360fd774854977af109d3ab3edc6d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "glass-dark-mode-clock",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by glass surface device and specimen page structure."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2803ba602bc466b0ebcae2fa8e7921a98ca701ed",
+      "byteCount": 27066,
+      "sha256": "7cd43cddf21947985f32ffefd02d2f2f4273cf79c438b0fa9dadc089fd35b329",
+      "artifactClass": "demo-html",
+      "ownerSkill": "glass-dark-mode-clock",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by glass surface device and specimen page structure."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0248d87bf6659a828967ffda4a7b0dc873b104dc",
+      "byteCount": 28294,
+      "sha256": "26c9b8fba847c7b7d70cbf74f1c34b87d1ee2b035b41af2131a5ac120bcea6e6",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "glass-dark-mode-clock",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by glass surface device and specimen page structure."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-mode-clock/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9be367d9f5cc2082ecfb5fe6fa8feff1a661cead",
+      "byteCount": 2017,
+      "sha256": "a5dcfe6c3d8b99181aa28f098a653219505a95ac081aa8a3405f7a8466bc5b6c",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "glass-dark-mode-clock",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by glass surface device and specimen page structure."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-ui",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "669bdfb00f1a98e17f017a4a13a891fe4e5022e3"
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-ui/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8ce6f95e14d0a8e1f92bda2588c34172a3962843",
+      "byteCount": 3146,
+      "sha256": "ff607716e434e6aecb53e738122d28cd149034f51ff35c4e3bf4690d7b69c9d3",
+      "artifactClass": "skill",
+      "ownerSkill": "glass-dark-ui",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by glass surface, gradient edge, and depth rubric constraints."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-ui/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3759101c44f418bdd9695e3cb9b7c5732fe3de7a"
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-ui/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "184526bc2b8121c01151158672096b4eecfdd11a",
+      "byteCount": 1988,
+      "sha256": "54198cf4cf1c4b6eacb2671d2aef292889ad81416075dda187ea956b0cb54cb2",
+      "artifactClass": "prompt",
+      "ownerSkill": "glass-dark-ui",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by glass surface, gradient edge, and depth rubric constraints."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-ui/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b5e4a1608d261f07ee33cffea5ecdf04a32b8f1f",
+      "byteCount": 16622,
+      "sha256": "5df44366be47d4a5979e7cbf47a3e502e0c397fcd08449c8cb44d6e55b73cb99",
+      "artifactClass": "demo-html",
+      "ownerSkill": "glass-dark-ui",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by glass surface, gradient edge, and depth rubric constraints."
+    },
+    {
+      "path": "agent-skills/web-design/glass-dark-ui/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "13211fc4f4efd6d9036ed5c1f945445ad313929f",
+      "byteCount": 53383,
+      "sha256": "d7ef91bbc50d7d69dc79d426b54552036dbcb3ecf6f8d1008b5ad483bbeef2ba",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "glass-dark-ui",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-05",
+        "SUR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/taste-rubric.md"
+      ],
+      "reason": "Covered by glass surface, gradient edge, and depth rubric constraints."
+    },
+    {
+      "path": "agent-skills/web-design/globe-gl",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "fa30e345036cfa1100b28da69d5f948867fd2724"
+    },
+    {
+      "path": "agent-skills/web-design/globe-gl/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "34edbed282bcd4f58b5d5cacbabe32512d66c4b1",
+      "byteCount": 1638,
+      "sha256": "e2739e1f035f78aba3268ff2ce2a5b0b13fa33422781071f94c22e87a58de912",
+      "artifactClass": "skill",
+      "ownerSkill": "globe-gl",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and redundant runtime dependencies."
+    },
+    {
+      "path": "agent-skills/web-design/globe-gl/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "76bb5254f9099ffab3a2f0861844b49186765403"
+    },
+    {
+      "path": "agent-skills/web-design/globe-gl/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5d71be32640868f00c4a5f503055b5fcf67d4759",
+      "byteCount": 1863,
+      "sha256": "f24051ac4b793b26abe2c2c4c540b1a744f0a073a5c8f98ad6bdb981cbac05c9",
+      "artifactClass": "prompt",
+      "ownerSkill": "globe-gl",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and redundant runtime dependencies."
+    },
+    {
+      "path": "agent-skills/web-design/globe-gl/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "46b02f4a21c322add61c11c5788d890049066567",
+      "byteCount": 16250,
+      "sha256": "1d2cf54cdf6408ebda56472c6ce52d698ab7a62ca3e364531baffb388b5ae047",
+      "artifactClass": "demo-html",
+      "ownerSkill": "globe-gl",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and redundant runtime dependencies."
+    },
+    {
+      "path": "agent-skills/web-design/globe-gl/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "944cd5d281f1c16b5d31bc5ab23d2a7621f9e44e",
+      "byteCount": 45363,
+      "sha256": "884376b05c113b4166c9dbed53744d30e5fccf3b603b8214a27843badc2e376f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "globe-gl",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Vendor library wrapper with volatile API and redundant runtime dependencies."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7447c1ff8ec7ef98fe527475dad514ed9cc2ccd9"
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b55295f3f06354e1173761fb94fc53d766280663",
+      "byteCount": 9887,
+      "sha256": "b29b372a1790954ea97746dc1ca62d82cc605c00ba4b88d95c3a1f0dcba4e171",
+      "artifactClass": "skill",
+      "ownerSkill": "globe-particles",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9933e8cd110a483e0ea825e93d58da15b050fdaa"
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4f16894d9d6e59390a1ea5658b7b05a08b7a2b6f",
+      "byteCount": 3256,
+      "sha256": "e9c461627f2ca7edae249203832f351d5d306f034235bd61151be6c45fd4cb8b",
+      "artifactClass": "prompt",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "e323fbdb0b7440aa8ec6c905182b5613df63073c"
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/assets/page-01-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cb7656849d3d492e5a7dfbfc84a8ba4affb433d0",
+      "byteCount": 47486,
+      "sha256": "6a7bb45fc2ab13660d9c66de569563e928ffaaa526d6f44f5d3147d5c35699f7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/assets/page-03-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5fcee093507f32bb37ed1d6f3e3b98822d2704b0",
+      "byteCount": 111548,
+      "sha256": "d1cf2835a4411c20236c5b9b4c27599768e45c87ae3bea2332e35d0c0519085f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b4c0e50d5e437fc7d0e8458f760abb960d92d742",
+      "byteCount": 47005,
+      "sha256": "b7cbd83537c98728b3d59f720bd93f6a9037e564587cb4a117dbbb5e813248c1",
+      "artifactClass": "demo-html",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ceb0f6977c78237fcf27414fe21ec98deeed4879",
+      "byteCount": 57969,
+      "sha256": "53756c023bc89a5f7f291f4e33eb062ee84758c9305de0bc0a2d2f0d72e7db84",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/globe-particles/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "77c55fa2cebf1855a10c70825dcef53584d31fd7",
+      "byteCount": 3990,
+      "sha256": "0b4c77d996c37ebf595a81c1b683bfb32d06eb6bfd7ebfcacf41950995659ee2",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "globe-particles",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt particle globe canvas effect with density layering and disposal."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "5637515f5b36f3c9f80c603bb4cf7d41701b0485"
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2ade4f58afd81bb00c55a62d8c1144788b5b5e29",
+      "byteCount": 1361,
+      "sha256": "48cef691946621cb90b0891a19b9bf9076fddfe54961847f78223515475894bd",
+      "artifactClass": "skill",
+      "ownerSkill": "gooey-blob-system",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9926abf5aae85de5b55bdfc9613aa933a5a7eadc"
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b4acc606f3fa4b36bcfa6d706bcbf9d7378935e2",
+      "byteCount": 3353,
+      "sha256": "a2df9e24c8b46d18f825950a2dc1c13c37b32f75e47cc91623fa88b2d421dd1b",
+      "artifactClass": "prompt",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "358e6e5f1541a82e5325ca6e0c7506e297802b9e"
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/assets/page-01-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2d791d66906a67e0bbd80e16d8a37f577798a7dd",
+      "byteCount": 282854,
+      "sha256": "0d71068ad67cbdbfca87b5e5f57f21fbb47fb29148e2ae8d2e1a5df136ea5cfc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/assets/page-02-3186f9ea-5f5a-49f7-8fcf-568ad52f515e-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "53ac591b09701e0ea83163e97db2663ed881a526",
+      "byteCount": 599390,
+      "sha256": "852496aebbe37c983c885d9aa20b3520e0c0244472703e3c2925b9c56f749a2c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/assets/page-03-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/assets/page-04-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "47b21e979b8d2fff5e7cae8373a42c0b456cb16b",
+      "byteCount": 81351,
+      "sha256": "8fa5ea63802229c4582ff7fb374d9faca16c134306b87e5d6e1dc02d16542d49",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "95383f995578e4c5c2e6d57da408a8973f191300",
+      "byteCount": 30129,
+      "sha256": "e3e7f73f42b35cad267ec86b3ac7ce153518d2cae57479d149e2c5aca7ecb0d2",
+      "artifactClass": "demo-html",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "92674752c5f548b492608d84e556a20485cdaa04",
+      "byteCount": 61089,
+      "sha256": "4b78dc92b8d722bb166ddd97081557489f959a35fe7d664b5f52b409c0b19254",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gooey-blob-system/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0ecec838564a6e94c33d8191c8e0cfc338e2af70",
+      "byteCount": 3711,
+      "sha256": "f540fc52339c57ff58e414b26d02f9a34b89a3c13cad2a03b6f321c883fcccdc",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "gooey-blob-system",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-10"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt gooey field surface device using SVG filter thresholding mechanisms."
+    },
+    {
+      "path": "agent-skills/web-design/gsap",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9b34ed80704b3f47cdd34f546eab81953ec7d1dd"
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2099f43a1ef8cc32a9f4cdf95f0f4d40044d3f90"
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d7bb720764d6ed3bda4713b52f3dad306809d8d9",
+      "byteCount": 4034,
+      "sha256": "c388738853064f4bbb4293b910efc0fb82f957298a49c94214c2522b138ae939",
+      "artifactClass": "skill",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6b7284576be7537dfa50a035cf1121061215526a"
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "410911598dd69ef7d9d3b50073bdcfe2e39d2ef7",
+      "byteCount": 3615,
+      "sha256": "69a28459c0f18e9f98c2dcb91ae7589f1fe6c90c97353449b0aa7f0e6e882bca",
+      "artifactClass": "prompt",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "e9dc23cf4e8fa6540a04d3c7a90195b064546e98"
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/assets/page-03-1779243686348-eb642d26-a435-4dff-bb2f-0003b03f70.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6d07542937649992427ecea9e429841baf72e6ce",
+      "byteCount": 5218447,
+      "sha256": "2d28009f665e6351d89e8a3b7d124a96d77242c3d01458a5bbf9d965c4d92c1a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/assets/page-04-1779243717410-ddca821f-6595-4a25-8269-cc90ddb2c1.png",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5695acfabd178a9c87cd7f12aae28dda867cad7d",
+      "byteCount": 4404485,
+      "sha256": "5fd7eca9c4ea4228b16e5d3c1ce12394cfea1c7aaf494607908a1eb37adf455c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "607c03db7a9935954b3324c6087370979cdc197c",
+      "byteCount": 97137,
+      "sha256": "0461c9c68dc4519cb7634c71fb32adb594d11665178fe9a34098abf89ae5596a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "562956f3330bd815886aa19b86e34603258d24b1",
+      "byteCount": 52946,
+      "sha256": "087ddd5b600038e5cc9dcfa60322858b38c7f82cf29eb40072825620929461af",
+      "artifactClass": "demo-html",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "63e4ca58eaa80cd5a44208cb0148cd201019c33d",
+      "byteCount": 81396,
+      "sha256": "50cd385199b048c33a6c60688a1ee747d20c5adb7c728cfd08089a23facbbb0d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap-scrolltrigger-storytelling/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "60e39325e454c76d335f2a9198f12dacaec26728",
+      "byteCount": 4157,
+      "sha256": "79d5f42576f8ed8bce14bb84ba1efdc8a7cfed32e418bd7fb1c4856d88c931ef",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "gsap-scrolltrigger-storytelling",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by cinematic chapters structure and GSAP scene contracts."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "217b3ed2eae9a4ca46dcabe6233dba30dd9c4893",
+      "byteCount": 198,
+      "sha256": "d6ad0e2552a4c4b6b6d27f7722c20b36653a9836335523ebe50eaf3a59fde40d",
+      "artifactClass": "reference/article",
+      "ownerSkill": "gsap",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a5e8f70737643fe06a2a5185d2028c4022cf8b98",
+      "byteCount": 3084,
+      "sha256": "eb9a0a84f0747fa19ce693cf776328945aebee1205ddc42c518c133c2ab6cb42",
+      "artifactClass": "skill",
+      "ownerSkill": "gsap",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7dfb8bda7022b0015a9689b8e209d05de84ecfa5"
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "11c8e5f17fc5a31475b0ee54ef49bc92a43d2330",
+      "byteCount": 2494,
+      "sha256": "b3b2d2bcecfc075759c651b3e06877ee4d4c827b048a189e51f12d10a56ff40a",
+      "artifactClass": "prompt",
+      "ownerSkill": "gsap",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6beb82c738c87a9d488be956b5dd760f684f40af"
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/assets/page-01-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a54eb4ed953818d1a99fa1e01a0b707f2b8dbcb4",
+      "byteCount": 53370,
+      "sha256": "2739f91b816b2962674544bbf18e60661b4447bd222366cc57c8bf8c1ff3db5d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/assets/page-02-0d868fef-f560-45ca-ab35-5dad4fc29059-800w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "24e29813ad47692a454232599e32ff4ecc21edc2",
+      "byteCount": 55628,
+      "sha256": "6b8ffa16cacb9d088a24668994c0461f5888a4623133f5c1e2c381fddc6aa4fd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b33b53977c4817d7025afed70a87a2e01a82b514",
+      "byteCount": 35102,
+      "sha256": "4a8a2d4327f052f65c479b958cff5fd335bfbf8a22c4c51829cc30c0e7a82b31",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2e9fd6f23c9b96a5671c424b968f04b4e892a68b",
+      "byteCount": 35372,
+      "sha256": "ed07c516f9bee15a7bceea79e7f8cec85bc77bc9d9154a0d453eb416c7072d57",
+      "artifactClass": "demo-html",
+      "ownerSkill": "gsap",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "354e3a5eac2ba00ccf707b29ebe0c15c63c57ab5",
+      "byteCount": 31450,
+      "sha256": "5b14f294d2a4916202a9af893b8b4a0e161810cead637c28e5c28ce9bf6f8124",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "gsap",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/gsap/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6ea2e6602e424e92b80eccbc5b7379672b8740ea",
+      "byteCount": 3640,
+      "sha256": "a4f052705845afe6400659407a0b69a2e76fa382e6a322fcc82134feee668617",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "gsap",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by existing dedicated GSAP motion direction guidance."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "5920a24151dcf9d6a99c43ce15f1a2ee52fbfeb2"
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e31221e976310d9da9bf1b6bd287a4900058ca4",
+      "byteCount": 4713,
+      "sha256": "6381a8257a1a42df490a12ce0902fb7b70acd50c8d231e86aaaed29d33fdee81",
+      "artifactClass": "skill",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "15ff498aedbc9eae93055c43aecbbeddeddb1631"
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0018d15a34a0c63407c0f5d53b017ffc272d81ee",
+      "byteCount": 3354,
+      "sha256": "c5521cd9d7a74e3db2cf9267dc52586b38cfed13cea41bbe1d4c80a0af69aeed",
+      "artifactClass": "prompt",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "b3d2434f463aea7775bd1aa934f8ae70dc28f107"
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/assets/page-01-77415a2e-dcbc-4748-a29d-fced4821881a-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "147def26626bdfac02c61e676c61213c323e8d1b",
+      "byteCount": 82206,
+      "sha256": "60c2d86441939d86784ca67dc7730da33a29d137307d40a72f9af744d0548d58",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/assets/page-02-eca707cc-a5b7-439a-b4fd-247f6106c2e1-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d50d497ac81cf54826eb3f26b136ee8f911b95a4",
+      "byteCount": 62810,
+      "sha256": "380665b3fe4d47990da36c79a8c8ac09779534d1d9687430bb2a8a750843bada",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/assets/page-03-3186f9ea-5f5a-49f7-8fcf-568ad52f515e-800w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3e7a95b41591b4d1b5744e25bdbca122d3be343a",
+      "byteCount": 74294,
+      "sha256": "fa447f11dc2fd203e6ac152b93e91da2642b5f5e91db8c87cf1ebfbfe0eae8ce",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/assets/page-04-4734259a-bad7-422f-981e-ce01e79184f2-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a620cf0f49f7c022088bb135db4c864d8f150a9f",
+      "byteCount": 17083,
+      "sha256": "d7b17e4c44f12e6899c68e9cb95aaae84fa548c2f879e032dbc32799b3f97380",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/assets/page-05-005600e5-f6ab-4e59-bc86-eaeb02797dfa-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7f46fe37232130157f514bdbe2d7ab0251c007c8",
+      "byteCount": 194699,
+      "sha256": "d3486deadf6ebbedd513d514f1f7202592fbdffefd6c45ea65cadf36d58004de",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1c48d21ec944b9d40859c473dcd23ec939164fd1",
+      "byteCount": 91289,
+      "sha256": "2e851d1182be539271b1772251716286ebf31cea07ccba0db3e8be5c2a1ad5bb",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7280b2ed01320f5cc8f0cdb4e1a4588f38110c3a",
+      "byteCount": 60839,
+      "sha256": "53366d8e3c52fb3df510ff3bf670646d5a30da720fa44f214b7720ea88ed2e1f",
+      "artifactClass": "demo-html",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3c4624f277495e8a430209f5694b6ba0811cf784",
+      "byteCount": 60691,
+      "sha256": "9331639c4dd7d4d828d8bae0a367fb94a264f754201b1af5c677f087cc16bd50",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/high-contrast-skeuomorphic-clean/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "58cebd3399f54e3095293c3110bbc325844bb849",
+      "byteCount": 3812,
+      "sha256": "964fa7f567629a1f254da7759a9fa228681452f59b1058af38f8785d830de51a",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "high-contrast-skeuomorphic-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by tactile depth surface device and persona selection."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f31e9698566fedc1b29d4c98ec54d5215ec459f0"
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0db1d1e9a06c9967cebfafbc3885d7e71123300f",
+      "byteCount": 4551,
+      "sha256": "76aa7e263f9c5b81920622c6c9e175a09eef10bf3d8c11a7d3edf5c95fe58abf",
+      "artifactClass": "skill",
+      "ownerSkill": "image-first-grid-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "89bfb3edf24f65e1f8ef1fae4678bb8abac5e89d"
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e5b00fcfce2130431bb047e26e5e2195fd910652",
+      "byteCount": 3489,
+      "sha256": "877479a156a0d6928233c055b2e8660ae2f1e69fda358ff06d6743a9501390d8",
+      "artifactClass": "prompt",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "48b414490df3573bff95f7d8871eccfa88eba267"
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c17c9ed9481fe26fe7fdfca9a0a8dab4dd3a771d",
+      "byteCount": 201962,
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f77fe5bede25677fe105589063c8b434ac5215e2",
+      "byteCount": 139542,
+      "sha256": "3ecad5d2605bbf56d3f02c0a2a4673d574d405a5d830e45b43d6a34c01cbe992",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ea0c87673cd6f78aa82acd6bcbacfb81d4c24047",
+      "byteCount": 45479,
+      "sha256": "4559d22599d5ed733eb14ba074e37de12e8db297571b70be93b898a347274658",
+      "artifactClass": "demo-html",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f2ea35d29c64fa36635ad78123be5627f1035be0",
+      "byteCount": 98145,
+      "sha256": "47dc6ced9e3d2354583a2dec0adba4c2d7da55e6325f48b38cbfb28c39f6e2cf",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/image-first-grid-layout/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ced21324228048bb32e25c85f91ab9a733d80247",
+      "byteCount": 4541,
+      "sha256": "76e52ce6f482adcdd57e82898d942803fa516a713f4d2dbab4c17caec4d1e596",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "image-first-grid-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and portfolio grid page structures."
+    },
+    {
+      "path": "agent-skills/web-design/landing-page",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "366d826c8032e02c08bfc1e3f7987be95bbafff9"
+    },
+    {
+      "path": "agent-skills/web-design/landing-page/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5185573c128cd68886cae436f7f94168067499a2",
+      "byteCount": 288,
+      "sha256": "c9a30602bd550f0db3716a48873660397901bfb498914ed332f6b036f7add57d",
+      "artifactClass": "reference/article",
+      "ownerSkill": "landing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by single-offer page structure and conversion evidence hierarchy."
+    },
+    {
+      "path": "agent-skills/web-design/landing-page/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ba43c9b98417818daf21bbeab7a460a49e416750",
+      "byteCount": 5275,
+      "sha256": "6ad9965bc6b8f682340998ddd17c7700f5529ae40603d47c3b4610892c459cad",
+      "artifactClass": "skill",
+      "ownerSkill": "landing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by single-offer page structure and conversion evidence hierarchy."
+    },
+    {
+      "path": "agent-skills/web-design/landing-page/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ee0c180bff6ca5b5402105f0b3f3fc05c5f6fb11"
+    },
+    {
+      "path": "agent-skills/web-design/landing-page/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e1e24df731f6667957ebcd6b3cd96e717e346eec",
+      "byteCount": 1894,
+      "sha256": "a227949e046224a9aa99961b48e57fc4265e71fc040639f0c768141093e9eee3",
+      "artifactClass": "prompt",
+      "ownerSkill": "landing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by single-offer page structure and conversion evidence hierarchy."
+    },
+    {
+      "path": "agent-skills/web-design/landing-page/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bb904555ba5d69186892810a879a08a59a7227c3",
+      "byteCount": 16513,
+      "sha256": "169b11a536877958c87d7580ef776285766ef729f9a120247dd73833f320e82f",
+      "artifactClass": "demo-html",
+      "ownerSkill": "landing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by single-offer page structure and conversion evidence hierarchy."
+    },
+    {
+      "path": "agent-skills/web-design/landing-page/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf675b44f5525adc47345f4f9b684fe0ad0a7948",
+      "byteCount": 57720,
+      "sha256": "89aa4f57832d02a817f593271b6ec8627b2d3ffb39a0625d63985c4032af129f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "landing-page",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "STR-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by single-offer page structure and conversion evidence hierarchy."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9b039d32e324fb6c1163d3e5df3e18dc8c4f09bd"
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "97ae8257385b0b6346b511cd68f05e01bec51573",
+      "byteCount": 4189,
+      "sha256": "f09d5b7cb8263b19d0aecc2e305a4d5f249a71187004860b8ff72272026a3f31",
+      "artifactClass": "skill",
+      "ownerSkill": "light-mode-paper-technical",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "a9326e79060f71f9afeaa5aa42a6742b77783e80"
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "72bd0a681c023100d0dd2184a6243f2642c105d4",
+      "byteCount": 3389,
+      "sha256": "ff92b60f13c5783a354f1a0dbe1e85878f3e4429300220e19e7f71026dde3e9e",
+      "artifactClass": "prompt",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9ccc59f2c87b29a47c003048cf6c0d26f944029f"
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "764233ff37fe552c54ee65be0329754f008a9577",
+      "byteCount": 362749,
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "072de2e20e298844fb880a2cf82fec2cca237d75",
+      "byteCount": 73780,
+      "sha256": "97c65569d294acbb5072f963eec2f67f57fd3e8fbba84cfa9a1bfe5042e92d54",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c038b784376e3d3e62eb2dbcfc1133ff787344c9",
+      "byteCount": 21909,
+      "sha256": "7abbd51e4c973de2df8ce06f7b1f24f9c20cbfc4cabb0438b88e80177d26f50e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6f8c9bb5e0aae0e546c890db29bd26d47aa32411",
+      "byteCount": 55563,
+      "sha256": "ef8f2e8093d0edfa63fc8a35cea1310f7a0be5b255dd0966049bfb72aa0c7357",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/light-mode-paper-technical/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "72bf523d8d450533593cea934b0758ac734ac172",
+      "byteCount": 3306,
+      "sha256": "e5a57b48690449d9c6b3f8c51f8dc967d0bf11a118ecaaf1c5335b016a406d50",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "light-mode-paper-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "DET-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, corner brackets, and light theme tokens."
+    },
+    {
+      "path": "agent-skills/web-design/liquid-metal-border",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "764ab72bc4d8edbbfc7a85998812408c9869f709"
+    },
+    {
+      "path": "agent-skills/web-design/liquid-metal-border/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2e1a955130cf9eda9da3759e4094e9377457d141",
+      "byteCount": 338,
+      "sha256": "1c30492905dc0ae18088eca30decb85a9805ef053dc4b810c744d3b43b0f3b15",
+      "artifactClass": "reference/article",
+      "ownerSkill": "liquid-metal-border",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Package-specific costly decorative shader without general architectural value."
+    },
+    {
+      "path": "agent-skills/web-design/liquid-metal-border/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a8b6c95092172b3fcfdad0cf68107ddb08bfd097",
+      "byteCount": 13655,
+      "sha256": "2dfe245bebc1d87a74030cf361480300785c86022b696eacdd0fcc8316875bec",
+      "artifactClass": "skill",
+      "ownerSkill": "liquid-metal-border",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Package-specific costly decorative shader without general architectural value."
+    },
+    {
+      "path": "agent-skills/web-design/liquid-metal-border/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "80895b6658a8be19f6aa3b0165805bd1be7e1907"
+    },
+    {
+      "path": "agent-skills/web-design/liquid-metal-border/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0f668fccdada88036dcac071640bf45769386bce",
+      "byteCount": 238,
+      "sha256": "0500519ba774b5330ce8bde8f3d290f07cafd34e3b6ac607c239a8237f2d4020",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "liquid-metal-border",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Package-specific costly decorative shader without general architectural value."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "092eae3e1a7c02b01c388020162455cc14d015e0"
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "55843c8b5600acd6f527f40676acab3fa072b094",
+      "byteCount": 818,
+      "sha256": "53f705e5f245f414d4e88b88e5f997b3201d8f782d407a2f2b5794e7b2aea8ed",
+      "artifactClass": "skill",
+      "ownerSkill": "marquee-loop",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "1c6c38bbb8c89ed91e96e7ef18bd480617e6a114"
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "eb062cde353dbda144f6cd2edda3d690483a4c59",
+      "byteCount": 2511,
+      "sha256": "7391e21c1a42248dcbc48b1abe0a36fff670acf41ae4cb5e6f1a76b810b0943e",
+      "artifactClass": "prompt",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "b8afa4307c8a18d428938374250df1e0311b7760"
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/page-01-6b97b0cc-6b81-4451-aacc-6b928e7d0a69-3840w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "75fadc390dfeccd9cba4d6da61e9496efee3ddec",
+      "byteCount": 1315224,
+      "sha256": "3597fbfa3064923c5e80a771246a67aecefd285fd52aec5ba3e62a2066189573",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/page-02-193e1472-0514-44eb-893a-1376091263f3-3840w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "804fd3e34fb45557223682142b40eff9364bcac9",
+      "byteCount": 1056637,
+      "sha256": "5f6d6d0d70ff972752ec4d4b043b10bb56fa2ce40bfa64f2d155952a009e9846",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/page-03-5180d964-2425-4134-8220-c1528af09124-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "575ab18abd03c273a6dd892da700e65750090812",
+      "byteCount": 55122,
+      "sha256": "2691bf2f81e47b30fa4ff85cce368ce22dc3f0107e15a6d2256a398027b657a0",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/page-04-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/page-05-fbddf75f-e2e3-4552-a710-55e2a5f4d6af-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cdf6c6c9ecf59ff40b8f605c9a70dd4b22308373",
+      "byteCount": 33767,
+      "sha256": "ce7993adc4e7d1508237d7bae4149a70e647046250e875472785d2b59235e05a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/page-06-16d38370-5873-45cf-bab1-60a7b923dc6e-800w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "046d6c9a108c52a281892441f69dafc69894c89a",
+      "byteCount": 57726,
+      "sha256": "f58be67861bc6e19c7ce8ea6ac20009d8660e7d0033176945c048efbf001c298",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/page-07-8e802a98-b83c-4c5d-99d1-e24406eb4ec9-3840w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9b8e72b8307a2366ef0c8769e05c89414169c30b",
+      "byteCount": 2271761,
+      "sha256": "e4475b891f89ca538be0bf69deea5d61e8fabf161f748f2a73dc168383a4b6f7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "659dd6fded853dee50d7846218bcfc471a3f1788",
+      "byteCount": 122918,
+      "sha256": "25d7ef3cb7414da76af43eb90987e1eeed3589abebefb43f0a5e60e95fb60a8d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "01d710178b0acd85c6d9349720b38d9c005f9a7f",
+      "byteCount": 29559,
+      "sha256": "12b7e6d199f675a7769163c1949c3012f549e41a0465c7202ad9a9fed849464a",
+      "artifactClass": "demo-html",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c40d8eeef1382c72e8b99023921591aa71cf1a5a",
+      "byteCount": 116930,
+      "sha256": "2c8ecddcfb0eccd6f485424cd253f01a1e040949d9a32d92d8599bc8b481325c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/marquee-loop/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "69bdf74da865e43a97edd05f0d58fb70534a64a5",
+      "byteCount": 4484,
+      "sha256": "b3f99069c9e8609c7ecb07f3fdc8a6e7a1fb59b08b6a18929c72115ec3580d0b",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "marquee-loop",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by existing marquee motion primitive and duplicate seam rules."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "96e93ffdae5d392b1ddab39b8e0fd3524d9613e7"
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b5e7cb70462f9fcea2b2fbc45760b896785314de",
+      "byteCount": 3959,
+      "sha256": "a3e4fb96f6092ac382530db24fdd15da559e959c5b7e02d0503918c1358dcf03",
+      "artifactClass": "skill",
+      "ownerSkill": "masked-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "a646df30a00c2d4ce41e61a1a7eee1a8fe66792a"
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7b78ad44268a24cc3247d9f27d875e4c563d1e34",
+      "byteCount": 2521,
+      "sha256": "000eb5cde67d8f0487c27ccc735509cc9ef949104928f3a511a5f75f14773f34",
+      "artifactClass": "prompt",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "48b414490df3573bff95f7d8871eccfa88eba267"
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c17c9ed9481fe26fe7fdfca9a0a8dab4dd3a771d",
+      "byteCount": 201962,
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f77fe5bede25677fe105589063c8b434ac5215e2",
+      "byteCount": 139542,
+      "sha256": "3ecad5d2605bbf56d3f02c0a2a4673d574d405a5d830e45b43d6a34c01cbe992",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ea0c87673cd6f78aa82acd6bcbacfb81d4c24047",
+      "byteCount": 45479,
+      "sha256": "4559d22599d5ed733eb14ba074e37de12e8db297571b70be93b898a347274658",
+      "artifactClass": "demo-html",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f2ea35d29c64fa36635ad78123be5627f1035be0",
+      "byteCount": 98145,
+      "sha256": "47dc6ced9e3d2354583a2dec0adba4c2d7da55e6325f48b38cbfb28c39f6e2cf",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/masked-reveal/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a9856faa2d77be9de8d1c0ed6daa2cec0d9f2d31",
+      "byteCount": 4513,
+      "sha256": "daf162509d0a21e8908a0f0fdf831ae20091a6b0e0774ebefce94d92303fb8b5",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "masked-reveal",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/gsap-motion-direction.md"
+      ],
+      "reason": "Covered by stagger text motion primitive and overflow mask mechanics."
+    },
+    {
+      "path": "agent-skills/web-design/matterjs",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d4f317929756e31ebcdc0c2e2ed0edd8097d1053"
+    },
+    {
+      "path": "agent-skills/web-design/matterjs/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b6938096a87c7a0cbdef6deef00d6b7efb1cc203",
+      "byteCount": 2227,
+      "sha256": "eeb1d2f6521e337dd5a5f0743ba00c00dd81f6e22b22a6f26c5d77fc44f16be4",
+      "artifactClass": "skill",
+      "ownerSkill": "matterjs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Physics engine wrapper lacking a justified design system gap."
+    },
+    {
+      "path": "agent-skills/web-design/matterjs/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "b80d8a8cb4a6bb5f0a05ea297a0ed12761c4a54c"
+    },
+    {
+      "path": "agent-skills/web-design/matterjs/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8d14128a510e81bde7658c4f64b28cdb261c871b",
+      "byteCount": 1902,
+      "sha256": "d114d5b7fdc36d6f7009dad70a418a95cb07fc108be8e8d515dcfe191c5cc654",
+      "artifactClass": "prompt",
+      "ownerSkill": "matterjs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Physics engine wrapper lacking a justified design system gap."
+    },
+    {
+      "path": "agent-skills/web-design/matterjs/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a42dbab5f1073f2c8fb2477827d3eb6c0d62b033",
+      "byteCount": 16293,
+      "sha256": "a65db809a7d7abe90769d73ecfd75d239ca71527120e5e102f529fcae173fb66",
+      "artifactClass": "demo-html",
+      "ownerSkill": "matterjs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Physics engine wrapper lacking a justified design system gap."
+    },
+    {
+      "path": "agent-skills/web-design/matterjs/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "843b3a7f1f2c2372b34e12c09c73510f93a15620",
+      "byteCount": 37965,
+      "sha256": "4685f090b28698bd0b0e920aa7fb31844b9537371f89ddbd201b4f6ef5a7338a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "matterjs",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Physics engine wrapper lacking a justified design system gap."
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d865dd3ad53e6dd58172bade9a966e684e97796c"
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f8997859ac5df2c8f44275d9875bad607124c19d",
+      "byteCount": 9875,
+      "sha256": "4c91c0ba4ccd73389f6bd0fc15b5065dc6c64866ee829249f98fb669c152ce33",
+      "artifactClass": "skill",
+      "ownerSkill": "mesh-gradient-dark-blue-clean",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/shader-gradient-direction.md"
+      ],
+      "reason": "Covered by shader gradient direction and brand persona styling."
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "735d3facb5305d345d7a0e50f931d81a9b0c8634"
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "65b0ab1c36b9a14cd2963858aca646b36fde0ffc",
+      "byteCount": 3296,
+      "sha256": "0eed0e642d4b09ea32b5fd23453c72ccdf12a76944e4ef309ea3ed68e06d2e4c",
+      "artifactClass": "prompt",
+      "ownerSkill": "mesh-gradient-dark-blue-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/shader-gradient-direction.md"
+      ],
+      "reason": "Covered by shader gradient direction and brand persona styling."
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4c9f7edcd98f9ebec0da212754fa61b86f165607"
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b1fbd79f1cbb72b4908bf956970bd18537ef80b7",
+      "byteCount": 26881,
+      "sha256": "3bfb70e2fd5359c261e9268583aca339d4d360fd774854977af109d3ab3edc6d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "mesh-gradient-dark-blue-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/shader-gradient-direction.md"
+      ],
+      "reason": "Covered by shader gradient direction and brand persona styling."
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2803ba602bc466b0ebcae2fa8e7921a98ca701ed",
+      "byteCount": 27066,
+      "sha256": "7cd43cddf21947985f32ffefd02d2f2f4273cf79c438b0fa9dadc089fd35b329",
+      "artifactClass": "demo-html",
+      "ownerSkill": "mesh-gradient-dark-blue-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/shader-gradient-direction.md"
+      ],
+      "reason": "Covered by shader gradient direction and brand persona styling."
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "07e0aa0b0b77f641c7b98034b936ba950951836d",
+      "byteCount": 27865,
+      "sha256": "8a9d8ef4dab1cea6002f3b201967677b5e53e078190d74582ab71dfdf38f967c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "mesh-gradient-dark-blue-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/shader-gradient-direction.md"
+      ],
+      "reason": "Covered by shader gradient direction and brand persona styling."
+    },
+    {
+      "path": "agent-skills/web-design/mesh-gradient-dark-blue-clean/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bff67d3b0e4ac6d4e9d915d6682545411861a359",
+      "byteCount": 2041,
+      "sha256": "964a97dd84d19abf14df76d8ed97bd1674a1fc6e0ba957543c1e309235882396",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "mesh-gradient-dark-blue-clean",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/shader-gradient-direction.md"
+      ],
+      "reason": "Covered by shader gradient direction and brand persona styling."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "11a7bebd636de3ac8dae70af7e1efbe24fe9a218"
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3eacd5daed078c97f5ec952988efb4df5f157835",
+      "byteCount": 4010,
+      "sha256": "99a761f4c95316a649b54782bbb23666882c98ec2eddce393f86a5601c270e23",
+      "artifactClass": "skill",
+      "ownerSkill": "nested-container-clean-agency",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2cc953ccf8f8aea5cef06217324ca0c8bac4ada1"
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f0fa0fcb59d2954d70187b50f13ab757333e55b5",
+      "byteCount": 3499,
+      "sha256": "0ff79aa025fcf28e821db4dfd5874c959810db228e3eff0f423e021e0f2a6eb1",
+      "artifactClass": "prompt",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9ccc59f2c87b29a47c003048cf6c0d26f944029f"
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "764233ff37fe552c54ee65be0329754f008a9577",
+      "byteCount": 362749,
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "072de2e20e298844fb880a2cf82fec2cca237d75",
+      "byteCount": 73780,
+      "sha256": "97c65569d294acbb5072f963eec2f67f57fd3e8fbba84cfa9a1bfe5042e92d54",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c038b784376e3d3e62eb2dbcfc1133ff787344c9",
+      "byteCount": 21909,
+      "sha256": "7abbd51e4c973de2df8ce06f7b1f24f9c20cbfc4cabb0438b88e80177d26f50e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b6ed49e4b847395f2501dc0777aba959bb8422be",
+      "byteCount": 55601,
+      "sha256": "d5224df5c78d7dd527ca0c169c68f41979a813072ddd274eab03136f820dffe1",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-clean-agency/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e6890def8a7024a75057adca4ab81f97b12ab943",
+      "byteCount": 3315,
+      "sha256": "997a1c2bc00c032f6b31ee33559fb17e19e7f8c710226405271b486ca10213f4",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "nested-container-clean-agency",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame layout and container restraint rules."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "867397fffa03c3ba019b5c97eedb76ef1cdf6a46"
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5bcc248674802518011cae8a14e8d2cc1ed12b76",
+      "byteCount": 1280,
+      "sha256": "02fde1df60f9d13015a4a25a2d935831da78f665c263b5d166117e1889c151b0",
+      "artifactClass": "skill",
+      "ownerSkill": "nested-container-frames",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f408ffaf51f3e7da8d8c6d06d4f984fcf7e207de"
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "49526aa912b8e326c85bf0be31cfb183297cdeea",
+      "byteCount": 2931,
+      "sha256": "6bf453a3aa71cb8f1069c52a8d8bba4125f7b27b4aa970470fa82e2814a16188",
+      "artifactClass": "prompt",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9ccc59f2c87b29a47c003048cf6c0d26f944029f"
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "764233ff37fe552c54ee65be0329754f008a9577",
+      "byteCount": 362749,
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "072de2e20e298844fb880a2cf82fec2cca237d75",
+      "byteCount": 73780,
+      "sha256": "97c65569d294acbb5072f963eec2f67f57fd3e8fbba84cfa9a1bfe5042e92d54",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c038b784376e3d3e62eb2dbcfc1133ff787344c9",
+      "byteCount": 21909,
+      "sha256": "7abbd51e4c973de2df8ce06f7b1f24f9c20cbfc4cabb0438b88e80177d26f50e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2c79e0648caf063e1a8ed19b9511b596e92619da",
+      "byteCount": 55597,
+      "sha256": "ba2795fc61514406e8c84facca953f2b167f174a6bb1e8802aa578d748388051",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/nested-container-frames/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f7ee4be998a25610fc1f664edd151ec574a4fd81",
+      "byteCount": 3297,
+      "sha256": "c67f2a7fc4590e48f01cdb7ba8e505318088cba02d02a46e7249b3b438e506ba",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "nested-container-frames",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by measured frame layout and concentric radius constraints."
+    },
+    {
+      "path": "agent-skills/web-design/number-details",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d45c9af38e1d7d50b52d5310629d5db56b51d638"
+    },
+    {
+      "path": "agent-skills/web-design/number-details/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "65111ea0e3884a455b586eab46a7ded06bf9c21a",
+      "byteCount": 793,
+      "sha256": "bd526d953244b8f05a578892640a86e550d062094866e4d9958b538313ef271a",
+      "artifactClass": "skill",
+      "ownerSkill": "number-details",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7ade2d65f45ab367fec8cc6e0406ce2be506a9e6"
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "27c2e5f2d460c2f25a1b9f2e6ed50331baf5eaed",
+      "byteCount": 2592,
+      "sha256": "a5cfb46687b49a55928b6b455d9231f80badc0f78d6e0bb954090530b792b40d",
+      "artifactClass": "prompt",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6ac18cfaac5d1354a08a4398400824f357c4e04f"
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-01-photo-1542224566-6e85f2e6772f.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ec725394ac8fc953053a5e0b7b15ab16bff39047",
+      "byteCount": 1238234,
+      "sha256": "8c60a544ff48b3e2900418d6098efe1c72b5541ed41cb44ea70cd9d2b03a2f20",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-02-photo-1518732714860-b62714ce0c59.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2395f1899e90eb8f5ff25fb033dda15e1f334f5f",
+      "byteCount": 186731,
+      "sha256": "fdc05d807596db69affad0b516142dd3267d9918e3f5e7c36af5807cec7c783f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-03-photo-1596394516093-501ba68a0ba6.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f2456d9dad368297149f3a3c9c73b6e33391c7d0",
+      "byteCount": 262867,
+      "sha256": "32a1f0a3fb3b604920ea7d8301e69eedd747d85a299c9e7a40f354360f0cbbc8",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-04-photo-1587061949409-02df41d5e562.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "85f1f0e3234310e144f735a9c3fc497b875ab153",
+      "byteCount": 533313,
+      "sha256": "dd5ea24c41f638a247ceb9a4b4277be9a3ce571525778352ede1b40b9c33e53c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-05-photo-1522708323590-d24dbb6b0267.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2e2f489743cd3526b2250f8ef66aabaf07cf46f6",
+      "byteCount": 238376,
+      "sha256": "a5705dd6a81f41b53984155db8648b5325b7ac40aa100158a4a44b03cc07f0ea",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-06-photo-1464822759023-fed622ff2c3b.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "492dd971afac789fee9f029417382b71fdab0d6e",
+      "byteCount": 439306,
+      "sha256": "bf39595522ac70a092bb41991e20e03f93c9ad9025a3176ed9a534aa66fa4895",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-07-photo-1544161515-4ab6ce6db874.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c5f52fd0b620fe766373d6018ea2935fe17c9e35",
+      "byteCount": 192865,
+      "sha256": "ca99771790e92886557b657ef1f4d4d213d0d58d102207edd4bc26987dbd146b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/page-08-photo-1555396273-367ea4eb4db5.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "95da7ef5e7a4c6d5d94abe108078e9b4cc0b0b79",
+      "byteCount": 576747,
+      "sha256": "5ebc42216d0cd25fef1caa8510c6972388744fd513de2b2f9ada053145e4c3d1",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6f25cf15f118ef1f6b8e8cc19d4f8088334c4e23",
+      "byteCount": 27628,
+      "sha256": "1e06aaa12c3395215a1f292f228f502281f2bb2b45970ab6982d59a1fe760008",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fbf2c8bd9298d6167655e74f16ea93b197ec2def",
+      "byteCount": 60416,
+      "sha256": "184da411f3d660fc3cb9ec2f428e7d9b832c4d84da3e2dcef0e5caf106662759",
+      "artifactClass": "demo-html",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "856078ae7e24df8ff2abc75ec29322007be64e66",
+      "byteCount": 141654,
+      "sha256": "24a064d10586a50d2cca53605a14a7d75730ce1cef79aa52d5bf5da3fdd2891e",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/number-details/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "868f62ffac42809a95cbf4ebe3defd49c153663a",
+      "byteCount": 4809,
+      "sha256": "606ec3740b3730bf9d9d1558f07e1fa7ea89bca597eb16454496b2ac4850e8f2",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "number-details",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "DET-01"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Covered by numeric index detail device in signature devices."
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4e01e35cb328239fea442e4cc7932827b5278210"
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0d3d04c1bc674feda9ea6cbfcd6d59b1766d5555",
+      "byteCount": 154,
+      "sha256": "91c92f2d1c5fd82a821af1cff492e51905c7086746d45d64c62d5864070153ee",
+      "artifactClass": "reference/article",
+      "ownerSkill": "operational-enterprise-ai",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt enterprise proof story structure with audit and rollback workflows."
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "22fd9b0f1daca4dbc5c2d3975d42b59ac2c42dee",
+      "byteCount": 4641,
+      "sha256": "fbbf4387d16cfb23c95eec0caacb4f204e51ad9fcc2bf2c9e9db9dd451fec566",
+      "artifactClass": "skill",
+      "ownerSkill": "operational-enterprise-ai",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt enterprise proof story structure with audit and rollback workflows."
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2d096babc157619dfe27c61fcce3a688f0a6e136"
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "dc6f476e835a7ebf74291ca4680fc23e7ae57493",
+      "byteCount": 267,
+      "sha256": "753cd215b89310fb4ba28393f575a9c996f5b4bb8753b03d01c8e793b15de890",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "operational-enterprise-ai",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt enterprise proof story structure with audit and rollback workflows."
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6a103ed9e6d91b01bcd99656f7048a785d6132dd"
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e13289bcb9bb2ad121d779211a3bf8af0ed3c859",
+      "byteCount": 1974,
+      "sha256": "ea722c38530383caef7297970175c00d854a946eaa7153ac056a42b52dba8dd1",
+      "artifactClass": "prompt",
+      "ownerSkill": "operational-enterprise-ai",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt enterprise proof story structure with audit and rollback workflows."
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4c9fca5c1dfe2aad6b1bfa528579d7d8fec8205e",
+      "byteCount": 7555,
+      "sha256": "b0473b8279a0e11c54f45be8160d9d2cf5b01aef82304e38acedb2ce1fcfdc4d",
+      "artifactClass": "demo-html",
+      "ownerSkill": "operational-enterprise-ai",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt enterprise proof story structure with audit and rollback workflows."
+    },
+    {
+      "path": "agent-skills/web-design/operational-enterprise-ai/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "46ae37f1960d824c666a2174698cf6a1d0d79538",
+      "byteCount": 151364,
+      "sha256": "72090d2a85e79cacc2de105d1c7ded9142d074c5bb4e8d12f371146a82c7c8ba",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "operational-enterprise-ai",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt enterprise proof story structure with audit and rollback workflows."
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "91463be598bba1ce21b74659aecba61709e2b973"
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2aefa1604a5699c81135d5e99efa2b33d6584845",
+      "byteCount": 4038,
+      "sha256": "4f532470971c92edd7407dfba5ec6656e0377c213903bd68bd82281b7ea39788",
+      "artifactClass": "skill",
+      "ownerSkill": "orange-clean-paper-saas",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by feature stack structure and paper persona token palette."
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "98ca27e2377432c37bd5895ec67795d66c3d661e"
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e5e30de6daa6f7dc8282cf8303655ae30eafd293",
+      "byteCount": 3342,
+      "sha256": "67ad1d3f085a2dd4dc083614457045a2c3d99285a2cadf0c263e13a3db9a5f62",
+      "artifactClass": "prompt",
+      "ownerSkill": "orange-clean-paper-saas",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by feature stack structure and paper persona token palette."
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "96376820d4c05e45101173356897bca537c1b0a9"
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "26b19d8c49753a683b4ee9ad0c2b614cab42d51c",
+      "byteCount": 66002,
+      "sha256": "30b4d29380a5ca4a091d2a4f6628c0c72235551eaf305cfc147878ade7cd2821",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "orange-clean-paper-saas",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by feature stack structure and paper persona token palette."
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4351973e40dd3fb8e3898f0fc2b4aca13782f339",
+      "byteCount": 33115,
+      "sha256": "7bd2ab66deb463f2fd4a03fb5ae4fad4d3a8fe6eed1a7a34d22628f5eef5202c",
+      "artifactClass": "demo-html",
+      "ownerSkill": "orange-clean-paper-saas",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by feature stack structure and paper persona token palette."
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f8fb2b7e8853b1ba127be9a4459d6309c22ccc45",
+      "byteCount": 62042,
+      "sha256": "0d08ccfb9be18adeae7a49f9cc8975a618f5f43ae519699b7032b6654ff78ad3",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "orange-clean-paper-saas",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by feature stack structure and paper persona token palette."
+    },
+    {
+      "path": "agent-skills/web-design/orange-clean-paper-saas/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3db8fea4e43e418b956ba11c711779853b066aad",
+      "byteCount": 2713,
+      "sha256": "5fa94a21ac1c6f7c1a674ab68538665aa5f1f7a62620c2bdbdca459e9835b098",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "orange-clean-paper-saas",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by feature stack structure and paper persona token palette."
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "87cf8e1be9c9fc6a973dabab742d4563a9d8810c"
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1913edbd49b5daf4024c64f7c935650bc1c1a17e",
+      "byteCount": 10566,
+      "sha256": "2cca505af09e4f34a96e1dd08b1d9bc1caca467dba3debfe62fce4756b2f2964",
+      "artifactClass": "skill",
+      "ownerSkill": "pointer-trail-emitter",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter motion primitive with ring-buffer and idle breath."
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d071237c0ce1e2a94eea67810f02b1851d5ee77a"
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0e0c25d3fdc0a8c7f40973e92e0d1df79eac486f",
+      "byteCount": 263,
+      "sha256": "3d42e335ef4b22608163b579e9d4fd4afec8403b0a4f6fd0822b7ccddd811443",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "pointer-trail-emitter",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter motion primitive with ring-buffer and idle breath."
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "81d027b0653233bba9324fdb4c7ec0b34d663b54"
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6220695794801fbc5f463b5eebc77f28500d71fc",
+      "byteCount": 3916,
+      "sha256": "e82de13795cb6fbd0df3791db751ea86ec62b228fb25d98ff2b0d604c4853e8c",
+      "artifactClass": "prompt",
+      "ownerSkill": "pointer-trail-emitter",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter motion primitive with ring-buffer and idle breath."
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9078c091f987fde6ac80f33b243f56af68b3bc68",
+      "byteCount": 23445,
+      "sha256": "59e414cc7b7b784a73e5fd1c6e757c6c3ddee72a0ad381ec1ceb1b98e6348979",
+      "artifactClass": "demo-html",
+      "ownerSkill": "pointer-trail-emitter",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter motion primitive with ring-buffer and idle breath."
+    },
+    {
+      "path": "agent-skills/web-design/pointer-trail-emitter/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6e0ba1ad21f1901e34ba07203a51e071984562a3",
+      "byteCount": 53582,
+      "sha256": "bb24fbbd9f930a7e664c432c299121ea4d7ad1c3c8fa8a739160f261e03646c2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "pointer-trail-emitter",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt distance emitter motion primitive with ring-buffer and idle breath."
+    },
+    {
+      "path": "agent-skills/web-design/pricing-page",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "1bf9e17cf43a93921716a5e7f32527e7d00c3d57"
+    },
+    {
+      "path": "agent-skills/web-design/pricing-page/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cb3302167e5e0f0a6786ff858659b2e62dbc0b7c",
+      "byteCount": 278,
+      "sha256": "aebc17e480d4acd18fb73dcd342f131b7dc0bc2154eceec0618b1038f419b618",
+      "artifactClass": "reference/article",
+      "ownerSkill": "pricing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt pricing comparison story structure with honest table fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/pricing-page/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6b05068ccaebafc8d991d352f1ba7dcd446e8806",
+      "byteCount": 5858,
+      "sha256": "9b3af6174e379042ea1579f5d62b6fb0030fe6298d35b417488ac1e5ef8159db",
+      "artifactClass": "skill",
+      "ownerSkill": "pricing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt pricing comparison story structure with honest table fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/pricing-page/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "c7bc69e0e6ed34829dc7518df047e37b7af9129b"
+    },
+    {
+      "path": "agent-skills/web-design/pricing-page/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5987f42044fbd27b59b107f9f6c1ced0510468ca",
+      "byteCount": 1868,
+      "sha256": "f62bf758a53cd0746dd0ee5746bef54a6201fe99eb960181289611777e4d06e3",
+      "artifactClass": "prompt",
+      "ownerSkill": "pricing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt pricing comparison story structure with honest table fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/pricing-page/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "778f9be3c5989b9973900e4178b70746f709369c",
+      "byteCount": 16870,
+      "sha256": "2f074a2e40214a843850d147b87fdf2ef0fe228420cd2f5e27414f9abaf74a67",
+      "artifactClass": "demo-html",
+      "ownerSkill": "pricing-page",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt pricing comparison story structure with honest table fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/pricing-page/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0e06eaa913449855d3bf557168dd84c36e56d8d5",
+      "byteCount": 54453,
+      "sha256": "47347aea05d9a9406dce4fe25c0505488992b0ac4422bfcdbe010299aeb0f905",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "pricing-page",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt pricing comparison story structure with honest table fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "5b5a6606353d62111ee983c939fca36e90824ec9"
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2e8754122d870754e244913fb9da354d037fec92",
+      "byteCount": 150,
+      "sha256": "5f60517e514a2a563920f6a27ff4ab3632d4a4359b53bb0eb136a292d69c17e1",
+      "artifactClass": "reference/article",
+      "ownerSkill": "product-proof-saas",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt product proof story structure with deterministic hero demonstrations."
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6c7381c167ddf682d6715fe5cbb1cf0960fd15d5",
+      "byteCount": 4357,
+      "sha256": "eb033e97a506e6a1155c98c861efc4bc99aa0f1afd33d99105d091f3e4b3d801",
+      "artifactClass": "skill",
+      "ownerSkill": "product-proof-saas",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt product proof story structure with deterministic hero demonstrations."
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "abf7bfc9bb4fdd211c0ba098e80a14188cd27392"
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5ebe8ce43409ec8a7ff4cbba51f75ec6deb2a30a",
+      "byteCount": 249,
+      "sha256": "5fdf8d2d4e53ca0e4e9f1792a2c24ecdc2c0b9a7afec57024d38682f89fb8fe8",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "product-proof-saas",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt product proof story structure with deterministic hero demonstrations."
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3b4392c4da4d42953a9f7b51454a64eb43404656"
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bee822e438964903b4a741a56d2488ca8cf7f89c",
+      "byteCount": 1885,
+      "sha256": "da5fab6f3e704d4288accc82319e9b1aaea2d68687c5dc096642f98d1795de14",
+      "artifactClass": "prompt",
+      "ownerSkill": "product-proof-saas",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt product proof story structure with deterministic hero demonstrations."
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3d6d4d433870db80a5459bbd89aad4f593151938",
+      "byteCount": 7973,
+      "sha256": "a12e8a319caaf6a5e8737d92168cfff6e1a28e81047e5655bbd56708b2619001",
+      "artifactClass": "demo-html",
+      "ownerSkill": "product-proof-saas",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt product proof story structure with deterministic hero demonstrations."
+    },
+    {
+      "path": "agent-skills/web-design/product-proof-saas/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "66b1bcede51f17dbd9fc1f02cda5044f0746fbbc",
+      "byteCount": 153019,
+      "sha256": "c6a9fd7452616e9ef44b5752733559f33d5c405fa4427ee2094b1f3185268a69",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "product-proof-saas",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt product proof story structure with deterministic hero demonstrations."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "6328931b0717fa946c6e684a14c8b418614cca18"
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "41e6b6d5856380b95f3d698ec5d9c4b37e108f4a",
+      "byteCount": 6019,
+      "sha256": "202004db5ff37fb8add044cf00288d984c9a680c2fb07e4bb2dacc3df90ac2a1",
+      "artifactClass": "skill",
+      "ownerSkill": "progressive-blur",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "489be24242716c7f130151c96a5e56d47f65bd68"
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "974eb856507664e2684e93318453ac1f35f17020",
+      "byteCount": 2927,
+      "sha256": "3dfd6b077cf1929e9fb7b63c290d79bdfaccfe45c5557c71b6f9224c3e8e83f7",
+      "artifactClass": "prompt",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7b1185559093a8d64f60b98b6f04e8d48e4dc33c"
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-01-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-02-0d868fef-f560-45ca-ab35-5dad4fc29059-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2d791d66906a67e0bbd80e16d8a37f577798a7dd",
+      "byteCount": 282854,
+      "sha256": "0d71068ad67cbdbfca87b5e5f57f21fbb47fb29148e2ae8d2e1a5df136ea5cfc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-03-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-04-3186f9ea-5f5a-49f7-8fcf-568ad52f515e-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "53ac591b09701e0ea83163e97db2663ed881a526",
+      "byteCount": 599390,
+      "sha256": "852496aebbe37c983c885d9aa20b3520e0c0244472703e3c2925b9c56f749a2c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-05-7f78131e-65e9-49b2-aa1f-ccc33e28df9f-1600w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "da01a5946767783be40ef434346459e38bcb547b",
+      "byteCount": 157556,
+      "sha256": "9a761eb7c70ef6e60fe55ab666f1d3d175d4103c5d8a597ef678fc2a0674aa3d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-06-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-07-d14dc069-558a-4c51-8aad-5cc237f9b61d-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bac3b6fd90a7242f9d0361758929b9decb1d2a8f",
+      "byteCount": 66005,
+      "sha256": "c42c8b60af648345f2340523c422b4d451b906c368fb4a1fbe2931a714a5d007",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-08-eca707cc-a5b7-439a-b4fd-247f6106c2e1-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "edaa940e355711470dd198749ed0905e38775bcf",
+      "byteCount": 249675,
+      "sha256": "4526a25eb7c0b86d945cf5e43ed53e85be9821edb8dc26017ed372b1450ae6f6",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-09-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-10-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "764233ff37fe552c54ee65be0329754f008a9577",
+      "byteCount": 362749,
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-11-5ee0a38a-b5d3-4531-8793-98beed4af162-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "581b1565cafeca5578bca12a5c5596c37f7f71a9",
+      "byteCount": 531939,
+      "sha256": "6a0ea1bc48598dd6b7848a1a718b87c93a2f15600c32eafa0d3e13138b3516cf",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-12-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-13-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c17c9ed9481fe26fe7fdfca9a0a8dab4dd3a771d",
+      "byteCount": 201962,
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-14-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-15-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/page-16-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1dcc2a3f5a9372832ae8ff61cde7c840822b1f1f",
+      "byteCount": 70117,
+      "sha256": "282d5c4816ceae85877c50eb31f238c326f37fc7227b6015d12de9e09a3775b5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bcd97f28ad5e5adafb81140966434e2637acb6c3",
+      "byteCount": 42198,
+      "sha256": "a3c5deb392374e06f44ba2c511202e0d66ad962e3afa88801b02ce164d869b02",
+      "artifactClass": "demo-html",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0cf7a65bb8db9f97bf07210243fe751a04dcde2e",
+      "byteCount": 46380,
+      "sha256": "29cbb4dabf7cdcc4e4ee954a8f48b7da4516df74503698b0bd7a3f93bd143a7d",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/progressive-blur/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8696f6cf97276697a8da7db042ac89ad21544b73",
+      "byteCount": 7073,
+      "sha256": "96423972c35124cddae3606226581a94bb26029cd683a3f330f0e8c1a53bc268",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "progressive-blur",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt progressive blur surface device with stacked masked blur bands."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3302c8dbb8b028c9bbdda616dafd3bfab0daf6c4"
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "31b269abb3ec0594ff3102ae0f5cc6ee7d88acc7",
+      "byteCount": 366,
+      "sha256": "83e606ff451cf7d798d7e58baabedca1dd264ea70f1f92f3360a7e3a631db307",
+      "artifactClass": "reference/article",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9a8986f1e08894bff1394f0654c4df5340a789e0",
+      "byteCount": 10442,
+      "sha256": "08650ccaa54b30d3d58dbdae4dfb4dab2ef1820a16a2e4c8973428be977debd8",
+      "artifactClass": "skill",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7a19c025d675affd6aea4f75c0c65e07413ea178"
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74694896bee877d5c0746964bdc10a2b6a4fcb9a",
+      "byteCount": 246,
+      "sha256": "a7714543916bebab1e0107321ce07b89fd2837c32e9be3f1cdb414a0bd9fccf8",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "af65408d782cfabbeef551d7f8694480e3e867b4"
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "766a6b4cbddc1d714be216ecc6ac1b05ca004497",
+      "byteCount": 2541,
+      "sha256": "4a4dd5a95f82b73ea9be6384370817ab0ae7163f510875a9a6c00540ba59c406",
+      "artifactClass": "prompt",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7deff5442839f5961179374715bdcba2ff704f84"
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo/assets/hero-opal.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c69486814698b2870eb22ffa4c255fae5417dbf4",
+      "byteCount": 173572,
+      "sha256": "c184aa79cade6f740cd55222885792f89bc3b1617215a74141fc53648f904fa1",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo/assets/hero-plaster.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "b7a62014225d83686c4c2e37060e7a10b8c3b2e0",
+      "byteCount": 117812,
+      "sha256": "c30895a7df14eed68efc4a3a0fb616ee8afd0d9e5795ccdef464be377ed2d2d2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5a007911d8608eef5794b5b5da674516cc35607a",
+      "byteCount": 7734,
+      "sha256": "c2d1a296ed1b449395fe2744693ff41a8cf799b9b8610fd61e5239379e1ddc62",
+      "artifactClass": "demo-html",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo/preview-feature.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "816790af43c45e4382a3bf05cfca5ba59c3b4ccc",
+      "byteCount": 111366,
+      "sha256": "6e38d6b8c3b873c510209ffa2722be61cd6695388d1e456bb809b0b8d7f549b2",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/reveal-hover-effect/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8b14dbc3cf2c5f9baac1ea9c1f09197e0e98e706",
+      "byteCount": 104290,
+      "sha256": "fb7cd1ec1b6a4be86eb3db83bce64e4e17e9924c2f2e36c7ab45c25af785a6bb",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "reveal-hover-effect",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-08"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt hover aperture motion primitive with aligned dual-image invariant."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "66b2b655cf59a937d35771c67bd8c01328d56405"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "352451e0030ae995e7814eee000f8d1415350eab",
+      "byteCount": 495,
+      "sha256": "0dc2650461e8fde41d855d78007f2f91b0f2b7924ef0f98d6fa657a44ae26a1a",
+      "artifactClass": "reference/article",
+      "ownerSkill": "scroll-progress-timeline",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt progress story motion primitive with semantic ordered-list baseline."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0695aeba2f58e7cf224192645fb0c420d9c15821",
+      "byteCount": 3991,
+      "sha256": "9f8b01bd025609b33f14a9b77a012f5e1019fa17e646a3899723aa941d539403",
+      "artifactClass": "skill",
+      "ownerSkill": "scroll-progress-timeline",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt progress story motion primitive with semantic ordered-list baseline."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "928ddb371959d840bad2565b0bf3c90a406d1ec4"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "386473f83a57417ebc2a5e003dd1a738b6f479ad",
+      "byteCount": 246,
+      "sha256": "6baf7c50c8feab9a992d14b25774864145a08bc50132028fbfd4ab688554c4e6",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "scroll-progress-timeline",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt progress story motion primitive with semantic ordered-list baseline."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "42a2b22940b4b1a58b42f067a33df417d62a3b31"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e29d8057be1a8fab1bef1f3525d0f1ca8586b5c8",
+      "byteCount": 1848,
+      "sha256": "cd5f5d50322e805e7fcb17360d9c08e7163afa8587b1df81779d1134c7a630fc",
+      "artifactClass": "prompt",
+      "ownerSkill": "scroll-progress-timeline",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt progress story motion primitive with semantic ordered-list baseline."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "eb5dbfc331d79c4c4ca2fa7dfe3ab2e5007a282a",
+      "byteCount": 12083,
+      "sha256": "7a1c1871a9fe3dc9798fd16fb81e5e6c7020c8a15a95224a01c9e1c7e1ef0154",
+      "artifactClass": "demo-html",
+      "ownerSkill": "scroll-progress-timeline",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt progress story motion primitive with semantic ordered-list baseline."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-progress-timeline/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "856ec0fd237f7fa9b425c2d7e3aecb4d9bff6cfb",
+      "byteCount": 99738,
+      "sha256": "7bb1ea21d594ef2fdc299e91243f4261550b06dc9a5004284f5dcd5ce725ef2f",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "scroll-progress-timeline",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt progress story motion primitive with semantic ordered-list baseline."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8b6c2c96a23cee1c6cb2ec840ef284c1b424dd98"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "82243eaa1bca1deb21345418ffd7f059fc7d2aa7",
+      "byteCount": 507,
+      "sha256": "a7d61327736c0fdba803b61b9c5ff0505cb4c682c2899cf95621018f8192d139",
+      "artifactClass": "reference/article",
+      "ownerSkill": "scroll-scrubbed-visual-sequence",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt reversible sequence motion primitive with normalized progress and preloading."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ef5f0e104961a78d712eea0b96f44e0a5802bd36",
+      "byteCount": 4640,
+      "sha256": "a98df66caf5861caf04ccd109dae86d45f7b4aa280540dac4827a7081630cd5a",
+      "artifactClass": "skill",
+      "ownerSkill": "scroll-scrubbed-visual-sequence",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt reversible sequence motion primitive with normalized progress and preloading."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ac2098be90e3542e8b4ce8d896cca566430fa8d0"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1e3035693ef15df884abee8fb96da9babd95d6fa",
+      "byteCount": 284,
+      "sha256": "309bd04cb86b76c370afe4158d3b48eda7b3558ada1efeae0de26b6e0c2f4611",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "scroll-scrubbed-visual-sequence",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt reversible sequence motion primitive with normalized progress and preloading."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "17d2bd0071f08247bc945814b6793a4128bca4e1"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e1ef1c81bf65c4b2e5a67ad8c9846b7a66bb6140",
+      "byteCount": 1929,
+      "sha256": "13ead358f4f31c75991e66efd9000d4b3ee9009dace25f15ccf17a462363cdcf",
+      "artifactClass": "prompt",
+      "ownerSkill": "scroll-scrubbed-visual-sequence",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt reversible sequence motion primitive with normalized progress and preloading."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1e59f2c5023226567701274c01e7e48c913ef09e",
+      "byteCount": 11312,
+      "sha256": "7a35cb7ee436dfa6a640995ac068e3f13a4d949d31b51a67e966ae50d5435c5b",
+      "artifactClass": "demo-html",
+      "ownerSkill": "scroll-scrubbed-visual-sequence",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt reversible sequence motion primitive with normalized progress and preloading."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-visual-sequence/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "76d37227c6fa7e691fee49ced5cf1c81b594e4ff",
+      "byteCount": 104186,
+      "sha256": "979dce1be0b1f2be7cac5b65615fcfca78e0d717b814e26c1ec28224acd76c5c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "scroll-scrubbed-visual-sequence",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt reversible sequence motion primitive with normalized progress and preloading."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "587bc42c25a5c35f509450d20bd13e44df1648a1"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e133c6d92866f6e11bc0ea257f8d643a18e71513",
+      "byteCount": 491,
+      "sha256": "c781bb17a4aafa1314f1152ab38b290eddf33de89e7b9ca5de87d6622fe418b8",
+      "artifactClass": "reference/article",
+      "ownerSkill": "scroll-scrubbed-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt scrubbed semantic text primitive preserving inline formatting and rewrapping."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e19951b81308cb0a22a8858cce92e8fea37fbb2a",
+      "byteCount": 4107,
+      "sha256": "40b48acaf16b5da6413b48d70f064c488c7bb33252bb934b743450f4f11b537e",
+      "artifactClass": "skill",
+      "ownerSkill": "scroll-scrubbed-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt scrubbed semantic text primitive preserving inline formatting and rewrapping."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4563c645e752f0bc741b044817246e966730a8eb"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6e129c60d4d6737ed5e57e505c30ac57f9462e8e",
+      "byteCount": 258,
+      "sha256": "e526d27f22939ac8117e5893a05d81390799fa928638c60d3c00a31a82bd04e2",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "scroll-scrubbed-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt scrubbed semantic text primitive preserving inline formatting and rewrapping."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8731497d3c61c7f07dc087788af29878cb4c8903"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e365ab693c5a14b0d083270d7a6b98bc637e5068",
+      "byteCount": 1727,
+      "sha256": "c9544548e2721b9813e17c66f8cae80579b775ecc0a3a7de7cc4fa26517c7561",
+      "artifactClass": "prompt",
+      "ownerSkill": "scroll-scrubbed-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt scrubbed semantic text primitive preserving inline formatting and rewrapping."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cbbbfa27ef3b4af8126e60c02ce9cd88e519b95a",
+      "byteCount": 7531,
+      "sha256": "a37987a6c9a352f8756df05e8fc32e437407127e254e7b6e7e99c0c2bdca5a6f",
+      "artifactClass": "demo-html",
+      "ownerSkill": "scroll-scrubbed-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt scrubbed semantic text primitive preserving inline formatting and rewrapping."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-scrubbed-word-reveal/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "899bc9a7f0d91133f912d4f986b1ba1bf1c736d0",
+      "byteCount": 91945,
+      "sha256": "5bd76e26b3787f366775b5d07d4018dab5f6aa83502d38fc2c4c75914e3e8cc3",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "scroll-scrubbed-word-reveal",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-03"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt scrubbed semantic text primitive preserving inline formatting and rewrapping."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "5f006d60f3d21ad23ed73f4f8b74456249bc6852"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4b4e490ce83e504c23debccaf27ee1b3e2313b9d",
+      "byteCount": 610,
+      "sha256": "13eb9828382d2aff33f7bec37ecae92dc02e91efc3f8a4bb4f29304bb6f3fc21",
+      "artifactClass": "reference/article",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6777dcf9d80f48de243eb314bfcb81ef3afd813a",
+      "byteCount": 11889,
+      "sha256": "505caf90b92ac6d9e6aecda1d79df36adc96fe5cbeb8eaac5c45b6cdefee7eab",
+      "artifactClass": "skill",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4161a27ad841ddcbd8cafed6f54154f3d1f77c1f"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d862ee48e12cc3fbf7cbfc2e6b742cb545546afb",
+      "byteCount": 321,
+      "sha256": "aa4f9df4867e4b42da188ec7e96c1c10d5a032b7c061a54a2ba54bc1b9e96475",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "237ef9937c1e84d1b13f1560f17f1c365dd141d4"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4aa554d461dd2755ac101f156bd9b238ae19fe05",
+      "byteCount": 1718,
+      "sha256": "4f88af79f782cdeae74930d4e95befc3894ca9753f462c7f6dcf18e61e48edf6",
+      "artifactClass": "prompt",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/html-data",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cf17f0f0a2f6060e1b7d99fcc2202133839b8a67"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/html-data/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ec260eac53ccc45cbc7c867e91686170792c891d",
+      "byteCount": 2288,
+      "sha256": "0ab7e675422ca3bfb78ec845b26a12112c2f7cc5f30b7693d5669fb7ac1504bb",
+      "artifactClass": "prompt",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/html-data/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6754dcdd5be201c281bdfda91dd4a69fd921eca7",
+      "byteCount": 14236,
+      "sha256": "82d95aaf52315e571f2cce12cfe589f94af4eecccc6a2a03ad273842190fed64",
+      "artifactClass": "demo-html",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a1841a05fd039f33b92559d255b940b94debafd8",
+      "byteCount": 11456,
+      "sha256": "51a674e8d2b3be22515526e35df87fb7da4888ccb4f61d8ea5bb89fb92376cac",
+      "artifactClass": "demo-html",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "db2c07289fabbfb43d04e0f8c1b8d857ff7f4948",
+      "byteCount": 51984,
+      "sha256": "92ac847f32cecc5939657130a882a8a40e6b13ef559b7f565cedd8af5e56eef5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/threejs",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "c311134c2a5ddfc614d3352a98b417ac71eae9ad"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/threejs/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "98b9ecb96781b7f015023e4b3c72d3c2aaa1b383",
+      "byteCount": 3719,
+      "sha256": "0b3eb26e57a7d4ba93aeb5cb7cae33aaf8053c359e9cb24742b2306bd97fbda5",
+      "artifactClass": "prompt",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/threejs/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "bb42b8154ecaeb01c25a6169c4a59a54d758f3db"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/threejs/assets/THREE-LICENSE.txt",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cf781430404b0ae0ba7d8dea3457a3515dd7c9b9",
+      "byteCount": 1081,
+      "sha256": "bfe119ea4fd413f5f7ca3fcd63adb0c4a073ed39daa2fe7d3e6b769e21272601",
+      "artifactClass": "license-notice",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "embedded-license-notice",
+      "legalDisposition": "license-evidence-only",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/threejs/assets/three.core.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "db045ec27f549562a59fa5b4697ad9f04f04f782",
+      "byteCount": 380922,
+      "sha256": "e5a824c8ec97ee44aeb8ce0ab64664e1dd1777df9d0ab2345b35f9941a9fcf33",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/threejs/assets/three.module.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "261543eb54d196334b22c22e446734d253e9eb86",
+      "byteCount": 355116,
+      "sha256": "0f860495069067a103d1df99e2bb01260f250e118ed7a50537167412ba195a0a",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/threejs/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1089b14741fadb9e892fca89170a3cc790c0ead6",
+      "byteCount": 25725,
+      "sha256": "2fac044dcd6e1bd2fd026fa2ce24ef0d0538ccaacb417c6ac6f44c980368d08e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ef3d3ff50149ebd08fb15397a713390fcdfe0bd1"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c250d911b5de4907c53576b7531b047c66135cde",
+      "byteCount": 3904,
+      "sha256": "f06dd72ff35d30c1b6bc70ec3be454eeb08c00b57e292448afd625f0525a4ddd",
+      "artifactClass": "prompt",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "dda7483f6ff5a620331e5821a9796e4106ee139b"
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video/assets/README.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2213aab407645614be7790d711da51f5a3d7e56a",
+      "byteCount": 666,
+      "sha256": "a35dd4d9399008974932357ed5518e2e5025c8f6c7a54c3c1aeae56b842e0df9",
+      "artifactClass": "reference/article",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video/assets/contract-flight-source.svg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a2cabf456a3c4c0f787f434a722bb9d0aecbc4ee",
+      "byteCount": 5641,
+      "sha256": "14ee89f566cd6e4467c0c67ec3d44a8d3848ab393980549b6bd12bf0f336803d",
+      "artifactClass": "authored-code",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video/assets/contract-flight.mp4",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8747fc82ead187eea4b0a5c11ce1d7710b6f652f",
+      "byteCount": 3829930,
+      "sha256": "961c33fd6374930527883fe0a26b0cff39ccc4a317b1bcef931cac2dc8b01b62",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video/assets/contract-flight.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ab39989de1406535cb635f5d19031601a4ce8e8a",
+      "byteCount": 50124,
+      "sha256": "17bb5a050c2fdea021551b75b297b87ce5e05a336dd7e955ef3fab329e67b3f0",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/scroll-world-storytelling/demo/video/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "498bce4c8f068cef22b0e8e7f53ea63a83e31fee",
+      "byteCount": 10820,
+      "sha256": "7a07598076a1fb6703e0f6b4f49d55f81aa8274a4f88a7cd8393a8ddef67594a",
+      "artifactClass": "demo-html",
+      "ownerSkill": "scroll-world-storytelling",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "STR-01",
+        "STR-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Adopt scroll-world renderer decision across video, 3D, and DOM."
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "09c164dc863c29f78363635ce710220e9575a8c7"
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a52b4893c387ec97ee0861d3a820f608030fa820",
+      "byteCount": 214,
+      "sha256": "a0917bb1d7ead101e6b847da5dc7fb9d3c81fdc7fa824f7d5d1b40acbf8cabf3",
+      "artifactClass": "reference/article",
+      "ownerSkill": "shaders-cursor-ripples",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Component-specific WebGPU shader wrapper without core design abstraction."
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a287cf5099180ea67fad11a9bd524de642373439",
+      "byteCount": 7900,
+      "sha256": "a5b7c4d290707f7fb1f59f8dd99aa1f3b8ae1b32b919da07a9b1c128ac2129bb",
+      "artifactClass": "skill",
+      "ownerSkill": "shaders-cursor-ripples",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Component-specific WebGPU shader wrapper without core design abstraction."
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "03d663c874e6b6efddef6d16a2299663226b9b3d"
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4fdca11abe408844d20ab96bdaccb99a4229a58b",
+      "byteCount": 241,
+      "sha256": "837cf88837cbfeef151c6610778a71542f57cdf05f037de66c700a184ebe85b0",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "shaders-cursor-ripples",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Component-specific WebGPU shader wrapper without core design abstraction."
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8353c9dfdb28273cab5ed4685a51e5c52764c679"
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/assets/react",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "ed6c186c8237ab2d774685389196b96e7c463aba"
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/assets/react/cursor-ripple-media.css",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ef6776547f4786645a66480f9de583be61b4ea9f",
+      "byteCount": 658,
+      "sha256": "2490bd796d2872aefa14bb4a30811750a98eb0029873fac78c5c764af1454859",
+      "artifactClass": "authored-code",
+      "ownerSkill": "shaders-cursor-ripples",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Component-specific WebGPU shader wrapper without core design abstraction."
+    },
+    {
+      "path": "agent-skills/web-design/shaders-cursor-ripples/assets/react/cursor-ripple-shader.tsx",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c4ae6a7932808634c3590c994b941d40310fefed",
+      "byteCount": 694,
+      "sha256": "41afc69fbd19b4f7f4217cec6d86d4d5757119c484c4e28ce2887f5b6d082072",
+      "artifactClass": "authored-code",
+      "ownerSkill": "shaders-cursor-ripples",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Component-specific WebGPU shader wrapper without core design abstraction."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "98697f7c0716fd19994ad5439b25ca05125aba2a"
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c13194f30f4503b332124a532b03849e45fdd4d9",
+      "byteCount": 4371,
+      "sha256": "2de1673864f136b05b10a17fcf987f39864f30a716250b98e09ce669525292e4",
+      "artifactClass": "skill",
+      "ownerSkill": "skeuomorphic-ui",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "255d99a936cd99bd680aa6234cfa637b9a71a39f"
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e3b7ecde492979fb5b8696b9f3f25ba390927b08",
+      "byteCount": 3025,
+      "sha256": "4ea972b5ff75805159fb7b375b5889b51932fa5451149989b1d65411e3fa360d",
+      "artifactClass": "prompt",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "48b414490df3573bff95f7d8871eccfa88eba267"
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c17c9ed9481fe26fe7fdfca9a0a8dab4dd3a771d",
+      "byteCount": 201962,
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f77fe5bede25677fe105589063c8b434ac5215e2",
+      "byteCount": 139542,
+      "sha256": "3ecad5d2605bbf56d3f02c0a2a4673d574d405a5d830e45b43d6a34c01cbe992",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ea0c87673cd6f78aa82acd6bcbacfb81d4c24047",
+      "byteCount": 45479,
+      "sha256": "4559d22599d5ed733eb14ba074e37de12e8db297571b70be93b898a347274658",
+      "artifactClass": "demo-html",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "93a8e3acd6e9c7faa1bc1f96dff4ea4b61759927",
+      "byteCount": 98528,
+      "sha256": "57425cd0f951ee4f62fe18887a0aa2e08cf69fe725bb8260508b025ba897541c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/skeuomorphic-ui/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f8dfa8ce83bf14dbef94ea87d525d7c33e193067",
+      "byteCount": 4518,
+      "sha256": "17a01023247f4e4f9ba1fd316302b5a2c7fb0da2e7d6deb5a8fe037b8f745b78",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "skeuomorphic-ui",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "SUR-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/signature-devices.md"
+      ],
+      "reason": "Adopt tactile depth surface device with multi-layer shadow elevation."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4d9e1d57190db84e4b0293697a3c51d600430825"
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1f78b8e82cdc7538427aac7ad2fd5edc19c79f54",
+      "byteCount": 743,
+      "sha256": "fd99604acf317b21dea735558e3ac9ae98ab5751d4addbffe640bde79da41b51",
+      "artifactClass": "skill",
+      "ownerSkill": "solar-duotone-bold",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d648c20bf2a9161c41bd4f7623cd4c1c1e510325"
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d98b66a0ecb328c2b21a15223f0549e2cece9970",
+      "byteCount": 2537,
+      "sha256": "8683b53870f2ab03bda6cbae358a46ee7fb47711c4d340d532a74516febc69ab",
+      "artifactClass": "prompt",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9ccc59f2c87b29a47c003048cf6c0d26f944029f"
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "764233ff37fe552c54ee65be0329754f008a9577",
+      "byteCount": 362749,
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "072de2e20e298844fb880a2cf82fec2cca237d75",
+      "byteCount": 73780,
+      "sha256": "97c65569d294acbb5072f963eec2f67f57fd3e8fbba84cfa9a1bfe5042e92d54",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c038b784376e3d3e62eb2dbcfc1133ff787344c9",
+      "byteCount": 21909,
+      "sha256": "7abbd51e4c973de2df8ce06f7b1f24f9c20cbfc4cabb0438b88e80177d26f50e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a446585f6b5fcebbd5cd0d5f88f0581ea83a437d",
+      "byteCount": 55595,
+      "sha256": "bbe08c5a657202eed3200ef00f2ba3bcd7ead0be207bf1b0d67d0eee118e4fc0",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/solar-duotone-bold/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "dcccb0e80e270672e84ff0dedb088a3e5b1381b0",
+      "byteCount": 3282,
+      "sha256": "6887c7e398a4c8b460e9b852bd89ba7c1cc87b490e590f9b0560c240e78c6fe5",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "solar-duotone-bold",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Single icon-set vendor prescription conflicting with family coherence rules."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "1bca1ec927a6de5c479cc03acc7803680003b57e"
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "406722079067f9f8d45069f727bdf28f9e582f71",
+      "byteCount": 4258,
+      "sha256": "ae8e02a4461773e0d4c04a3ef367cad1a7b6933565549d3296e4a0e54a8b1c0b",
+      "artifactClass": "skill",
+      "ownerSkill": "split-layout-technical",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "277510bdf6011ddc10d0319e3cd86a1d2fdc4467"
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e859de5c442cb4e84d842899cef4beab53c989e6",
+      "byteCount": 3464,
+      "sha256": "6965030c38881d181557959b808fc830cb654a4be606cf43c3866ddabcc9eb9f",
+      "artifactClass": "prompt",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "48b414490df3573bff95f7d8871eccfa88eba267"
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets/page-01-65695f80-23f9-46ee-8487-cbb6c93cc48b-3840w.webp",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14c17545abe76f947ee8bf0df2c35fb5e6d37adc",
+      "byteCount": 536390,
+      "sha256": "aa13a51aa712319693dc94d6fcd6dc8ac32d4bbd869fd12fd6872fcb57632005",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets/page-03-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets/page-05-e534354d-c5f2-4399-a1d9-2f50338e8c47-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8e519cedbdd3976485487aea85409c434129ea3b",
+      "byteCount": 85289,
+      "sha256": "715a6071cdbc31593c5ce34ef33fa3c97f0f251bd1508828cd3f45769553c7bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets/page-06-fb6415fd-bf4d-4ccf-8e9d-7ab445e99207-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c17c9ed9481fe26fe7fdfca9a0a8dab4dd3a771d",
+      "byteCount": 201962,
+      "sha256": "bb9608e956b3ba037ddff5f238268c5c0a0b4ad0dd96f529ae56feae5ac72c30",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f77fe5bede25677fe105589063c8b434ac5215e2",
+      "byteCount": 139542,
+      "sha256": "3ecad5d2605bbf56d3f02c0a2a4673d574d405a5d830e45b43d6a34c01cbe992",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ea0c87673cd6f78aa82acd6bcbacfb81d4c24047",
+      "byteCount": 45479,
+      "sha256": "4559d22599d5ed733eb14ba074e37de12e8db297571b70be93b898a347274658",
+      "artifactClass": "demo-html",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c16648be772d8f66cc2893060abdf116f211756e",
+      "byteCount": 98900,
+      "sha256": "76b73c67f533bf8c87e3042a10690f4bceaeb8b237db0f5f4aa8bf866831ae56",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/split-layout-technical/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "20ba1a66c095630a1eaa7cb5b8cc6d7e3fce7ef8",
+      "byteCount": 4538,
+      "sha256": "ae85aa49911b805288b6c86c243e816b4458cafa1e164b1413d0e873389d4467",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "split-layout-technical",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by split studio layout in existing page structures."
+    },
+    {
+      "path": "agent-skills/web-design/staggered-word-reveal",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2ec9560458b0363cd10bc93202e2007efa443d89"
+    },
+    {
+      "path": "agent-skills/web-design/staggered-word-reveal/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "339a182a139cce273d26c8d6a7b6db818a78bf39",
+      "byteCount": 4925,
+      "sha256": "79061529376810788b1d824e0f16a18c048d1c426d6909442888c9507ead08c9",
+      "artifactClass": "skill",
+      "ownerSkill": "staggered-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt staggered semantic text primitive with DOM-safe word reveal."
+    },
+    {
+      "path": "agent-skills/web-design/staggered-word-reveal/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f9225b87f7ab880f3a9806b4b6b40b0db2dedf33"
+    },
+    {
+      "path": "agent-skills/web-design/staggered-word-reveal/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "14b3ef298297e72ba7abcc5884044a08f13ca2a4",
+      "byteCount": 2043,
+      "sha256": "6f4febc96eb3acc3bbaf91ff66c161383b0ded8ef33c2d4cd3afb6122a0d690c",
+      "artifactClass": "prompt",
+      "ownerSkill": "staggered-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt staggered semantic text primitive with DOM-safe word reveal."
+    },
+    {
+      "path": "agent-skills/web-design/staggered-word-reveal/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bab2e5b5a981a5eb01adb615094856c66af98e3c",
+      "byteCount": 16531,
+      "sha256": "4a1de2f39870ef909a85bbf452381c516baea5805884a584095d09ecf86d9dfc",
+      "artifactClass": "demo-html",
+      "ownerSkill": "staggered-word-reveal",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt staggered semantic text primitive with DOM-safe word reveal."
+    },
+    {
+      "path": "agent-skills/web-design/staggered-word-reveal/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5c12bf15c3ce58970d03935cda6262844217b3f9",
+      "byteCount": 71323,
+      "sha256": "32579d9529bd36ab7fc501f6dd417073b8e3f2c5c970144868fbda4e1452ed2a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "staggered-word-reveal",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "MOT-02"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/motion-craft.md"
+      ],
+      "reason": "Adopt staggered semantic text primitive with DOM-safe word reveal."
+    },
+    {
+      "path": "agent-skills/web-design/tailwindcss",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "cdb9b4d246e010213637374493561033e63e01ea"
+    },
+    {
+      "path": "agent-skills/web-design/tailwindcss/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "1335ef2d962a282fdd0e09056a5cf7db14414aa0",
+      "byteCount": 72,
+      "sha256": "f7145bc7d040b52fcfecc94809efc85094a530f05d30f9a044e6e601c79d8828",
+      "artifactClass": "reference/article",
+      "ownerSkill": "tailwindcss",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Framework implementation wrapper belonging outside core design knowledge."
+    },
+    {
+      "path": "agent-skills/web-design/tailwindcss/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fe522920fd8c8f534bf696dd3090d3d16dedbaf5",
+      "byteCount": 2816,
+      "sha256": "90d2150c24c7453d3f75914791d5356c87606a7c1b933d3371a6120624720c4e",
+      "artifactClass": "skill",
+      "ownerSkill": "tailwindcss",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Framework implementation wrapper belonging outside core design knowledge."
+    },
+    {
+      "path": "agent-skills/web-design/tailwindcss/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "094d6722b020f82b5da685059905fbff7edad89c"
+    },
+    {
+      "path": "agent-skills/web-design/tailwindcss/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6e75b48b6614e82d990c7311e2491a40b30b9236",
+      "byteCount": 1885,
+      "sha256": "fcedabd00e30c99499bf7c74046061dbb53d19caa3eabe7e678c7d09b22294a4",
+      "artifactClass": "prompt",
+      "ownerSkill": "tailwindcss",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Framework implementation wrapper belonging outside core design knowledge."
+    },
+    {
+      "path": "agent-skills/web-design/tailwindcss/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6e44b3d8592e4c0ecf0ebb7a28ab41f56cba946a",
+      "byteCount": 16519,
+      "sha256": "65442d33e8982ed8c3db7e4067e9124fb0dc15577ea4a585afef2bc3e7e6907b",
+      "artifactClass": "demo-html",
+      "ownerSkill": "tailwindcss",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Framework implementation wrapper belonging outside core design knowledge."
+    },
+    {
+      "path": "agent-skills/web-design/tailwindcss/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fc933055b21c3c29ca1b448f4fe77869420e5fc6",
+      "byteCount": 50535,
+      "sha256": "b5bc82ebc6ef107f6861ce59ca67d54d11aeb9218fe158a8e545b9c270fc3391",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "tailwindcss",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Framework implementation wrapper belonging outside core design knowledge."
+    },
+    {
+      "path": "agent-skills/web-design/tech-green-dark-mode-modern",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "605a783c454d667b88ea632f4bbee344c4b889fc"
+    },
+    {
+      "path": "agent-skills/web-design/tech-green-dark-mode-modern/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "41c129a320fc2ed21074c27fb5c2bb76d6a0c223",
+      "byteCount": 4028,
+      "sha256": "9c47f3929ebd3c3290b6d759f39a32a5ceada51f1a75404d90c391da862b9403",
+      "artifactClass": "skill",
+      "ownerSkill": "tech-green-dark-mode-modern",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, atmospheric light, and persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/tech-green-dark-mode-modern/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "23d07540301f6623deb04a554af0a822a3b13fa9"
+    },
+    {
+      "path": "agent-skills/web-design/tech-green-dark-mode-modern/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ad26b4a5c12170ec3f2dc19f35c1126a8ebe2650",
+      "byteCount": 1942,
+      "sha256": "8f27208c3efcbd9672e200e70850696080be0cd5e7ffc96bbb92800c2db5abfa",
+      "artifactClass": "prompt",
+      "ownerSkill": "tech-green-dark-mode-modern",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, atmospheric light, and persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/tech-green-dark-mode-modern/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4f08313e1ab04205688ba37563c9c787e47ff369",
+      "byteCount": 16630,
+      "sha256": "538569ef6c49727f47d734816d1e469899663dc29ddf07832726b223e4b3cd73",
+      "artifactClass": "demo-html",
+      "ownerSkill": "tech-green-dark-mode-modern",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, atmospheric light, and persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/tech-green-dark-mode-modern/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ee9c910b012e7bbee0988b652732591380b66b25",
+      "byteCount": 78811,
+      "sha256": "14884d21017b1a8a61c5133bad17331aa1b88bc091a13cf630b5d5169ed7e46a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "tech-green-dark-mode-modern",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "LAY-01",
+        "SUR-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by measured frame, atmospheric light, and persona tokens."
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "201ffa2bc2e4fad3aa87db4a344c9e8cf2ad8fe8"
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d47a87edb1576d2a79b84989bcf8abbc30539f9d",
+      "byteCount": 4272,
+      "sha256": "1960e7805000cece8f3d5edd87d89232e31caa5d43a9000842bb29cad4de5597",
+      "artifactClass": "skill",
+      "ownerSkill": "technical-wireframe-info-layout",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion."
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "81a407e7d0acf72c80ef822d3a7e1b3416365e61"
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a9796cf8bb8926e98b735e71058f89c70ba47db7",
+      "byteCount": 3472,
+      "sha256": "2ea0ce5924cd7caf6e6e07c3536aab2872ae8898649b58191a5c5db85221b83b",
+      "artifactClass": "prompt",
+      "ownerSkill": "technical-wireframe-info-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion."
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "022bd2af2459c77477448c514b6f7ab3bbc2897e"
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo/assets/page-01-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cb7656849d3d492e5a7dfbfc84a8ba4affb433d0",
+      "byteCount": 47486,
+      "sha256": "6a7bb45fc2ab13660d9c66de569563e928ffaaa526d6f44f5d3147d5c35699f7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "technical-wireframe-info-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion."
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "522064b02be114cad7931b97b8c7094f6d5769e6",
+      "byteCount": 49327,
+      "sha256": "01d0bb6d9691f29191cd3a511c295961e7711adf4566f1bcbd3a4e7daa06dae0",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "technical-wireframe-info-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion."
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf103976c8779bab2a1da09701a2a44426ee1c42",
+      "byteCount": 45410,
+      "sha256": "c0bd03fa1e08482f5325b13941cba2d7ffa0af009892112b877ca981e06cd2db",
+      "artifactClass": "demo-html",
+      "ownerSkill": "technical-wireframe-info-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion."
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "42f424dd46562390f05b4e17c61c6c2bcced8429",
+      "byteCount": 56203,
+      "sha256": "bd69740419388047f4d2fde2cdc2eb6238cd8024a68cef2db2db5222385acd0c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "technical-wireframe-info-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion."
+    },
+    {
+      "path": "agent-skills/web-design/technical-wireframe-info-layout/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5477185de041bdab813ac8e2e6ab4d2b244a33ed",
+      "byteCount": 2951,
+      "sha256": "9a1b190097961e921a427cb9247174586e186ced867fc92c15dd3911a76ec44b",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "technical-wireframe-info-layout",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "MOT-11"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/page-structures.md"
+      ],
+      "reason": "Covered by specimen page structure and scan assembly motion."
+    },
+    {
+      "path": "agent-skills/web-design/thinking-orbs",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "d5d53c07abe7c9f6c87999044875dab269de7c4a"
+    },
+    {
+      "path": "agent-skills/web-design/thinking-orbs/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c392d76579b4093c9fcbf965f0711cff06b31c0d",
+      "byteCount": 891,
+      "sha256": "d71796a72e298834da0e4b188e0e4d7ddaaabe6c748702d26d0d09accf8801d5",
+      "artifactClass": "reference/article",
+      "ownerSkill": "thinking-orbs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Package wrapper for status states covered by general accessibility."
+    },
+    {
+      "path": "agent-skills/web-design/thinking-orbs/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "89f1468b4e98dde077cf006cb74e6bbd4ded3443",
+      "byteCount": 9673,
+      "sha256": "6c24fc7f6582d636e45394f5d27ee6360c5ac55b03775e6d939847aefe2d20d4",
+      "artifactClass": "skill",
+      "ownerSkill": "thinking-orbs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Package wrapper for status states covered by general accessibility."
+    },
+    {
+      "path": "agent-skills/web-design/thinking-orbs/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "bbfe44e266d01f208f9cb1f745dca0c6a2d2259c"
+    },
+    {
+      "path": "agent-skills/web-design/thinking-orbs/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "61f32b4a8f10d0a611c42a3cc1ec31960d7a9e85",
+      "byteCount": 204,
+      "sha256": "766f45d2b284a52f2816d4bfd9cb28d112ffcdf43f80533e5c40369171092dd0",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "thinking-orbs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Package wrapper for status states covered by general accessibility."
+    },
+    {
+      "path": "agent-skills/web-design/threejs",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4bd27346503789dcbba2a908f69838f7ff458cd3"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "4c66071d09467b98861210d86038f8a659b19c4f"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d2317169f082d7ee367e9f547069859c80c0d483",
+      "byteCount": 8466,
+      "sha256": "fa361bdf1008be41e9447ebe1e9e195a6d0ecc9a781a8e8c63ac25cdc7aedc86",
+      "artifactClass": "skill",
+      "ownerSkill": "threejs-landscape",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt landscape canvas effect with polar-grid LOD and time transitions."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3b67ff2ba4cddae8a9b1655f5aca6613588edf33"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "088b3e9c8eac12d3e9d6c74ff97a78e8d3a229ca",
+      "byteCount": 280,
+      "sha256": "92bc56e5b93243293b261ab56f562ef244604c965884aa6efd0df21cf11697ec",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "threejs-landscape",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt landscape canvas effect with polar-grid LOD and time transitions."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "892d047ad671955340e40d76666bdbf130b8e775"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3b90ba55f3d47a6bd1b4f4c541291230a4dd99e0",
+      "byteCount": 1826,
+      "sha256": "aa23559b8f4c502e1dc05ea6fb10a77e40f3c30d849edb27106455b584a8c685",
+      "artifactClass": "prompt",
+      "ownerSkill": "threejs-landscape",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt landscape canvas effect with polar-grid LOD and time transitions."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "78a01de1d3def6034f4ce072b8b0370104f8fb36"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/demo/assets/three.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4494cf4e8d37049896b6051da6edfe44a83355af",
+      "byteCount": 608081,
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "threejs-landscape",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt landscape canvas effect with polar-grid LOD and time transitions."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "0596646ee26bf7bba7393023f1bd748d732c3023",
+      "byteCount": 27460,
+      "sha256": "8529d56b5308cdf7bcc8b32ecd78d9c2a490bf14647e06e0587331849d134f52",
+      "artifactClass": "demo-html",
+      "ownerSkill": "threejs-landscape",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt landscape canvas effect with polar-grid LOD and time transitions."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-landscape/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e8058ea1f70fb5a6b30d28224e649307215ed2a4",
+      "byteCount": 729506,
+      "sha256": "096034baed0bbb9424757a9fe6049602216f86b00c7f9d094e5f1ebd52e4292c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "threejs-landscape",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-05"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt landscape canvas effect with polar-grid LOD and time transitions."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "b3db158363e674e143c147fc1c8d4297aec2a90f"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9cc6dfe97cfc480d806468dcfcf756ab2bfadd32",
+      "byteCount": 8254,
+      "sha256": "f184ccfbad0ce6ed6e00731decf2fa044109c2bcd40fc9793e4e2de3ee4bb0a7",
+      "artifactClass": "skill",
+      "ownerSkill": "threejs-towers",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt procedural architecture effect with clipping plane assembly sequences."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "739bef1a044a02c92be3c6835287ada5abd8312d"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f5772c69fd5dc97e059686f672dd9f120b654728",
+      "byteCount": 245,
+      "sha256": "2d6123d7f8df5d0f0a477b27163f8e51a628b8fae24d8629205924148301a96c",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "threejs-towers",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt procedural architecture effect with clipping plane assembly sequences."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "e46d0fda14bbd2d4e5a34437f0bf3818bc257a2a"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7ff0414ad5bd3a5fd4b1d856e463834d945aed4d",
+      "byteCount": 1931,
+      "sha256": "5a85d11d8110d6c69f0cfdab785c3be16548dcf1f7f399644ce631856a15b322",
+      "artifactClass": "prompt",
+      "ownerSkill": "threejs-towers",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt procedural architecture effect with clipping plane assembly sequences."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "78a01de1d3def6034f4ce072b8b0370104f8fb36"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/demo/assets/three.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4494cf4e8d37049896b6051da6edfe44a83355af",
+      "byteCount": 608081,
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "threejs-towers",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt procedural architecture effect with clipping plane assembly sequences."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cc341ff1d574c3b1378851209790a8d1e1f51e4a",
+      "byteCount": 28908,
+      "sha256": "9c1f83cc6535b5cadf58439de3f07abaa7262bb26ddd722e36265b3e3d00d852",
+      "artifactClass": "demo-html",
+      "ownerSkill": "threejs-towers",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt procedural architecture effect with clipping plane assembly sequences."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-towers/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "e7d354b4653ede6a8893620ef20b940e314ee50f",
+      "byteCount": 183153,
+      "sha256": "ebd2842cf716377ea5ae8ae0ab755aaad26eb20cfa9e582beae6d3b7fa16aa01",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "threejs-towers",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt procedural architecture effect with clipping plane assembly sequences."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "081a993169f1aa3f66b81e24d023d0d10eac9cfa"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "166e1e0af6dfe5cbb240e1f720ebfc15e09fb352",
+      "byteCount": 7941,
+      "sha256": "c87f93d7189459fda61cadad78fa938498c0612a106c6084746ee5784fb1d6bd",
+      "artifactClass": "skill",
+      "ownerSkill": "threejs-weather",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt weather system canvas effect with frustum-anchored precipitation models."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/agents",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "dea91a9a72296e7b42c4e3428e4b9f09b61a17c6"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/agents/openai.yaml",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "706b0d35be2c6e745aeb75bfae746240dc43be74",
+      "byteCount": 255,
+      "sha256": "dc7e341ae40d71eb75f35fc706fdb01e032540063873afe1cf8932341aab4460",
+      "artifactClass": "agent-yaml",
+      "ownerSkill": "threejs-weather",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt weather system canvas effect with frustum-anchored precipitation models."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "24fc80ed8675c5b38411848aa82c541f5670c4b9"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ea2a06e2deb6a12d176452cdbbfb8d33735090bf",
+      "byteCount": 2006,
+      "sha256": "142ce18c56c86b0849651d16b789b3a75c1bd1554c61973c9c82c06488f02bda",
+      "artifactClass": "prompt",
+      "ownerSkill": "threejs-weather",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt weather system canvas effect with frustum-anchored precipitation models."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "78a01de1d3def6034f4ce072b8b0370104f8fb36"
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/demo/assets/three.min.js",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "4494cf4e8d37049896b6051da6edfe44a83355af",
+      "byteCount": 608081,
+      "sha256": "8a5f7249903b54d30f79f708699d2fed2d6a1d0741a4cd41377d1f01bb5a2271",
+      "artifactClass": "vendored-minified-js",
+      "ownerSkill": "threejs-weather",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt weather system canvas effect with frustum-anchored precipitation models."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "63e76d4a4f0cabdb0906d5636e5158c45d3b0143",
+      "byteCount": 38358,
+      "sha256": "b4c4a5c11806f1391137b7e70788c0801aa84f0a7b02272608a6a0ad8ec2f1c7",
+      "artifactClass": "demo-html",
+      "ownerSkill": "threejs-weather",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt weather system canvas effect with frustum-anchored precipitation models."
+    },
+    {
+      "path": "agent-skills/web-design/threejs-weather/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6593d029e4ef455b3573068303b5f3b4992bd282",
+      "byteCount": 621384,
+      "sha256": "3fade90da7c1ec3d040a220d97a19477b9a9dde236505e7381ab3c9c8edca15a",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "threejs-weather",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-07"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt weather system canvas effect with frustum-anchored precipitation models."
+    },
+    {
+      "path": "agent-skills/web-design/threejs/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "07c70beb5f2732da3b3f6f521fca7c62e31bf219",
+      "byteCount": 49,
+      "sha256": "b4025d3e5a5ce293131229ca01329be5a676af4e3c53b61f3778e83eb454b33f",
+      "artifactClass": "reference/article",
+      "ownerSkill": "threejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Covered by existing Three.js scene contracts and effect guidance."
+    },
+    {
+      "path": "agent-skills/web-design/threejs/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5aa0672f5e52215aed117b80c79b780409a70b94",
+      "byteCount": 3476,
+      "sha256": "e6ebd6e0354b7d05fbfb87a63403b6c2a8c62450f86ff7a9316d55283d586813",
+      "artifactClass": "skill",
+      "ownerSkill": "threejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Covered by existing Three.js scene contracts and effect guidance."
+    },
+    {
+      "path": "agent-skills/web-design/threejs/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "2a18fd283002176ea66d26e80455132b6a1c1613"
+    },
+    {
+      "path": "agent-skills/web-design/threejs/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8ce29cffb35c999970cfc1b1e297f32ec10aaf47",
+      "byteCount": 1903,
+      "sha256": "3993393c5470b1834982d9e8af500a8b05fd1c7fa042c11a78b13ea9b3bc6d06",
+      "artifactClass": "prompt",
+      "ownerSkill": "threejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Covered by existing Three.js scene contracts and effect guidance."
+    },
+    {
+      "path": "agent-skills/web-design/threejs/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "be40b1f002f5814c5a0040002b70e83fd274527b",
+      "byteCount": 16255,
+      "sha256": "dc0d8fda194818f6b8ebb88c1d16566b6b02d6d6e37d8118a2f3a1e730187430",
+      "artifactClass": "demo-html",
+      "ownerSkill": "threejs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Covered by existing Three.js scene contracts and effect guidance."
+    },
+    {
+      "path": "agent-skills/web-design/threejs/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "7fe0d7190369781acd2709aa679b3c5fe5325cc9",
+      "byteCount": 39601,
+      "sha256": "4c1d469e856af594b675a14249883ec730c953933c97ba53188742260f835574",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "threejs",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Covered by existing Three.js scene contracts and effect guidance."
+    },
+    {
+      "path": "agent-skills/web-design/unicorn-studio",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "27bc76cd25d9392725160170a7b47d7591f8f637"
+    },
+    {
+      "path": "agent-skills/web-design/unicorn-studio/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9616faf794ff0141fcf5524a61b293dfc845eb3b",
+      "byteCount": 321,
+      "sha256": "2fc5cc2cbbaafc153f7662b60def4881b3e28f3d20f137a6e8d2b4f9c2b16306",
+      "artifactClass": "reference/article",
+      "ownerSkill": "unicorn-studio",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Hosted embed runtime wrapper violating self-contained knowledge architecture."
+    },
+    {
+      "path": "agent-skills/web-design/unicorn-studio/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6830bb0af84655c76e8ec3cece0f367dcff89f14",
+      "byteCount": 2558,
+      "sha256": "580b4ff727af5aa3d3909ee5e8cfe8e955949df597769a141b7548e8cd9f089c",
+      "artifactClass": "skill",
+      "ownerSkill": "unicorn-studio",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Hosted embed runtime wrapper violating self-contained knowledge architecture."
+    },
+    {
+      "path": "agent-skills/web-design/unicorn-studio/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "57d41d93bd59f4ac97fa191bf638e45857224af8"
+    },
+    {
+      "path": "agent-skills/web-design/unicorn-studio/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "94e87f9026d4e2cc917a5bc28922df81eeab1f0a",
+      "byteCount": 1863,
+      "sha256": "00f0a9bcd03ad48bf23b2a82e2dd5e17efed1292a934db741cf837a9f0a9b45e",
+      "artifactClass": "prompt",
+      "ownerSkill": "unicorn-studio",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Hosted embed runtime wrapper violating self-contained knowledge architecture."
+    },
+    {
+      "path": "agent-skills/web-design/unicorn-studio/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "53c22547556a135a80955a98032639c59b04f54d",
+      "byteCount": 16239,
+      "sha256": "8bc27e037532aacbdf955885de8c76d7666a0c79b403b75853557ccd7e18c39c",
+      "artifactClass": "demo-html",
+      "ownerSkill": "unicorn-studio",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Hosted embed runtime wrapper violating self-contained knowledge architecture."
+    },
+    {
+      "path": "agent-skills/web-design/unicorn-studio/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "59433a67e43838aa4d23c5cb4fe454b3f587b1cb",
+      "byteCount": 45480,
+      "sha256": "7907de2e1d42db327590bc68d9b8377e5d4e05ce6512cfb1f1b6f028d11089d9",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "unicorn-studio",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Hosted embed runtime wrapper violating self-contained knowledge architecture."
+    },
+    {
+      "path": "agent-skills/web-design/vantajs",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "65a1eb53fa2f46c25f2bf053877261b2ff96c2f4"
+    },
+    {
+      "path": "agent-skills/web-design/vantajs/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6f883bed6e9c60ec36e469b94a09cf7ffdbba982",
+      "byteCount": 124,
+      "sha256": "32a9f219ccfe870b64449b031a2a355ee7f83566fe78b458f70e76ec457f26f4",
+      "artifactClass": "reference/article",
+      "ownerSkill": "vantajs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Preset library wrapper causing dependency drift and generic outputs."
+    },
+    {
+      "path": "agent-skills/web-design/vantajs/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "66332092cf51159f20ffe7b8539566c3a5b7b76b",
+      "byteCount": 2037,
+      "sha256": "eeacf653ac518fccf3102d85cffb4002ecc2b0b8a4238757b2945a354b9afea0",
+      "artifactClass": "skill",
+      "ownerSkill": "vantajs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Preset library wrapper causing dependency drift and generic outputs."
+    },
+    {
+      "path": "agent-skills/web-design/vantajs/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "8c439e2bfd8fc990c352f672ce49cde8746b44b2"
+    },
+    {
+      "path": "agent-skills/web-design/vantajs/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5221033fc2bfc48e2d251a1bdaaf17566f633c39",
+      "byteCount": 1820,
+      "sha256": "26ce12dbd0832f2571321bf72c2ca2a3b89e1b0f8973dff00ac49619536ecead",
+      "artifactClass": "prompt",
+      "ownerSkill": "vantajs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Preset library wrapper causing dependency drift and generic outputs."
+    },
+    {
+      "path": "agent-skills/web-design/vantajs/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "f064d1bab24a19d794dbb84571a2e8056999b459",
+      "byteCount": 16186,
+      "sha256": "fba9b32afd9549637ab059712e1a01c31e077bdf2d4fb5b813afdd680cef231a",
+      "artifactClass": "demo-html",
+      "ownerSkill": "vantajs",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Preset library wrapper causing dependency drift and generic outputs."
+    },
+    {
+      "path": "agent-skills/web-design/vantajs/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cbe2753e09125443ec3098a5c16fc3122a2fa957",
+      "byteCount": 39524,
+      "sha256": "780c28d8caeccfae740e805542fe0494e2fa3f204c49fac19e62eb1472c9a0cf",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "vantajs",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "rejected",
+      "techniqueIds": [],
+      "existingKnowledgeRefs": [],
+      "reason": "Preset library wrapper causing dependency drift and generic outputs."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "93c13e987aafd6332bbcd95d3602d3b46d93cbb5"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d11f1522c95ac59ed3ed8e67b6389fdc8abcb381",
+      "byteCount": 6603,
+      "sha256": "8b4c8fca568309a6156389bb21b7077a27abe24213789d7f1b2c7d5ab79f3e45",
+      "artifactClass": "skill",
+      "ownerSkill": "webgl-3d-object",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "f8383bc75aa2b3fb5025140f8789fdafa71886df"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "2ec197f2b5eecedd74339486af81f5830444421b",
+      "byteCount": 3234,
+      "sha256": "73f6a81afa2ff0aff412eda6146bee50b883f672f7c591078fc0f7191834aa3f",
+      "artifactClass": "prompt",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "3ff28768e2c16c993eb0e669f5d89b1b043e4de0"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets/page-01-4734259a-bad7-422f-981e-ce01e79184f2-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ebf14e0f6e4547525ebdf610a29ebca420fec70e",
+      "byteCount": 44753,
+      "sha256": "7c5d0ce6a7c09525fbccb58630648d2a2a5cbae23566d8c2a2883b1b1cbab1bc",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets/page-02-724142aa-44a6-48d3-9cf3-761e00d05b78-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "735c2baf4929acbcd8cf0b63a975870a5de418a7",
+      "byteCount": 989406,
+      "sha256": "cf38c5d328948a752335fead031955f3db89c5584effb869d90e7a44b818c451",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets/page-03-fa51902b-c2a4-4c33-a96e-a8f1ef67edc6-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "cb7656849d3d492e5a7dfbfc84a8ba4affb433d0",
+      "byteCount": 47486,
+      "sha256": "6a7bb45fc2ab13660d9c66de569563e928ffaaa526d6f44f5d3147d5c35699f7",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets/page-04-005600e5-f6ab-4e59-bc86-eaeb02797dfa-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "bf5d1b2112d445fa92dc7a48efe810e7d5698cf5",
+      "byteCount": 728581,
+      "sha256": "5643fc34792343982ab3990a1107745535413692371f1269473a69ba53b148ca",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets/page-05-5ee0a38a-b5d3-4531-8793-98beed4af162-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "581b1565cafeca5578bca12a5c5596c37f7f71a9",
+      "byteCount": 531939,
+      "sha256": "6a0ea1bc48598dd6b7848a1a718b87c93a2f15600c32eafa0d3e13138b3516cf",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets/page-06-5ee0a38a-b5d3-4531-8793-98beed4af162-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "581b1565cafeca5578bca12a5c5596c37f7f71a9",
+      "byteCount": 531939,
+      "sha256": "6a0ea1bc48598dd6b7848a1a718b87c93a2f15600c32eafa0d3e13138b3516cf",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "fb8aa04c2cf97e682d4ff1bdb735e9920d7800dc",
+      "byteCount": 54765,
+      "sha256": "286e0e416bedd9dcf291faacd7ae23317999db58c544ed650b45afbf5d811b4c",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "6deadfe582e347e9bc3d0286ee1b178466aa7211",
+      "byteCount": 59638,
+      "sha256": "0918702673c1dedc00cf5d20e8f3abd6488a80344f82928a67919088e4669118",
+      "artifactClass": "demo-html",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "13242ef4cd8a7102c8e2eaf27a5e12dc830963c3",
+      "byteCount": 62684,
+      "sha256": "37c82650d4c071ed1d67b9f210ffb40cf70797bb685bcc769c0407a7d5effe09",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-3d-object/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3c3607c9a9f20dcda28a6e1b4a01ea0af8363344",
+      "byteCount": 4013,
+      "sha256": "53bcf8eacf876b474f2f7d357650688558ba7084374b147d875a7aa8cdf311a0",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "webgl-3d-object",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-04"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt lit 3D object canvas effect with PBR lighting and static fallbacks."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-landing-steering",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "55ef17bf83432fefa9dadb904c369c71e38c5a64"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-landing-steering/REFERENCES.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "164ad9d246e9b054ac9916dfe87f51f976abe780",
+      "byteCount": 351,
+      "sha256": "0db35f710352de6d5090d40af3b0cbd200c7ad06ef0335a5172869989e7bea46",
+      "artifactClass": "reference/article",
+      "ownerSkill": "webgl-landing-steering",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "SYS-04",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/prompt-plan-orchestration.md"
+      ],
+      "reason": "Covered by effect budgeting and orchestrator quality governor contracts."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-landing-steering/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "489aedbeb3dc6889395f15c919f341cc7d6894e5",
+      "byteCount": 5157,
+      "sha256": "a5310ca2912c1c5ae8eb38f14284e5876da88bdbb9ee8034838aafba462a5127",
+      "artifactClass": "skill",
+      "ownerSkill": "webgl-landing-steering",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "SYS-04",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/prompt-plan-orchestration.md"
+      ],
+      "reason": "Covered by effect budgeting and orchestrator quality governor contracts."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-landing-steering/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "dbb3ad23ba53906f0d60fb2f6820bb909ad2a392"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-landing-steering/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "586fcf79cc4c6ec7983b2463919d81ad9150faf2",
+      "byteCount": 1973,
+      "sha256": "0b5f641c38a688170dd3b9ba7818d5c761db58f0cc544110eef44839f2bb6cea",
+      "artifactClass": "prompt",
+      "ownerSkill": "webgl-landing-steering",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "SYS-04",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/prompt-plan-orchestration.md"
+      ],
+      "reason": "Covered by effect budgeting and orchestrator quality governor contracts."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-landing-steering/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "ef12d8a646b3edabaceebdfbdcde0ed4cc442538",
+      "byteCount": 16522,
+      "sha256": "07c4273eaed32bc04860b2934bd3a59aaaa788ce12d3339ce26af9fc62d815a6",
+      "artifactClass": "demo-html",
+      "ownerSkill": "webgl-landing-steering",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "SYS-04",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/prompt-plan-orchestration.md"
+      ],
+      "reason": "Covered by effect budgeting and orchestrator quality governor contracts."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-landing-steering/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "8812e21fdad403d67a5cf495c8dbcb86cc8cbfd3",
+      "byteCount": 67782,
+      "sha256": "fdc17167959c312091a8fc7156dddc1837d5e18c8252b91aa34bee0ba72d0ba1",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-landing-steering",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "no-per-asset-license-field",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "covered-existing",
+      "techniqueIds": [
+        "SYS-01",
+        "SYS-04",
+        "SYS-06"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/prompt-plan-orchestration.md"
+      ],
+      "reason": "Covered by effect budgeting and orchestrator quality governor contracts."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "b3103148de9e1ba939011f94cabbb9e3729ce17d"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/SKILL.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "5a2a1963ae6c4fc2dc42ea4a7be861383fb32001",
+      "byteCount": 9398,
+      "sha256": "da5aef6c1b15ae0a98b545a5d51ac323c4614484e7faaa2346ec15d2b76dc21e",
+      "artifactClass": "skill",
+      "ownerSkill": "webgl-laser",
+      "inspectionStatus": "statically-inspected",
+      "adoptability": "idea-only",
+      "thirdPartyMarker": false,
+      "licenseEvidence": "repository-root-MIT",
+      "legalDisposition": "idea-only-independent-rewrite",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "7efcdd1d38e8a0388f24452f51cb0ae2986912cd"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/PROMPT.md",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "d23e5e5e1e68f1ab70a1dce4d4191f4bb6b54a9e",
+      "byteCount": 3419,
+      "sha256": "102fdf2e684d3f4b1b171c989ccd7f630d0ce46c816eaf3717d2d9cdf43e12b9",
+      "artifactClass": "prompt",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/assets",
+      "mode": "040000",
+      "objectType": "tree",
+      "gitObjectId": "9ccc59f2c87b29a47c003048cf6c0d26f944029f"
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/assets/page-01-2f563338-39fa-47ea-9761-658d4f3f84db-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "74b6044b7a373ebbb73626a00905fc0b2b292d9a",
+      "byteCount": 298959,
+      "sha256": "868ee7e6983767d120387ecbd017fd6870f85aa0c5aeba6db06d54e0504c2934",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/assets/page-02-4f5668c5-fc4a-44e0-bc5e-a664189d3c31-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "3cd794d1e0e7989a2970cb4a945098fd1a83e13f",
+      "byteCount": 217369,
+      "sha256": "95767b6c354c4ac206cadaac8937b5a7b74ea1e227fa2f578703674d3725bcdd",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/assets/page-03-77415a2e-dcbc-4748-a29d-fced4821881a-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "764233ff37fe552c54ee65be0329754f008a9577",
+      "byteCount": 362749,
+      "sha256": "3c53a7cdf511b5078b720e0846641af3f3627ccd5ad310dc21346f24e8cc7fb5",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/assets/page-04-c92852bb-a510-405a-85ab-ffa0fde136a4-1600w.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "9197184ae879083d916ddf6934acfc2a2ee1f35b",
+      "byteCount": 214106,
+      "sha256": "20b69fddcd23ce1c188891dc2febb3cab2865519cae9210b347c52fcc801260b",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/assets/source-preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "072de2e20e298844fb880a2cf82fec2cca237d75",
+      "byteCount": 73780,
+      "sha256": "97c65569d294acbb5072f963eec2f67f57fd3e8fbba84cfa9a1bfe5042e92d54",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/index.html",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "c038b784376e3d3e62eb2dbcfc1133ff787344c9",
+      "byteCount": 21909,
+      "sha256": "7abbd51e4c973de2df8ce06f7b1f24f9c20cbfc4cabb0438b88e80177d26f50e",
+      "artifactClass": "demo-html",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/preview.jpg",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "a446585f6b5fcebbd5cd0d5f88f0581ea83a437d",
+      "byteCount": 55595,
+      "sha256": "bbe08c5a657202eed3200ef00f2ba3bcd7ead0be207bf1b0d67d0eee118e4fc0",
+      "artifactClass": "binary-asset",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    },
+    {
+      "path": "agent-skills/web-design/webgl-laser/demo/source.json",
+      "mode": "100644",
+      "objectType": "blob",
+      "gitObjectId": "85fc97bb954976a7f195c6e314d96474cb7fd87a",
+      "byteCount": 3261,
+      "sha256": "bb058fd5874dbafc54fac741aa753645caaaaa57ed4480d41cdf1dae9bc71568",
+      "artifactClass": "source-metadata",
+      "ownerSkill": "webgl-laser",
+      "provenance": "neuform-synchronized",
+      "inspectionStatus": "not-inspected",
+      "adoptability": "not-adoptable",
+      "thirdPartyMarker": true,
+      "licenseEvidence": "license-unverified-quarantine",
+      "legalDisposition": "metadata-only-quarantine",
+      "disposition": "adopted",
+      "techniqueIds": [
+        "FX-09"
+      ],
+      "existingKnowledgeRefs": [
+        "knowledge/canvas-effect-direction.md"
+      ],
+      "reason": "Adopt laser field canvas effect with halo layering and lifecycle controls."
+    }
+  ]
+}

--- a/scripts/check-mengto-web-technique-source.mjs
+++ b/scripts/check-mengto-web-technique-source.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  duplicateBlobGroups, enumerate, findNeuformOwners, parseArgs, readJson, sha256, sourceRecord,
+  validateDecisions, verifyRootLicenseEvidence,
+} from "./lib/mengto-web-technique-source.mjs";
+
+function assert(condition, message) { if (!condition) throw new Error(message); }
+
+try {
+  const options = parseArgs(process.argv.slice(2), ["corpus", "revision", "ledger"]);
+  const ledgerPath = resolve(options.ledger);
+  const ledgerDir = dirname(ledgerPath);
+  const manifest = readJson(ledgerPath);
+  assert(manifest.schemaVersion === 1, "manifest schemaVersion must be 1");
+  assert(manifest.upstream?.revision === options.revision, "manifest revision mismatch");
+  assert(Array.isArray(manifest.parts) && manifest.parts.length === 2, "manifest must contain tree and skills parts");
+  const loaded = new Map();
+  for (const part of manifest.parts) {
+    const path = resolve(ledgerDir, part.path);
+    const bytes = readFileSync(path);
+    assert(sha256(bytes) === part.sha256, `${part.kind} part SHA-256 mismatch`);
+    const value = JSON.parse(bytes.toString("utf8"));
+    const rows = part.kind === "tree" ? value.records : value.skills;
+    assert(Array.isArray(rows) && rows.length === part.recordCount, `${part.kind} part record count mismatch`);
+    loaded.set(part.kind, value);
+  }
+  const decisions = loaded.get("skills");
+  assert(JSON.stringify(manifest.upstream) === JSON.stringify(decisions.upstream), "manifest/decisions upstream provenance mismatch");
+  const counts = validateDecisions(decisions, options.revision);
+  verifyRootLicenseEvidence(options.corpus, options.revision, decisions.upstream);
+  for (const [key, value] of Object.entries(counts)) assert(JSON.stringify(manifest[key]) === JSON.stringify(value), `manifest ${key} mismatch`);
+  const records = loaded.get("tree").records;
+  assert(records.length === manifest.treeRecordCount, "manifest treeRecordCount mismatch");
+  for (let index = 1; index < records.length; index += 1) assert(records[index - 1].path < records[index].path, "tree part records are not bytewise path-sorted");
+  const actual = enumerate(options.corpus, options.revision);
+  assert(actual.length === records.length, "source/ledger record count mismatch");
+  const skillMap = new Map(decisions.skills.map((row) => [row.skill, row]));
+  const neuformOwners = findNeuformOwners(options.corpus, actual);
+  for (let index = 0; index < actual.length; index += 1) {
+    const source = actual[index];
+    const record = records[index];
+    const expectedRecord = sourceRecord(options.corpus, source, skillMap, neuformOwners);
+    assert(JSON.stringify(record) === JSON.stringify(expectedRecord), `source/ledger semantic record mismatch for ${source.path}`);
+  }
+  const declaredSkills = [...skillMap.keys()].sort();
+  const ownerSkills = records.filter((record) => record.artifactClass === "skill").map((record) => record.ownerSkill).sort();
+  assert(JSON.stringify(declaredSkills) === JSON.stringify(ownerSkills), "decision skills do not exactly match source skill owners");
+  const blobs = records.filter((record) => record.objectType === "blob");
+  assert(blobs.length === manifest.blobRecordCount, "manifest blobRecordCount mismatch");
+  assert(blobs.filter((record) => !["binary-asset", "root-support"].includes(record.artifactClass)).length === manifest.textArtifactCount, "manifest textArtifactCount mismatch");
+  assert(JSON.stringify(duplicateBlobGroups(records)) === JSON.stringify(manifest.duplicateBlobGroups), "manifest duplicateBlobGroups mismatch");
+  process.stdout.write(`verified ${records.length} pinned source records\n`);
+} catch (error) {
+  process.stderr.write(`source ledger verification failed: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/generate-mengto-web-technique-ledger.mjs
+++ b/scripts/generate-mengto-web-technique-ledger.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync } from "node:fs";
+import { basename, dirname, relative, resolve } from "node:path";
+import {
+  duplicateBlobGroups, enumerate, findNeuformOwners, parseArgs, readJson, sha256, sourceRecord,
+  validateDecisions, verifyRootLicenseEvidence, writeJson,
+} from "./lib/mengto-web-technique-source.mjs";
+
+try {
+  const options = parseArgs(process.argv.slice(2), ["corpus", "revision", "ledger"]);
+  const ledgerPath = resolve(options.ledger);
+  const ledgerDir = dirname(ledgerPath);
+  const decisionsPath = options.decisions
+    ? resolve(options.decisions)
+    : resolve(ledgerDir, basename(ledgerPath, ".json"), "skills.json");
+  if (!decisionsPath.startsWith(`${ledgerDir}/`)) throw new Error("decisions must be inside the ledger directory");
+  const decisions = readJson(decisionsPath);
+  const counts = validateDecisions(decisions, options.revision);
+  verifyRootLicenseEvidence(options.corpus, options.revision, decisions.upstream);
+  const entries = enumerate(options.corpus, options.revision);
+  if (entries.length === 0) throw new Error("git enumeration returned no source records");
+  const skillMap = new Map(decisions.skills.map((row) => [row.skill, row]));
+  const neuformOwners = findNeuformOwners(options.corpus, entries);
+  const records = entries.map((entry) => sourceRecord(options.corpus, entry, skillMap, neuformOwners));
+  const partDir = resolve(ledgerDir, "mengto-web-techniques--202608");
+  const treePath = resolve(partDir, "tree.json");
+  mkdirSync(partDir, { recursive: true });
+  writeJson(treePath, { schemaVersion: 1, kind: "tree", records });
+  const treeBytes = readFileSync(treePath);
+  const decisionsBytes = readFileSync(decisionsPath);
+  const blobs = records.filter((record) => record.objectType === "blob");
+  writeJson(ledgerPath, {
+    schemaVersion: 1,
+    id: "mengto-web-techniques--202608",
+    upstream: decisions.upstream,
+    enumeration: { scope: "agent-skills/web-design", command: "git ls-tree -r -t -l --full-tree <revision> -- agent-skills/web-design" },
+    treeRecordCount: records.length,
+    blobRecordCount: blobs.length,
+    textArtifactCount: blobs.filter((record) => !["binary-asset", "root-support"].includes(record.artifactClass)).length,
+    duplicateBlobGroups: duplicateBlobGroups(records),
+    ...counts,
+    parts: [
+      { kind: "tree", path: relative(ledgerDir, treePath), sha256: sha256(treeBytes), recordCount: records.length },
+      { kind: "skills", path: relative(ledgerDir, decisionsPath), sha256: sha256(decisionsBytes), recordCount: decisions.skills.length },
+    ],
+  });
+  process.stdout.write(`generated ${records.length} pinned source records\n`);
+} catch (error) {
+  process.stderr.write(`source ledger generation failed: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/lib/mengto-web-technique-source.mjs
+++ b/scripts/lib/mengto-web-technique-source.mjs
@@ -1,0 +1,199 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+
+export const SCOPE = "agent-skills/web-design";
+const TEXT_EXTENSIONS = new Set([
+  ".css", ".html", ".js", ".json", ".jsx", ".md", ".mdx", ".mjs", ".rst",
+  ".scss", ".svg", ".toml", ".ts", ".tsx", ".txt", ".yaml", ".yml",
+]);
+const CATEGORIES = ["core", "style", "vendor", "composite"];
+const DISPOSITIONS = ["adopted", "covered-existing", "rejected"];
+const MENGTO_REVISION = "4c716b516b6b0143f3037631306b3730d2832344";
+const MENGTO_COUNTS = {
+  skillRecordCount: 88,
+  categoryCounts: { core: 37, style: 27, vendor: 15, composite: 9 },
+  dispositionCounts: { adopted: 34, "covered-existing": 41, rejected: 13 },
+};
+
+export function parseArgs(argv, required) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error(`malformed arguments near ${flag ?? "<end>"}`);
+    }
+    values[flag.slice(2)] = value;
+  }
+  for (const key of required) if (!values[key]) throw new Error(`missing --${key}`);
+  if (!/^[0-9a-f]{40}$/.test(values.revision)) throw new Error("revision must be 40 lowercase hex characters");
+  return values;
+}
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function checkedOutBlob(corpus, entry) {
+  const bytes = readFileSync(join(corpus, entry.path));
+  const objectId = createHash("sha1")
+    .update(`blob ${bytes.length}\0`)
+    .update(bytes)
+    .digest("hex");
+  if (objectId !== entry.gitObjectId) {
+    throw new Error(`checked-out bytes do not match pinned blob ${entry.path}`);
+  }
+  return bytes;
+}
+export function readJson(path) {
+  try { return JSON.parse(readFileSync(path, "utf8")); }
+  catch (error) { throw new Error(`cannot read JSON ${path}: ${error.message}`); }
+}
+export function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+export function git(corpus, args, encoding = null) {
+  try {
+    return execFileSync("git", ["-C", corpus, ...args], {
+      encoding, maxBuffer: 256 * 1024 * 1024,
+      env: { ...process.env, GIT_NO_LAZY_FETCH: "1" },
+    });
+  } catch (error) {
+    throw new Error(`git ${args.join(" ")} failed: ${error.stderr?.toString().trim() || error.message}`);
+  }
+}
+
+export function enumerate(corpus, revision) {
+  git(corpus, ["cat-file", "-e", `${revision}^{commit}`]);
+  const output = git(corpus, ["ls-tree", "-r", "-t", "-l", "--full-tree", revision, "--", SCOPE], "utf8");
+  return output.trim().split("\n").filter(Boolean).map((line) => {
+    const [metadata, path] = line.split("\t");
+    const [mode, objectType, gitObjectId, size] = metadata.trim().split(/\s+/);
+    return { path, mode, objectType, gitObjectId, byteCount: objectType === "blob" ? Number(size) : undefined };
+  }).filter((entry) => entry.path.startsWith(`${SCOPE}/`))
+    .sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+}
+
+export function artifactClass(path) {
+  const lower = path.toLowerCase();
+  const file = basename(lower);
+  const extension = extname(lower);
+  if (!TEXT_EXTENSIONS.has(extension)) return "binary-asset";
+  if (file.includes("license")) return "license-notice";
+  if (file === "skill.md") return "skill";
+  if (file === "source.json") return "source-metadata";
+  if (lower.includes("/agents/") && [".yaml", ".yml"].includes(extension)) return "agent-yaml";
+  if (/\.min\.(js|css)$/.test(file)) return "vendored-minified-js";
+  if (extension === ".html") return "demo-html";
+  if (file.includes("prompt") || lower.includes("/prompts/")) return "prompt";
+  if ([".css", ".js", ".jsx", ".mjs", ".scss", ".svg", ".ts", ".tsx"].includes(extension)) return "authored-code";
+  if ([".md", ".mdx", ".rst", ".txt"].includes(extension)) return "reference/article";
+  return "other-text";
+}
+
+function countBy(rows, field, keys) {
+  return Object.fromEntries(keys.map((key) => [key, rows.filter((row) => row[field] === key).length]));
+}
+
+export function duplicateBlobGroups(records) {
+  const pathsByHash = new Map();
+  for (const record of records) {
+    if (record.objectType !== "blob") continue;
+    const paths = pathsByHash.get(record.sha256) ?? [];
+    paths.push(record.path);
+    pathsByHash.set(record.sha256, paths);
+  }
+  return [...pathsByHash.entries()]
+    .filter(([, paths]) => paths.length > 1)
+    .map(([hash, paths]) => ({ sha256: hash, paths: paths.sort() }))
+    .sort((left, right) => left.sha256.localeCompare(right.sha256));
+}
+
+export function findNeuformOwners(corpus, entries) {
+  return new Set(entries
+    .filter((entry) => entry.objectType === "blob" && entry.path.endsWith("/demo/source.json"))
+    .filter((entry) => checkedOutBlob(corpus, entry).toString("utf8").toLowerCase().includes("neuform"))
+    .map((entry) => entry.path.slice(`${SCOPE}/`.length).split("/")[0]));
+}
+
+export function verifyRootLicenseEvidence(corpus, revision, upstream) {
+  const evidence = upstream?.rootLicenseEvidence;
+  if (upstream?.rootLicense !== "MIT" || evidence?.path !== "LICENSE") {
+    throw new Error("root MIT license requires pinned LICENSE evidence");
+  }
+  const line = git(corpus, ["ls-tree", "-l", revision, "--", evidence.path], "utf8").trim();
+  if (!line) throw new Error("pinned root LICENSE is missing");
+  const [metadata, path] = line.split("\t");
+  const [mode, objectType, gitObjectId, byteCount] = metadata.split(/\s+/);
+  if (path !== evidence.path || objectType !== "blob") throw new Error("root LICENSE evidence is not a blob");
+  const bytes = git(corpus, ["cat-file", "blob", gitObjectId]);
+  const actual = { path, mode, gitObjectId, byteCount: Number(byteCount), sha256: sha256(bytes) };
+  if (JSON.stringify(actual) !== JSON.stringify(evidence)) throw new Error("root LICENSE evidence mismatch");
+}
+
+export function validateDecisions(value, revision) {
+  if (value?.schemaVersion !== 1 || !Array.isArray(value.skills)) throw new Error("decisions require schemaVersion 1 and skills[]");
+  if (value.upstream?.revision !== revision) throw new Error("decisions upstream revision mismatch");
+  if (!value.upstream?.repository || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(value.upstream?.capturedAt ?? "")) {
+    throw new Error("decisions upstream metadata incomplete");
+  }
+  const seen = new Set();
+  for (const row of value.skills) {
+    if (!row.skill || seen.has(row.skill)) throw new Error(`invalid or duplicate skill ${row.skill}`);
+    seen.add(row.skill);
+    if (!CATEGORIES.includes(row.category) || !DISPOSITIONS.includes(row.disposition)) throw new Error(`invalid decisions enum for ${row.skill}`);
+    if (!row.reason?.trim() || !Array.isArray(row.techniqueIds) || !Array.isArray(row.existingKnowledgeRefs)) throw new Error(`incomplete decisions row ${row.skill}`);
+    if (row.disposition === "adopted" && row.techniqueIds.length === 0) throw new Error(`adopted ${row.skill} requires techniqueIds`);
+    if (row.disposition === "covered-existing" && row.techniqueIds.length + row.existingKnowledgeRefs.length === 0) throw new Error(`covered-existing ${row.skill} requires a destination`);
+    if (row.disposition === "rejected" && row.techniqueIds.length + row.existingKnowledgeRefs.length > 0) throw new Error(`rejected ${row.skill} cannot have a destination`);
+  }
+  const actual = {
+    skillRecordCount: value.skills.length,
+    categoryCounts: countBy(value.skills, "category", CATEGORIES),
+    dispositionCounts: countBy(value.skills, "disposition", DISPOSITIONS),
+  };
+  if (JSON.stringify(actual) !== JSON.stringify(value.expected)) throw new Error("decisions expected counts mismatch");
+  if (revision === MENGTO_REVISION && JSON.stringify(actual) !== JSON.stringify(MENGTO_COUNTS)) {
+    throw new Error("decisions do not match the approved MengTo count baseline");
+  }
+  return actual;
+}
+
+export function sourceRecord(corpus, entry, skillMap, neuformOwners = new Set()) {
+  if (entry.objectType === "tree") return { path: entry.path, mode: entry.mode, objectType: "tree", gitObjectId: entry.gitObjectId };
+  const bytes = checkedOutBlob(corpus, entry);
+  const relative = entry.path.slice(`${SCOPE}/`.length);
+  const ownerSkill = relative.includes("/") ? relative.split("/")[0] : null;
+  const decision = ownerSkill ? skillMap.get(ownerSkill) : null;
+  if (ownerSkill && !decision) throw new Error(`no decision for owner skill ${ownerSkill}`);
+  const kind = ownerSkill ? artifactClass(entry.path) : "root-support";
+  const neuformDerived = Boolean(ownerSkill && neuformOwners.has(ownerSkill) && relative.startsWith(`${ownerSkill}/demo/`));
+  const quarantined = neuformDerived || !decision || decision.disposition === "rejected" || [
+    "agent-yaml", "binary-asset", "license-notice", "source-metadata", "vendored-minified-js",
+  ].includes(kind);
+  const licenseEvidence = kind === "license-notice"
+    ? "embedded-license-notice"
+    : neuformDerived
+      ? "license-unverified-quarantine"
+    : ["binary-asset", "source-metadata"].includes(kind)
+      ? "no-per-asset-license-field"
+      : kind === "vendored-minified-js"
+        ? "license-unverified-quarantine"
+        : decision ? "repository-root-MIT" : "repository-support-only";
+  const legalDisposition = kind === "license-notice"
+    ? "license-evidence-only"
+    : quarantined ? "metadata-only-quarantine" : "idea-only-independent-rewrite";
+  return {
+    path: entry.path, mode: entry.mode, objectType: "blob", gitObjectId: entry.gitObjectId,
+    byteCount: bytes.length, sha256: sha256(bytes), artifactClass: kind, ownerSkill,
+    provenance: neuformDerived ? "neuform-synchronized" : undefined,
+    inspectionStatus: neuformDerived || ["binary-asset", "vendored-minified-js"].includes(kind) ? "not-inspected" : "statically-inspected",
+    adoptability: quarantined ? "not-adoptable" : "idea-only",
+    thirdPartyMarker: neuformDerived || ["binary-asset", "license-notice", "source-metadata", "vendored-minified-js"].includes(kind),
+    licenseEvidence,
+    legalDisposition,
+    disposition: decision?.disposition ?? "rejected", techniqueIds: decision?.techniqueIds ?? [],
+    existingKnowledgeRefs: decision?.existingKnowledgeRefs ?? [], reason: decision?.reason ?? "Root support metadata only",
+  };
+}

--- a/tests/mengto-web-technique-source-ledger.test.ts
+++ b/tests/mengto-web-technique-source-ledger.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "..");
+const generate = join(root, "scripts/generate-mengto-web-technique-ledger.mjs");
+const check = join(root, "scripts/check-mengto-web-technique-source.mjs");
+let tmp = "";
+let corpus = "";
+let revision = "";
+let decisions = "";
+let ledger = "";
+
+function run(script: string, args: string[]) {
+  return spawnSync(process.execPath, [script, ...args], { encoding: "utf8" });
+}
+
+function args(withDecisions = false) {
+  const base = ["--corpus", corpus, "--revision", revision, "--ledger", ledger];
+  return withDecisions ? [...base, "--decisions", decisions] : base;
+}
+
+function write(path: string, value: string | Buffer) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, value);
+}
+
+function initFixture() {
+  corpus = join(tmp, "corpus");
+  execFileSync("git", ["init", "-q", corpus]);
+  execFileSync("git", ["-C", corpus, "config", "user.name", "Fixture"]);
+  execFileSync("git", ["-C", corpus, "config", "user.email", "fixture@example.test"]);
+  const base = join(corpus, "agent-skills/web-design");
+  write(join(corpus, "LICENSE"), "MIT fixture license\n");
+  write(join(base, "README.md"), "fixture\n");
+  write(join(base, "core-one/SKILL.md"), "core\n");
+  write(join(base, "core-one/references/guide.md"), "guide\n");
+  write(join(base, "core-one/references/guide-copy.md"), "guide\n");
+  write(join(base, "core-one/references/THREE-LICENSE.txt"), "third-party license\n");
+  write(join(base, "core-one/agents/openai.yaml"), "interface: fixture\n");
+  write(join(base, "style-one/SKILL.md"), "style\n");
+  write(join(base, "style-one/demo/index.html"), "<main>fixture</main>\n");
+  write(join(base, "style-one/demo/PROMPT.md"), "neuform prompt\n");
+  write(join(base, "style-one/demo/source.json"), "{\"provider\":\"Neuform\"}\n");
+  write(join(base, "vendor-one/SKILL.md"), "vendor\n");
+  write(join(base, "vendor-one/demo/vendor.min.js"), "minified-fixture\n");
+  write(join(base, "composite-one/SKILL.md"), "composite\n");
+  write(join(base, "composite-one/demo/asset.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  execFileSync("git", ["-C", corpus, "add", "."]);
+  execFileSync("git", ["-C", corpus, "commit", "-qm", "fixture"]);
+  revision = execFileSync("git", ["-C", corpus, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  ledger = join(tmp, "out/mengto.json");
+  decisions = join(tmp, "out/mengto/skills.json");
+  const licenseBytes = readFileSync(join(corpus, "LICENSE"));
+  const licenseLine = execFileSync("git", ["-C", corpus, "ls-tree", "-l", revision, "--", "LICENSE"], { encoding: "utf8" }).trim();
+  const licenseMetadata = licenseLine.split("\t")[0] ?? "";
+  const [licenseMode, , licenseObjectId, licenseByteCount] = licenseMetadata.split(/\s+/);
+  write(decisions, `${JSON.stringify({
+    schemaVersion: 1,
+    upstream: {
+      repository: "https://example.test/source.git",
+      revision,
+      capturedAt: "2026-08-21T00:27:35Z",
+      rootLicense: "MIT",
+      rootLicenseEvidence: {
+        path: "LICENSE", mode: licenseMode, gitObjectId: licenseObjectId,
+        byteCount: Number(licenseByteCount), sha256: createHash("sha256").update(licenseBytes).digest("hex"),
+      },
+    },
+    expected: {
+      skillRecordCount: 4,
+      categoryCounts: { core: 1, style: 1, vendor: 1, composite: 1 },
+      dispositionCounts: { adopted: 2, "covered-existing": 1, rejected: 1 },
+    },
+    skills: [
+      { skill: "core-one", category: "core", disposition: "adopted", reason: "Reusable mechanism", techniqueIds: ["MOT-01"], existingKnowledgeRefs: [] },
+      { skill: "style-one", category: "style", disposition: "covered-existing", reason: "Existing owner", techniqueIds: [], existingKnowledgeRefs: ["knowledge/page-structures.md"] },
+      { skill: "vendor-one", category: "vendor", disposition: "rejected", reason: "Vendor wrapper", techniqueIds: [], existingKnowledgeRefs: [] },
+      { skill: "composite-one", category: "composite", disposition: "adopted", reason: "Reusable system contract", techniqueIds: ["SYS-01"], existingKnowledgeRefs: [] },
+    ],
+  }, null, 2)}\n`);
+}
+
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "mengto-ledger-")); initFixture(); });
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+describe("MengTo pinned source ledger", () => {
+  it("generates and verifies an exact offline ledger", () => {
+    expect(run(generate, args(false)).status).toBe(0);
+    const result = run(check, args());
+    expect(result.status, result.stderr).toBe(0);
+    const manifest = JSON.parse(readFileSync(ledger, "utf8"));
+    const records = JSON.parse(readFileSync(join(dirname(ledger), manifest.parts[0].path), "utf8")).records;
+    expect(manifest.skillRecordCount).toBe(4);
+    expect(manifest.duplicateBlobGroups).toEqual([
+      {
+        sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        paths: [
+          "agent-skills/web-design/core-one/references/guide-copy.md",
+          "agent-skills/web-design/core-one/references/guide.md",
+        ],
+      },
+    ]);
+    expect(records.map((record: { path: string }) => record.path)).toEqual(
+      [...records].map((record: { path: string }) => record.path).sort(),
+    );
+    expect(records.find((record: { path: string }) => record.path.endsWith("asset.png"))).toMatchObject({
+      inspectionStatus: "not-inspected", adoptability: "not-adoptable",
+      legalDisposition: "metadata-only-quarantine",
+    });
+    expect(records.find((record: { path: string }) => record.path.endsWith("THREE-LICENSE.txt"))).toMatchObject({
+      artifactClass: "license-notice", adoptability: "not-adoptable",
+      licenseEvidence: "embedded-license-notice", legalDisposition: "license-evidence-only",
+    });
+    expect(records.find((record: { path: string }) => record.path.endsWith("openai.yaml"))).toMatchObject({
+      artifactClass: "agent-yaml", adoptability: "not-adoptable",
+      legalDisposition: "metadata-only-quarantine",
+    });
+    expect(records.find((record: { path: string }) => record.path.endsWith("style-one/demo/PROMPT.md"))).toMatchObject({
+      provenance: "neuform-synchronized", inspectionStatus: "not-inspected",
+      adoptability: "not-adoptable", licenseEvidence: "license-unverified-quarantine",
+    });
+  });
+
+  it.each([
+    ["bad revision", () => { revision = "0".repeat(40); }, "revision"],
+    ["malformed decisions", () => write(decisions, "{}\n"), "decisions"],
+  ])("rejects %s", (_name, mutate, message) => {
+    mutate();
+    const result = run(generate, args(true));
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toLowerCase()).toContain(message);
+  });
+
+  it.each(["missing-record", "mutated-sha", "semantic-field", "unsorted", "bad-part-hash", "bad-count"])(
+    "rejects %s ledger mutation",
+    (mutation) => {
+      expect(run(generate, args(true)).status).toBe(0);
+      const manifest = JSON.parse(readFileSync(ledger, "utf8"));
+      const partPath = join(dirname(ledger), manifest.parts[0].path);
+      const treePart = JSON.parse(readFileSync(partPath, "utf8"));
+      const records = treePart.records;
+      if (mutation === "missing-record") records.pop();
+      if (mutation === "mutated-sha") records.find((record: { objectType: string }) => record.objectType === "blob").sha256 = "0".repeat(64);
+      if (mutation === "semantic-field") {
+        const binary = records.find((record: { artifactClass: string }) => record.artifactClass === "binary-asset");
+        binary.inspectionStatus = "statically-inspected";
+        binary.adoptability = "idea-only";
+        binary.legalDisposition = "idea-only-independent-rewrite";
+      }
+      if (mutation === "unsorted") [records[0], records[1]] = [records[1], records[0]];
+      if (["missing-record", "mutated-sha", "semantic-field", "unsorted"].includes(mutation)) {
+        write(partPath, `${JSON.stringify({ ...treePart, records }, null, 2)}\n`);
+        manifest.parts[0].sha256 = execFileSync("shasum", ["-a", "256", partPath], { encoding: "utf8" }).split(" ")[0];
+      }
+      if (mutation === "bad-part-hash") manifest.parts[0].sha256 = "f".repeat(64);
+      if (mutation === "bad-count") manifest.parts[0].recordCount += 1;
+      write(ledger, `${JSON.stringify(manifest, null, 2)}\n`);
+      expect(run(check, args()).status).not.toBe(0);
+    },
+  );
+
+  it("rejects a self-consistent ledger with a missing skill decision", () => {
+    expect(run(generate, args(true)).status).toBe(0);
+    const manifest = JSON.parse(readFileSync(ledger, "utf8"));
+    const skillsPart = manifest.parts.find((part: { kind: string }) => part.kind === "skills");
+    const skillsPath = join(dirname(ledger), skillsPart.path);
+    const value = JSON.parse(readFileSync(skillsPath, "utf8"));
+    const removed = value.skills.pop();
+    value.expected.skillRecordCount -= 1;
+    value.expected.categoryCounts[removed.category] -= 1;
+    value.expected.dispositionCounts[removed.disposition] -= 1;
+    write(skillsPath, `${JSON.stringify(value, null, 2)}\n`);
+    skillsPart.recordCount -= 1;
+    skillsPart.sha256 = execFileSync("shasum", ["-a", "256", skillsPath], { encoding: "utf8" }).split(" ")[0];
+    manifest.skillRecordCount -= 1;
+    manifest.categoryCounts[removed.category] -= 1;
+    manifest.dispositionCounts[removed.disposition] -= 1;
+    write(ledger, `${JSON.stringify(manifest, null, 2)}\n`);
+    expect(run(check, args()).status).not.toBe(0);
+  });
+
+  it("rejects root-manifest provenance drift", () => {
+    expect(run(generate, args(true)).status).toBe(0);
+    const manifest = JSON.parse(readFileSync(ledger, "utf8"));
+    manifest.upstream = { ...manifest.upstream, rootLicense: "UNVERIFIED" };
+    delete manifest.upstream.capturedAt;
+    delete manifest.upstream.rootLicenseEvidence;
+    write(ledger, `${JSON.stringify(manifest, null, 2)}\n`);
+    expect(run(check, args()).status).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Outcome

Pins the complete MengTo web-design source universe at commit 4c716b516b6b0143f3037631306b3730d2832344 and adds an offline, fail-closed provenance ledger.

## Evidence

- 926 tree records, 669 blobs, 373 scoped text artifacts, 88 skills
- category baseline: 37 core, 27 style, 15 vendor, 9 composite
- dispositions: 34 adopted, 41 covered-existing, 13 rejected
- 322 Neuform-derived demo records quarantined; binary/vendor payloads remain non-adoptable
- root MIT license pinned by Git OID, SHA-256, byte count, and capture timestamp
- semantic tampering, decision-count drift, provenance drift, and blob mismatch are rejected

## Verification

- npm run typecheck
- npm run lint
- npm run build
- npm test: 206 files, 3656 passed, 10 skipped
- focused source-ledger tests: 11 passed
- independent adversarial review: no blocking findings

Closes #213