### PR TITLE
feat: route web technique suggestions

### DIFF
--- a/eval/web-technique-routing-grader.mjs
+++ b/eval/web-technique-routing-grader.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const [promptsPath, decisionsPath] = process.argv.slice(2);
+if (!promptsPath || !decisionsPath) {
+  console.error("usage: node eval/web-technique-routing-grader.mjs <prompts.json> <decisions.json>");
+  process.exit(2);
+}
+
+let prompts; let catalog; let decisionRows;
+try {
+  prompts = JSON.parse(readFileSync(promptsPath, "utf8"));
+  catalog = JSON.parse(readFileSync(prompts.catalog, "utf8"));
+  decisionRows = JSON.parse(readFileSync(decisionsPath, "utf8"));
+} catch {
+  console.log(JSON.stringify({ summary: { covered: "0/0", passed: 0 }, misses: [{ id: "input", pass: false, problems: ["input-json-invalid"] }] }, null, 2));
+  process.exit(1);
+}
+const validRows = (rows) => Array.isArray(rows) && rows.every((row) => row && typeof row === "object" && typeof row.id === "string" && row.id.trim() !== "");
+const uniqueIds = (rows) => new Set(rows.map((row) => row.id)).size === rows.length;
+if (!prompts || typeof prompts.catalog !== "string" || !validRows(prompts.briefs) || !uniqueIds(prompts.briefs) || !catalog || !validRows(catalog.techniques) || !uniqueIds(catalog.techniques) || !validRows(decisionRows)) {
+  console.log(JSON.stringify({ summary: { covered: `0/${Array.isArray(prompts?.briefs) ? prompts.briefs.length : 0}`, passed: 0 }, misses: [{ id: "input", pass: false, problems: ["input-shape-invalid"] }] }, null, 2));
+  process.exit(1);
+}
+const decisions = new Map(decisionRows.map((row) => [row.id, row]));
+const decisionIdCounts = new Map();
+for (const row of decisionRows) decisionIdCounts.set(row.id, (decisionIdCounts.get(row.id) ?? 0) + 1);
+const knownIds = new Set(catalog.techniques.map((row) => row.id));
+const briefIds = new Set(prompts.briefs.map((row) => row.id));
+const idPattern = /\b[A-Z][A-Z0-9]*-\d{2}\b/g;
+
+function directionProblems(direction) {
+  if (!direction || typeof direction !== "object" || Array.isArray(direction)) return ["direction-shape-invalid"];
+  const { signatureTechnique } = direction;
+  if (typeof signatureTechnique !== "string" || signatureTechnique.trim() === "") return ["empty-signature-technique"];
+  const ids = signatureTechnique.match(idPattern) ?? [];
+  if (ids.length === 0) return [];
+  if (ids.length > 1) return ["multiple-catalog-ids"];
+  if (!knownIds.has(ids[0])) return ["unknown-catalog-id"];
+  return signatureTechnique.startsWith(`${ids[0]} — `) ? [] : ["catalog-format-invalid"];
+}
+
+const graded = [];
+for (const brief of prompts.briefs) {
+  const decision = decisions.get(brief.id);
+  if (decision === undefined) {
+    graded.push({ id: brief.id, pass: false, problems: ["decision-missing"] });
+    continue;
+  }
+  const problems = decisionIdCounts.get(brief.id) === 1 ? [] : ["decision-id-duplicate"];
+  if (decision.questionsAsked !== 0) problems.push("technique-question-asked");
+  const directionRows = Array.isArray(decision.directions) ? decision.directions : [];
+  if (directionRows.length !== 3) problems.push("direction-count-invalid");
+  const primaryIds = [];
+  for (const direction of directionRows) {
+    problems.push(...directionProblems(direction));
+    const signature = direction && typeof direction === "object" ? direction.signatureTechnique : null;
+    const ids = typeof signature === "string" ? signature.match(idPattern) ?? [] : [];
+    if (ids.length === 1 && knownIds.has(ids[0])) primaryIds.push(ids[0]);
+  }
+  if (new Set(primaryIds).size !== primaryIds.length) problems.push("primary-id-repeated");
+  graded.push({ id: brief.id, pass: problems.length === 0, problems });
+}
+for (const row of decisionRows) {
+  if (!briefIds.has(row.id)) graded.push({ id: row.id, pass: false, problems: ["unknown-brief-id"] });
+}
+
+const covered = prompts.briefs.filter((brief) => decisions.has(brief.id)).length;
+const output = { summary: { covered: `${covered}/${prompts.briefs.length}`, passed: graded.filter((row) => row.pass).length }, misses: graded.filter((row) => !row.pass) };
+console.log(JSON.stringify(output, null, 2));
+if (output.misses.length > 0) process.exitCode = 1;

--- a/eval/web-technique-routing-prompts.json
+++ b/eval/web-technique-routing-prompts.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "catalog": "knowledge/web-techniques/catalog.json",
+  "briefs": [
+    {"id":"brief-1","brief":"Show a technical operations product with spatial depth, readable proof, and a restrained fallback."},
+    {"id":"brief-2","brief":"Create a calm service-booking page where content and availability outrank visual novelty."},
+    {"id":"brief-3","brief":"Redesign an editorial portfolio while retaining its existing case-study information architecture."}
+  ]
+}

--- a/knowledge/generation-craft-defaults.md
+++ b/knowledge/generation-craft-defaults.md
@@ -152,6 +152,17 @@ headings, colors, icons, or images does not make a repeated composition distinct
 The page should read as one narrative family, not a collage. Distinct section architecture means
 different jobs expressed through related forms—not arbitrary novelty in every viewport.
 
+## Technique selection boundary
+
+When a prompt plan preserves exactly three directions, each direction may carry zero or one primary
+imported technique from `knowledge/web-techniques/catalog.json` formatted `<ID> — <brief-specific adaptation>`. A no-match direction may
+retain an original free-string technique; novelty alone does not establish fit. Do not ask a
+technique-preference question. After the direction is selected, open only the selected deep card
+for a catalog-derived value; an original free string opens no catalog card.
+Invoke a specialist only when its catalog handoff is registered and reachable for the workflow and
+the suitability, tier, and anti-use gates pass. An unavailable handoff means no handoff, never a
+replacement.
+
 ## Qualification evidence
 
 A craft-qualified delivery includes:

--- a/knowledge/prompt-plan-orchestration.md
+++ b/knowledge/prompt-plan-orchestration.md
@@ -50,6 +50,9 @@ prohibited claims, decision-changing unknowns, and content inventory before visu
 
 Each direction defines structural thesis, focal mechanism, region rhythm, signature technique,
 hero or workspace architecture, shape language, system fit, and execution/convergence risk.
+Preserve exactly three directions. For each direction, consider zero or one primary imported technique from
+`knowledge/web-techniques/catalog.json`, formatted `<ID> — <brief-specific adaptation>`; retain an arbitrary non-empty original
+`signatureTechnique` when no catalog row earns brief fit. Never ask a technique-preference question.
 
 ALLOWED: select the strongest direction while retaining the other two as inspectable alternatives.
 
@@ -131,7 +134,8 @@ Order the packet as:
 
 1. role and outcome;
 2. surface constraints and product truth;
-3. selected direction and visual DNA;
+3. selected direction and visual DNA; for a catalog-derived technique, include only its selected
+   card, while an original free string includes no catalog card;
 4. region production briefs;
 5. selected proportion plan;
 6. assets, content, behavior, motion, responsive, and states;

--- a/knowledge/web-technique-craft.md
+++ b/knowledge/web-technique-craft.md
@@ -8,7 +8,7 @@ when: [web-design, visual-direction, interaction-concept, landing-page, immersiv
 
 ## Purpose
 
-Turn a design brief into a small, explicit set of web craft techniques that strengthen the
+Turn a design brief into one explicit web craft technique per direction when it strengthens the
 idea without turning the page into an effects sampler.
 
 ## Mental Model
@@ -30,15 +30,17 @@ floors; a selected technique is subordinate to them.
 
 1. Read `knowledge/web-techniques/catalog.json`. Match the brief to each row's `when` signals
    and reject any row whose `requires` conditions are unavailable.
-2. Propose at most two techniques per direction. Name each as
-   `<ID> — <brief-specific adaptation>` so the choice is reviewable rather than implied.
+2. Preserve exactly three directions. For each, propose at most one primary imported technique per
+   direction, formatted `<ID> — <brief-specific adaptation>` so the choice is reviewable rather
+   than implied. Prefer an original free-string technique when no catalog row earns a fit; novelty
+   alone is never a fit.
 3. Make directions structurally different: rewording one ID does not create a new direction.
-   Prefer no technique when none changes hierarchy, comprehension, feedback, or narrative.
-4. Open only the family card declared by the selected row. Apply its anti-use, fallback,
+   Do not ask a technique-preference question; taste ambiguity earns variants, not interrogation.
+4. After direction choice, open only the selected family card declared by the chosen row. Apply its anti-use, fallback,
    responsive/input, lifecycle/performance, verification, and failure-mode clauses.
-5. If `handoffSkill` is non-null, suggest that registered specialist only for a listed
-   `applicableWorkflows` verb. A null handoff means implement from the card and existing owners;
-   never invent a replacement specialist.
+5. If `handoffSkill` is non-null, suggest that specialist only when it is registered and reachable
+   for the current workflow, and suitability, tier, and anti-use gates all pass. A null or
+   unavailable handoff means no handoff; never invent a replacement specialist.
 
 ## Direction proposal contract
 
@@ -50,9 +52,9 @@ For each proposed direction, tell the user:
 - the main performance or lifecycle cost;
 - the specialist handoff, when the catalog explicitly permits one.
 
-ALLOWED: a restrained surface mechanism plus one narrative or interaction mechanism when they
-solve different jobs. NOT ALLOWED: stacking techniques that compete for the same focal moment,
-because simultaneous signatures erase hierarchy and make graceful downgrade impossible.
+ALLOWED: zero or one primary imported technique per direction, with an original free-string
+technique when no catalog row earns the job. NOT ALLOWED: stacking techniques that compete for the
+same focal moment, because simultaneous signatures erase hierarchy and make graceful downgrade impossible.
 
 ## Quality boundary
 

--- a/templates/agents/designer.md
+++ b/templates/agents/designer.md
@@ -20,6 +20,15 @@ ambiguity costs ZERO questions — it costs variants the user picks from. Never
 guess an invocation — form commands from `ui schema --json`; check what is
 verifiable in THIS project with `ui gate coverage`.
 
+For generate-shaped work, read `knowledge/web-technique-craft.md` and
+`knowledge/web-techniques/catalog.json`. Preserve exactly three directions; each can carry zero or
+at most one primary imported technique formatted `<ID> — <brief-specific adaptation>`, or an
+original free-string technique when no row earns fit. Do not ask a technique-preference question.
+After direction choice, open only the selected card for a catalog-derived technique; an original
+free string opens no catalog card. Invoke a specialist only when the catalog
+handoff is registered and reachable for the workflow and suitability, tier, and anti-use gates pass;
+an unavailable handoff means no handoff, never a replacement.
+
 {{KNOWLEDGE_ANCHOR}}
 
 **Non-negotiables:**

--- a/templates/workflows/generate.md
+++ b/templates/workflows/generate.md
@@ -23,6 +23,7 @@ Read only the relevant parts of:
 - `knowledge/figma-craft/facet-model.md`;
 - `knowledge/user-evidence.md` when claims or research are present;
 - `knowledge/prompt-modes.md` when a visual reference is supplied.
+- `knowledge/web-technique-craft.md` and `knowledge/web-techniques/catalog.json` while compiling directions.
 
 Write `design-brief.json` matching `schemas/design-brief.schema.json`. Preserve the raw request,
 tag every assumption with provenance and confidence, declare prohibited claims, and produce
@@ -37,6 +38,12 @@ Do not proceed while the brief has errors.
 Compile `prompt-plan.json` matching `schemas/prompt-plan.schema.json`. Bind all facets and
 cross-cutting layers to evidence, preserve exactly three structurally divergent directions, give
 every major region a production brief, and define actionable visual-system DNA.
+
+For each of the exactly three directions, consider zero or at most one primary imported technique
+from the catalog. Format a selected row as `<ID> — <brief-specific adaptation>`; preserve an
+original free-string `signatureTechnique` when no row earns brief fit. Do not ask a
+technique-preference question—taste ambiguity earns variants. Do not open deep cards while comparing
+directions.
 
 Always create a content-led and a golden proportion candidate. Render and compare them under the
 same content, assets, visual DNA, regions, and viewports. Golden ratio is a candidate only; release
@@ -75,6 +82,10 @@ Soul and evidence outrank memory. Memory is a weak prior.
 
 Use the three preserved prompt-plan directions. Confirm the selected direction still has the best
 brief fit after proportion comparison. Do not recreate or silently collapse the alternatives.
+After direction choice, if the technique is catalog-derived, open only the selected card declared
+by its row; an original free string opens no catalog card. Invoke a specialist
+only when that row's handoff is registered and reachable for `generate`, and suitability, tier, and
+anti-use gates pass; an unavailable handoff means no handoff, never a substitute.
 
 Write a version 2 `generation-contract.json` matching
 `schemas/generation-contract.schema.json`, including:

--- a/templates/workflows/redesign.md
+++ b/templates/workflows/redesign.md
@@ -132,6 +132,18 @@ read the section for the chosen slug. Extract the full aesthetic DNA:
 
 The persona DNA is the **mandatory** style contract for the redesign.
 
+### 5.5 Consider one technique after the contra-persona is chosen
+
+Read `knowledge/web-technique-craft.md` and `knowledge/web-techniques/catalog.json`. Preserve the
+source IA and content above technique novelty. Consider exactly three structural directions; each
+may use zero or at most one primary imported catalog technique formatted
+`<ID> — <brief-specific adaptation>`, or an original free-string technique when no row earns fit.
+Do not ask a technique-preference question. After direction choice, open only the selected card for
+a catalog-derived technique; an original free string opens no catalog card.
+Invoke a specialist only when its catalog handoff is registered and reachable for `redesign` and
+suitability, tier, and anti-use gates pass. An unavailable handoff means no handoff, never a
+hallucinated replacement.
+
 ### 6. Generate the redesigned variant
 
 Combine three contracts and produce a single complete HTML artifact:

--- a/tests/adapters-skill-refs.test.ts
+++ b/tests/adapters-skill-refs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 import { SKILL_NAMES } from "../src/adapters/templates.js";
 import { VERB_SKILL_REFS } from "../src/adapters/skill-refs.js";
 
@@ -21,6 +22,17 @@ describe("workflow skill references", () => {
   it("does not route non-motion infrastructure workflows to gsap-motion", () => {
     for (const verb of ["init", "extract", "learn", "why", "evidence"] as const) {
       expect(VERB_SKILL_REFS[verb] ?? []).not.toContain("gsap-motion");
+    }
+  });
+
+  it("keeps every catalog handoff reachable only through its declared workflow", () => {
+    const catalog = JSON.parse(readFileSync(new URL("../knowledge/web-techniques/catalog.json", import.meta.url), "utf8")) as {
+      techniques: { id: string; handoffSkill: string | null; applicableWorkflows: string[] }[];
+    };
+    for (const technique of catalog.techniques.filter((row) => row.handoffSkill !== null)) {
+      for (const verb of technique.applicableWorkflows) {
+        expect(VERB_SKILL_REFS[verb], `${technique.id} declares unknown workflow '${verb}'`).toContain(technique.handoffSkill);
+      }
     }
   });
 });

--- a/tests/agents-gen.test.ts
+++ b/tests/agents-gen.test.ts
@@ -166,4 +166,13 @@ describe("templates/agents/ contract", () => {
     );
     expect(tpl, `${role}.md must forbid editing knowledge/`).toMatch(/NEVER edit `knowledge\/`/);
   });
+
+  it("designer routes catalog-backed techniques without a taste question or all-card loading", () => {
+    const tpl = readFileSync(join(REPO_ROOT, "templates", "agents", "designer.md"), "utf8");
+    expect(tpl).toContain("knowledge/web-technique-craft.md");
+    expect(tpl).toContain("knowledge/web-techniques/catalog.json");
+    expect(tpl).toContain("at most one primary");
+    expect(tpl).toContain("technique-preference question");
+    expect(tpl).toContain("only the selected");
+  });
 });

--- a/tests/prompt-plan-validation.test.ts
+++ b/tests/prompt-plan-validation.test.ts
@@ -13,6 +13,21 @@ describe("prompt-plan validation", () => {
     });
   }
 
+  it("keeps both legacy and catalog-formatted signature techniques compatible", () => {
+    const legacy = validPromptPlan();
+    ((legacy["directions"] as Array<Record<string, unknown>>)[0]!)["signatureTechnique"] = "a quiet archival sequence";
+    expect(validatePromptPlan(legacy).ready).toBe(true);
+    const catalog = validPromptPlan();
+    ((catalog["directions"] as Array<Record<string, unknown>>)[0]!)["signatureTechnique"] = "FX-01 — spatial grid behind operational proof";
+    expect(validatePromptPlan(catalog).ready).toBe(true);
+  });
+
+  it("still rejects an empty signature technique", () => {
+    const plan = validPromptPlan();
+    ((plan["directions"] as Array<Record<string, unknown>>)[0]!)["signatureTechnique"] = "";
+    expect(validatePromptPlan(plan).findings.map((finding) => finding.checkId)).toContain("incomplete-direction-set");
+  });
+
   const failures: Array<[string, string, (plan: Record<string, unknown>) => void]> = [
     ["missing facets", "missing-facet-binding", (plan) => {
       (plan["facetBindings"] as unknown[]).pop();

--- a/tests/web-technique-routing.test.ts
+++ b/tests/web-technique-routing.test.ts
@@ -1,0 +1,98 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+const grader = join(root, "eval", "web-technique-routing-grader.mjs");
+let temp = "";
+
+afterEach(() => { if (temp) rmSync(temp, { recursive: true, force: true }); temp = ""; });
+
+describe("web-technique routing contract", () => {
+  it("makes generate, redesign, and the designer consult one-primary catalog routing without a new question", () => {
+    for (const path of ["templates/workflows/generate.md", "templates/workflows/redesign.md", "templates/agents/designer.md"]) {
+      const content = read(path);
+      expect(content).toContain("knowledge/web-technique-craft.md");
+      expect(content).toContain("knowledge/web-techniques/catalog.json");
+      expect(content).toContain("at most one primary");
+      expect(content).toContain("technique-preference question");
+      expect(content).toContain("only the selected");
+    }
+  });
+
+  it("keeps the router to one imported ID per direction and freezes catalog-authorized handoff", () => {
+    const content = read("knowledge/web-technique-craft.md");
+    expect(content).toMatch(/at most one primary imported technique per\s+direction/);
+    expect(content).toContain("<ID> — <brief-specific adaptation>");
+    expect(content).toContain("registered and reachable");
+    expect(content).toContain("suitability, tier, and anti-use");
+  });
+
+  it("opens no catalog card for a compatible legacy free-string technique", () => {
+    for (const path of ["knowledge/generation-craft-defaults.md", "knowledge/prompt-plan-orchestration.md"]) {
+      expect(read(path)).toContain("free string");
+      expect(read(path)).toContain("no catalog card");
+    }
+  });
+
+  it("provides a bounded deterministic grader for valid, repeated, and overloaded direction IDs", () => {
+    expect(existsSync(grader)).toBe(true);
+    temp = mkdtempSync(join(tmpdir(), "web-technique-routing-"));
+    const decisions = join(temp, "decisions.json");
+    const valid = ["brief-1", "brief-2", "brief-3"].map((id, index) => ({ id, questionsAsked: 0, directions: [
+      { signatureTechnique: index === 0 ? "FX-01 — spatial grid for live operational proof" : "STR-04 — availability-led service path" },
+      { signatureTechnique: "MOT-02 — staged readable headline" },
+      { signatureTechnique: "original editorial fold" },
+    ] }));
+    const run = (prompts = "eval/web-technique-routing-prompts.json") => spawnSync(process.execPath, [grader, prompts, decisions], { cwd: root, encoding: "utf8" });
+    writeFileSync(decisions, JSON.stringify(valid));
+    expect(run().status).toBe(0);
+    writeFileSync(decisions, "[]");
+    const uncovered = run();
+    expect(uncovered.status).toBe(1);
+    expect(JSON.parse(uncovered.stdout).summary.covered).toBe("0/3");
+    expect(JSON.parse(uncovered.stdout).misses[0].problems).toContain("decision-missing");
+    writeFileSync(decisions, JSON.stringify([...valid, valid[0]]));
+    const duplicate = run();
+    expect(duplicate.status).toBe(1);
+    expect(JSON.parse(duplicate.stdout).misses[0].problems).toContain("decision-id-duplicate");
+    writeFileSync(decisions, JSON.stringify([...valid, { ...valid[0], id: "unknown-brief" }]));
+    const unknown = run();
+    expect(unknown.status).toBe(1);
+    expect(JSON.parse(unknown.stdout).summary.covered).toBe("3/3");
+    expect(JSON.parse(unknown.stdout).misses.at(-1).problems).toContain("unknown-brief-id");
+    writeFileSync(decisions, JSON.stringify({ directions: [] }));
+    const malformedRoot = run();
+    expect(malformedRoot.status).toBe(1);
+    expect(JSON.parse(malformedRoot.stdout).misses[0].problems).toContain("input-shape-invalid");
+    writeFileSync(decisions, JSON.stringify([{ ...valid[0], directions: { length: 3 } }]));
+    expect(run().status).toBe(1);
+    writeFileSync(decisions, JSON.stringify([{ ...valid[0], directions: [null, ...valid[0]!.directions.slice(1)] }]));
+    const nullDirection = run();
+    expect(nullDirection.status).toBe(1);
+    expect(JSON.parse(nullDirection.stdout).misses[0].problems).toContain("direction-shape-invalid");
+    const malformedPrompts = join(temp, "malformed-prompts.json");
+    writeFileSync(malformedPrompts, JSON.stringify({ catalog: "knowledge/web-techniques/catalog.json", briefs: [null] }));
+    expect(JSON.parse(run(malformedPrompts).stdout).misses[0].problems).toContain("input-shape-invalid");
+    writeFileSync(malformedPrompts, JSON.stringify({ catalog: "knowledge/web-techniques/catalog.json", briefs: [{ id: "brief-1" }, { id: "brief-1" }] }));
+    expect(JSON.parse(run(malformedPrompts).stdout).misses[0].problems).toContain("input-shape-invalid");
+    const malformedCatalog = join(temp, "malformed-catalog.json");
+    writeFileSync(malformedCatalog, JSON.stringify({ techniques: [null] }));
+    writeFileSync(malformedPrompts, JSON.stringify({ catalog: malformedCatalog, briefs: [{ id: "brief-1" }] }));
+    expect(JSON.parse(run(malformedPrompts).stdout).misses[0].problems).toContain("input-shape-invalid");
+    const baseline = valid[0]!;
+    writeFileSync(decisions, JSON.stringify([{ ...baseline, directions: [{ signatureTechnique: "FX-01 — first; MOT-02 — second" }, ...baseline.directions.slice(1)] }]));
+    const overloaded = run();
+    expect(overloaded.status).toBe(1);
+    expect(JSON.parse(overloaded.stdout).misses[0].problems).toContain("multiple-catalog-ids");
+    writeFileSync(decisions, JSON.stringify([{ ...baseline, directions: [{ signatureTechnique: "FX-01 — one" }, { signatureTechnique: "FX-01 — different suffix" }, baseline.directions[2]!] }]));
+    const repeated = run();
+    expect(repeated.status).toBe(1);
+    expect(JSON.parse(repeated.stdout).misses[0].problems).toContain("primary-id-repeated");
+  });
+});


### PR DESCRIPTION
## Summary
- route generate, redesign, and designer through the web-technique router and catalog
- preserve exactly three directions with zero or one primary catalog technique per direction
- load only the selected catalog card and invoke only registered, reachable specialist handoffs
- retain prompt-plan compatibility for legacy free-string techniques
- add a fail-closed multi-brief routing evaluator and adapter/template regression coverage

## Verification
- `npm test` (210 files, 3699 passed, 10 skipped)
- focused routing tests: 49 passed
- cross-runtime adapter tests: 75 passed
- typecheck, lint, build, knowledge check (0 findings)
- disposable Claude/Antigravity/Codex stale→refresh→doctor checks; artifact counts unchanged
- Claude agent stale→refresh→check; generated designer bytes changed
- independent adversarial review: no blockers

Closes #216