### PR TITLE
feat(activation): fail closed unsupported surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,8 @@ Then open your agent CLI in that project and type:
 /ui:generate a pricing page for a developer-tools SaaS — 3 tiers, dark theme
 ```
 
-That's the whole loop: **describe → compile → qualify.** Have an existing app? Run
+That's the whole loop: **describe → activate → compile → qualify.** Unsupported surfaces stop
+before compilation instead of silently falling back to HTML. Have an existing app? Run
 `/ui:learn` first so the DS is compiled from your product's own evidence.
 
 `ease-design` is DESIGN:OS's npm name — the package ships the `ui` kernel. `v0.3.0`
@@ -502,7 +503,11 @@ A better prompt improves the first draft. It does not prove the draft is ready.
 
 ```text
 raw request
-  → design-brief.json
+  → capability-activation request
+  → ui knowledge activate
+      ↳ unsupported surface → CAPABILITY_UNQUALIFIED (route: null)
+      ↳ qualified web marketing → capability-activation.json
+  → design-brief.json v2 (activationRef)
   → generation-contract.json
   → candidate + 1440/768/390 renders
   → qualification-record.json
@@ -513,6 +518,7 @@ The host model owns design reasoning. The zero-dependency `ui` kernel only valid
 contracts and rejects false-green verdicts:
 
 ```sh
+ui knowledge activate capability-request.json --json > capability-activation.json
 ui delivery validate design-brief.json
 ui delivery validate generation-contract.json
 ui delivery validate qualification-record.json
@@ -542,8 +548,10 @@ Qualified Delivery v2 adds an implementation-grade craft contract:
 - a named composition thesis, signature spatial move, and whitespace strategy.
 
 Version 1 artifacts remain valid historical records. Only version 2 proves the current craft
-contract. `ui delivery validate` resolves a v2 qualification record's `contractRef` relative to
-the record and rejects missing or contradictory evidence.
+contract. A v2 design brief binds `activationRef` to a qualified `web-marketing → generate → html`
+receipt; `ui delivery validate` recomputes its request and installed-catalog digests. The validator
+also resolves a v2 qualification record's `contractRef` relative to the record and rejects missing
+or contradictory evidence.
 
 The design prompt orchestrator compiles weak intent before generation: provenance-bound facets,
 product truth, three structurally divergent directions, complete region briefs, actionable visual
@@ -558,6 +566,8 @@ candidates, promoted knowledge, or rejected counterevidence. Promotion requires 
 approval or repeated winning evidence across at least three cases and two categories.
 
 The schemas are public contracts:
+[capability profiles](schemas/capability-profiles.schema.json) ·
+[capability activation](schemas/capability-activation.schema.json) ·
 [design brief](schemas/design-brief.schema.json) ·
 [prompt plan](schemas/prompt-plan.schema.json) ·
 [generation contract](schemas/generation-contract.schema.json) ·
@@ -700,25 +710,27 @@ never generates assets, calls a model, or accesses the network.
 
 ```mermaid
 flowchart TD
-    U["1 · User intent or reference"] --> B["2 · Preserve raw request<br/>compile design-brief.json"]
-    B --> PP["3 · Compile prompt-plan.json<br/>3 structural directions · region jobs · visual DNA"]
+    U["1 · User intent or reference"] --> CA{"2 · ui knowledge activate<br/>typed surface + visible evidence"}
+    CA -- unqualified --> STOP["Stop · CAPABILITY_UNQUALIFIED<br/>route: null"]
+    CA -- web-marketing qualified --> B["3 · Preserve activation receipt<br/>compile design-brief.json v2"]
+    B --> PP["4 · Compile prompt-plan.json<br/>3 structural directions · region jobs · visual DNA"]
     PP --> PF{"ui prompt-plan<br/>validate + preflight"}
     PF -- fail --> B
-    PF -- pass --> G["4 · Ground the project<br/>scan · DS context · soul · memory prior"]
-    G --> S["5 · Select direction<br/>content-led vs golden candidate"]
-    S --> C["6 · generation-contract.json v2<br/>sections · assets · states · viewports · motion"]
-    C --> A["7 · Resolve assets<br/>project → approved source → image generation → no image"]
-    A --> I["8 · Implement one candidate<br/>semantic responsive UI · Phosphor · GSAP only when justified"]
-    I --> SG{"9 · Six static gates"}
+    PF -- pass --> G["5 · Ground the project<br/>scan · DS context · soul · memory prior"]
+    G --> S["6 · Select direction<br/>content-led vs golden candidate"]
+    S --> C["7 · generation-contract.json v2<br/>sections · assets · states · viewports · motion"]
+    C --> A["8 · Resolve assets<br/>project → approved source → image generation → no image"]
+    A --> I["9 · Implement one candidate<br/>semantic responsive UI · Phosphor · GSAP only when justified"]
+    I --> SG{"10 · Six static gates"}
     SG -- fail --> R["Targeted repair<br/>worst evidence-backed finding only"]
-    SG -- pass --> RE["10 · Render evidence<br/>1440 · 768 · 390 · states · reduced motion · no-JS"]
-    RE --> Q["11 · Independent curator<br/>qualification-record.json"]
+    SG -- pass --> RE["11 · Render evidence<br/>1440 · 768 · 390 · states · reduced motion · no-JS"]
+    RE --> Q["12 · Independent curator<br/>qualification-record.json"]
     Q -- DRAFT_WITH_CONCERNS --> R
     R --> SG
     Q -- BLOCKED_BY_EVIDENCE --> ASK["Ask for missing product truth"]
-    Q -- QUALIFIED --> D["12 · Deliver with evidence<br/>then integrate through code-surface intake"]
+    Q -- QUALIFIED --> D["13 · Deliver with evidence<br/>then integrate through code-surface intake"]
     D --> EXP{"Quality-learning task?"}
-    EXP -- no --> RCPT["13 · Record evidence receipt"]
+    EXP -- no --> RCPT["14 · Record evidence receipt"]
     EXP -- yes --> AD["Art-direct qualified control<br/>section reference boards · max 3 ceiling revisions"]
     AD --> LR["Blinded comparison + learning-record.json"]
     LR --> PR{"Expert approval or<br/>3 wins across 2 categories?"}
@@ -969,19 +981,21 @@ instead of falling into the accepting branch.
 ## How the loop works, mechanically
 
 1. **You describe intent** → `/ui:generate landing page for a new gym`.
-2. **Intent compiles** — the raw request becomes a provenance-tagged brief and a validated
+2. **Capability activates first** — the host records the requested surface with visible evidence;
+   `ui knowledge activate` either emits a qualified receipt or stops with `route: null`.
+3. **Intent compiles only after qualification** — the raw request becomes a provenance-tagged brief and a validated
    prompt plan with three structural directions, explicit region jobs, and visual DNA.
-3. **The project grounds the decision** — current DS, soul, evidence, and memory context load;
+4. **The project grounds the decision** — current DS, soul, evidence, and memory context load;
    current product truth outranks recalled preference.
-4. **Direction and assets resolve before code** — content-led and golden candidates are compared;
+5. **Direction and assets resolve before code** — content-led and golden candidates are compared;
    icons, logos, imagery, states, responsive transformations, and motion receive explicit roles.
-5. **One candidate earns delivery** — six static gates run first; desktop/tablet/mobile and
+6. **One candidate earns delivery** — six static gates run first; desktop/tablet/mobile and
    behavioral renders feed an independent curator.
-6. **Repair stays bounded** — only the worst evidence-backed finding is repaired per round, for
+7. **Repair stays bounded** — only the worst evidence-backed finding is repaired per round, for
    at most three attempts, with affected gates and renders rerun.
-7. **Status stays honest** — only clean evidence emits `QUALIFIED`; unresolved work remains
+8. **Status stays honest** — only clean evidence emits `QUALIFIED`; unresolved work remains
    `DRAFT_WITH_CONCERNS` or `BLOCKED_BY_EVIDENCE`.
-8. **Learning needs causality** — evidence, application, artifact, and outcome form a receipt.
+9. **Learning needs causality** — evidence, application, artifact, and outcome form a receipt.
    Quality-learning tasks preserve controls, use blinded comparison, and promote a lesson only
    after expert approval or repeated wins across categories.
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -65,6 +65,7 @@ for a human reading top to bottom.
 | `page-structures.md` | **Shape before dress — the page-composition layer between persona and code.** The macrostructure catalog (21 named page shapes — pick one shape, not six loose axes), the diversification rule + the variety↔conformance switch (resist the default-attractor), honest-copy rules (no fabricated evidence), the six-axis pre-emit self-critique, and the nav/footer/hero "AI tells" (with pointers to the `taste-lint`/`layout-lint` checkIds that catch the machine-detectable ones). Read when shaping a standalone landing / marketing / docs surface or a custom `ds preview` chrome — NOT for a single component. |
 | `prompt-modes.md` | The replicate / enhance / adapt strategy modifiers for reference-driven generation. |
 | `need-routing.md` | The need→verb decision procedure — which design:os application for which stated need, the three sanctioned asks, the selection route |
+| `capability-profiles.json` | Typed surface capability authority — qualified workflow/artifact/knowledge/witness joins plus explicit unqualified refusals. Resolve it with `ui knowledge activate` before running a production workflow. |
 | `delivery-assets.md` | **Resolve reproduced images to originals, never screenshot crops** — the best→last-resort resolution ladder (inline-SVG logo → harvested site-served raster → sprite slice → screenshot-crop LAST RESORT, art-only), the machine floor (the deterministic `avoidable-screenshot-crop` lint in `ui validate-layout` + the host-model resolution workflow that fills `real/` and emits `ASSET-MAP.json` provenance), and the failure modes (crop-includes-text · screenshot-as-hero · missing-DPR · provenance-loss). Read when rebuilding / cloning / design-from-URL off a probed source with a mirror + asset harvest — NOT for a from-scratch generative design. |
 | `asset-production-orchestration.md` | **Generated raw material → curated website assets** — the provider-neutral request and provenance contract, locked-reference branching, hard-edge chroma vs soft-alpha dual-render vs segmentation/decomposition routing, immutable raw custody, sidecar curation, recomposition QA, atomic publish, and portable PNG + PSD delivery. Read when Codex, Gemini, or another runtime hand generates or edits raster assets for `design-os`. |
 | `ux-psychology.md` | UX laws (Hick's, Fitts', Miller's, …), Gestalt perception, cognitive biases, emotional design, trust building, cognitive-load management, ethical persuasion — with per-law application rules and a final audit checklist. Read selectively: only the law(s) a brief triggers. |
@@ -88,16 +89,17 @@ constraint-language rules, provenance grammar, and quarantine rules `ui knowledg
 enforces.
 
 **Generate a design from an intent**
-1. `prompt-plan-orchestration.md` — compile and validate product truth, directions, regions,
+1. `need-routing.md` + `ui knowledge activate` — classify the requested artifact with evidence and fail closed when the surface has no qualified route
+2. `prompt-plan-orchestration.md` — compile and validate product truth, directions, regions,
    visual DNA, and proportion candidates
-2. `persona-index.md` — auto-select personas from the intent
-3. `personas/<family>.md` — load the full DNA of each chosen persona
-4. `signature-devices.md` — when the persona reads on-brief but forgettable, compose one hero
+3. `persona-index.md` — auto-select personas from the intent
+4. `personas/<family>.md` — load the full DNA of each chosen persona
+5. `signature-devices.md` — when the persona reads on-brief but forgettable, compose one hero
    signature move (at most two) onto its DNA
-5. `web-technique-craft.md` — when the brief benefits from distinctive surface, motion,
+6. `web-technique-craft.md` — when the brief benefits from distinctive surface, motion,
    interaction, scroll, canvas, or 3D craft, propose the canonical technique choices and fallbacks
-6. `mode-constraints.md` — apply the UI mode's constraints + `TECHNICAL_RULES`
-7. `taste-rubric.md` — score the result; refine the failing axes
+7. `mode-constraints.md` — apply the UI mode's constraints + `TECHNICAL_RULES`
+8. `taste-rubric.md` — score the result; refine the failing axes
 
 **Establish / compile a design system**
 - `token-taxonomy.md` — token tiers and immutability rules

--- a/knowledge/capability-profiles.json
+++ b/knowledge/capability-profiles.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "profiles": [
+    {
+      "id": "web-marketing",
+      "status": "qualified",
+      "acceptedInputKinds": ["words", "visual-reference", "existing-artifact"],
+      "workflow": "generate",
+      "artifact": "html",
+      "requiredKnowledge": [
+        "need-routing",
+        "qualified-delivery",
+        "prompt-plan-orchestration",
+        "generation-craft-defaults"
+      ],
+      "machineWitnesses": [
+        "delivery validate",
+        "prompt-plan validate",
+        "prompt-plan preflight",
+        "gate",
+        "ds-usage-lint",
+        "ds a11y"
+      ],
+      "renderedWitnesses": ["1440px", "768px", "390px", "reduced-motion", "javascript-failure"],
+      "manualWitnesses": ["independent-curator", "owner-visible-acceptance"],
+      "qualificationEvidence": "knowledge/qualified-delivery.md",
+      "action": "Proceed with generate and preserve this activation receipt beside the design brief."
+    },
+    {
+      "id": "native-macos",
+      "status": "unqualified",
+      "acceptedInputKinds": ["words", "visual-reference", "existing-artifact"],
+      "workflow": null,
+      "artifact": "native-macos-application",
+      "refusalCode": "CAPABILITY_UNQUALIFIED",
+      "action": "Do not run generate. Offer web-marketing only as an explicit user-approved alternative.",
+      "advisoryKnowledge": ["content-design", "design-review", "verification-honesty"],
+      "qualificationRequirements": [
+        "SwiftUI and AppKit knowledge packet",
+        "build and test contract",
+        "native static and rendered witnesses",
+        "accessibility tree evidence",
+        "owner-visible acceptance from a second held-out pilot"
+      ]
+    }
+  ]
+}

--- a/knowledge/need-routing.md
+++ b/knowledge/need-routing.md
@@ -17,9 +17,10 @@ commands from `ui schema --json`, verify what is checkable here with `ui gate co
 
 ## Mental model
 
-Routing is a chain of ordered gates — first match wins. Meta needs route before artifact
-classes; artifact classes before input sources; input sources before the new-vs-existing
-fork. Two laws govern every leaf:
+Routing is a chain of ordered gates — first match wins. G0–G3 first separate meta work,
+specialized artifacts, Figma work, and capture inputs. Capability activation is the precondition
+for every G4 surface-production leg; it does not redefine the earlier routes. Two laws
+govern every leaf:
 
 1. **Verb ambiguity costs one question; taste ambiguity costs zero questions — it costs
    variants.** Unsure WHICH verb: ask exactly one question (the three sanctioned asks
@@ -31,7 +32,7 @@ fork. Two laws govern every leaf:
 
 ## The gates
 
-Walk them top-down, first match wins — but SPLIT composites before walking: a
+Walk them top-down, first match wins, and SPLIT composites before walking: a
 need that names BOTH a reference source (URL, image, repo) AND an artifact to
 produce or change routes to a sequence (Composition rule below), never a single
 leaf. The reference decides the capture leg (G3 verbs); the artifact decides the
@@ -41,6 +42,25 @@ artifact half of the sentence. Splitting a composite does NOT skip **ask #3**:
 when the reference arrives without a replicate-vs-inspired sentence ("make us
 one like this", "start from this one"), that one question comes BEFORE the
 capture leg is chosen — it decides the capture's fidelity mode.
+
+**G-1 — requested artifact surface activation.** The host identifies the artifact being requested,
+not every platform noun in the sentence, then writes a `capability-activation-request` with quoted
+`requested-artifact` evidence (or the documented page-output default). Run:
+
+```sh
+ui knowledge activate capability-activation-request.json --json
+```
+
+A non-zero result stops routing. `CAPABILITY_UNQUALIFIED` means the surface is known but has no
+qualified delivery route; preserve `route: null`, show `action`, and never substitute `generate`.
+An explicit artifact platform always beats the HTML default. For example, “native macOS app”
+activates `native-macos`; “landing page for a native macOS app” activates `web-marketing` because
+the requested artifact is the landing page and the app is subject context. The binary validates
+the typed selection and current capability; it does not perform semantic classification.
+Every G4 production leg runs G-1, whether the surface is new or already exists. For an existing
+qualified web surface, activation authorizes the surface and G4 still selects the edit verb; the
+catalog route remains the new-artifact entry route, not an override to regenerate it.
+Do not run G-1 for G0, G1, G2, or capture-only G3 routes; their existing verb contracts remain authoritative.
 
 **G0 — meta and ops (no new artifact).** "Why is X this way / what was decided" →
 `why`. "Log this interview / finding / transcript" → `evidence`. New project / setup →
@@ -75,8 +95,9 @@ reference arrived without a sentence saying replicate-vs-inspired → **ask #3**
 below, first. Then the leaves: a figma.com URL to turn into code → `figma`. A
 screenshot or image file → `from-ref`. A live URL → `from-url`. Words only → G4.
 
-**G4 — does a generated artifact already exist here?** No → `generate`. Yes: same
-direction plus a vibe-word nudge → `iterate`; same direction but a craft/quality problem
+**G4 — does a qualified generated artifact already exist here?** First require a qualified G-1
+result for the requested surface. No existing artifact → the activated route (`generate` only when
+G-1 returned `QUALIFIED` with `route: "generate"`). Existing artifact: same direction plus a vibe-word nudge → `iterate`; same direction but a craft/quality problem
 ("polish", failing axes) → `refine`; direction rejected outright → `redesign`; cannot
 tell which → **ask #2** ("keep this direction, or throw it away?").
 
@@ -94,8 +115,19 @@ table lists the common composites; other chains follow the same capture-then-
 produce shape.
 
 **Defaults — never ask about these.** Prompt mode → Replicate (`prompt-modes.md`).
-Output surface → HTML unless Figma is explicitly named. Persona → the pick-persona
+An unspecified page-shaped output → `web-marketing`; never apply that default when the explicit artifact platform
+is native or Figma. Persona → the pick-persona
 skill. Anything taste-shaped → the selection route, zero questions.
+
+## Surface activation table
+
+This table is the human-readable join to `knowledge/capability-profiles.json`; `ui knowledge check`
+keeps both directions in parity with the live workflow, knowledge and witness registries.
+
+| Surface | Status | Candidate route |
+|---|---|---|
+| `web-marketing` | qualified | `generate` |
+| `native-macos` | unqualified | none (`CAPABILITY_UNQUALIFIED`, `route: null`) |
 
 ## Route table
 
@@ -120,7 +152,7 @@ with the live verb registry — a new capability cannot ship until this table te
 | Triage or close Figma comments | `figma-comments` |
 | Convert a figma.com URL into code | `figma` |
 | Reproduce or draw from a screenshot / image | `from-ref` |
-| A new surface from words alone | `generate` |
+| A new marketing / landing HTML surface from words, after qualified activation | `generate` |
 | Nudge an existing artifact, same direction | `iterate` |
 | Fix craft/quality on an existing artifact, same direction | `refine` |
 | Replace the direction of an existing artifact | `redesign` |
@@ -131,6 +163,7 @@ with the live verb registry — a new capability cannot ship until this table te
 ## Cross-references
 
 - Per-verb trigger language: each `templates/workflows/<verb>.md` frontmatter (canonical).
+- Capability status, artifact, knowledge and witnesses: `capability-profiles.json`.
 - Fidelity modes (Replicate/Enhance/Adapt): `prompt-modes.md` — fidelity, not routing.
 - The four-surface audit question: `templates/journeys/daily.md` §1.
 - What is verifiable in this project right now: `ui gate coverage`.

--- a/schemas/capability-activation.schema.json
+++ b/schemas/capability-activation.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ease-design/schemas/capability-activation.schema.json",
+  "title": "ease-design capability activation request or receipt",
+  "oneOf": [
+    { "$ref": "#/definitions/request" },
+    { "$ref": "#/definitions/receipt" }
+  ],
+  "definitions": {
+    "request": {
+      "type": "object",
+      "required": ["kind", "version", "rawRequest", "requestedSurface", "inputKind", "selectionEvidence"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "capability-activation-request" },
+        "version": { "const": 1 },
+        "rawRequest": { "type": "string", "minLength": 1 },
+        "requestedSurface": { "type": "string", "minLength": 1 },
+        "inputKind": { "type": "string", "minLength": 1 },
+        "selectionEvidence": { "$ref": "#/definitions/selectionEvidence" }
+      },
+      "allOf": [{
+        "if": {
+          "properties": {
+            "selectionEvidence": {
+              "properties": { "kind": { "const": "documented-default" } },
+              "required": ["kind"]
+            }
+          }
+        },
+        "then": { "properties": { "requestedSurface": { "const": "web-marketing" } } }
+      }]
+    },
+    "receipt": {
+      "type": "object",
+      "required": ["kind", "version", "requestDigest", "catalogDigest", "requestedSurface", "inputKind", "selectionEvidence", "disposition", "route", "artifact", "selectedKnowledge", "machineWitnesses", "renderedWitnesses", "manualWitnesses", "action"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "capability-activation" },
+        "version": { "const": 1 },
+        "requestDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "catalogDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "requestedSurface": { "type": "string" },
+        "inputKind": { "type": "string" },
+        "selectionEvidence": { "$ref": "#/definitions/selectionEvidence" },
+        "disposition": { "enum": ["QUALIFIED", "UNQUALIFIED"] },
+        "route": { "type": ["string", "null"] },
+        "artifact": { "type": "string" },
+        "selectedKnowledge": { "type": "array", "items": { "type": "string" } },
+        "machineWitnesses": { "type": "array", "items": { "type": "string" } },
+        "renderedWitnesses": { "type": "array", "items": { "type": "string" } },
+        "manualWitnesses": { "type": "array", "items": { "type": "string" } },
+        "action": { "type": "string" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "selectionEvidence": {
+                "properties": { "kind": { "const": "documented-default" } },
+                "required": ["kind"]
+              }
+            }
+          },
+          "then": { "properties": { "requestedSurface": { "const": "web-marketing" } } }
+        },
+        {
+          "if": { "properties": { "disposition": { "const": "UNQUALIFIED" } } },
+          "then": { "properties": { "route": { "const": null } } }
+        },
+        {
+          "if": { "properties": { "disposition": { "const": "QUALIFIED" } } },
+          "then": { "properties": { "route": { "type": "string", "minLength": 1 } } }
+        }
+      ]
+    },
+    "selectionEvidence": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "quote", "role"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "quoted-request" },
+            "quote": { "type": "string", "minLength": 1 },
+            "role": { "const": "requested-artifact" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "rule"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "documented-default" },
+            "rule": { "const": "unspecified-page-output-defaults-to-web-marketing" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/capability-profiles.schema.json
+++ b/schemas/capability-profiles.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ease-design/schemas/capability-profiles.schema.json",
+  "title": "ease-design capability profiles",
+  "type": "object",
+  "required": ["version", "profiles"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": 1 },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "status", "acceptedInputKinds", "workflow", "artifact"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "status": { "enum": ["qualified", "unqualified"] },
+          "acceptedInputKinds": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+          "workflow": { "type": ["string", "null"] },
+          "artifact": { "type": "string", "minLength": 1 },
+          "requiredKnowledge": { "$ref": "#/definitions/stringList" },
+          "machineWitnesses": { "$ref": "#/definitions/stringList" },
+          "renderedWitnesses": { "$ref": "#/definitions/stringList" },
+          "manualWitnesses": { "$ref": "#/definitions/stringList" },
+          "qualificationEvidence": { "type": "string", "minLength": 1 },
+          "refusalCode": { "type": "string", "minLength": 1 },
+          "action": { "type": "string", "minLength": 1 },
+          "advisoryKnowledge": { "$ref": "#/definitions/stringList" },
+          "qualificationRequirements": { "$ref": "#/definitions/stringList" }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "status": { "const": "qualified" } } },
+            "then": {
+              "required": ["requiredKnowledge", "machineWitnesses", "renderedWitnesses", "manualWitnesses", "qualificationEvidence"],
+              "properties": { "workflow": { "type": "string", "minLength": 1 } }
+            }
+          },
+          {
+            "if": { "properties": { "status": { "const": "unqualified" } } },
+            "then": {
+              "required": ["refusalCode", "action", "qualificationRequirements"],
+              "properties": {
+                "workflow": { "const": null },
+                "refusalCode": { "const": "CAPABILITY_UNQUALIFIED" }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "stringList": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+  }
+}

--- a/schemas/design-brief.schema.json
+++ b/schemas/design-brief.schema.json
@@ -7,9 +7,10 @@
   "additionalProperties": false,
   "properties": {
     "kind": { "const": "design-brief" },
-    "version": { "const": 1 },
+    "version": { "enum": [1, 2] },
     "rawRequest": { "type": "string", "minLength": 1 },
     "surface": { "enum": ["marketing-landing"] },
+    "activationRef": { "type": "string", "minLength": 1 },
     "audience": { "type": "string", "minLength": 1 },
     "context": { "type": "string", "minLength": 1 },
     "primaryOutcome": { "type": "string", "minLength": 1 },
@@ -41,5 +42,11 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "version": { "const": 2 } } },
+      "then": { "required": ["activationRef"] }
+    }
+  ]
 }

--- a/src/commands/delivery.ts
+++ b/src/commands/delivery.ts
@@ -1,8 +1,12 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { dirname, isAbsolute, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ParsedArgs } from "../core/cli-args.js";
 import { DeliveryError, validateDelivery } from "../core/delivery-model.js";
 import type { DeliveryValidationContext } from "../core/delivery-model.js";
+import { digestText, parseCapabilityCatalog } from "../core/capability-activation.js";
+import type { CapabilityCatalog } from "../core/capability-activation.js";
+import { resolvePackageRoots } from "../core/init-stub.js";
 import { errJson, errText, okJsonWithExit } from "../core/output.js";
 import type { CommandResult } from "../core/output.js";
 
@@ -13,7 +17,7 @@ Usage:
   ui delivery validate <file.json> [--json]
 
 Kinds:
-  design-brief          Provenance-tagged intent and evaluable criteria
+  design-brief          Provenance-tagged intent and evaluable criteria; v2 binds capability activation
   generation-contract  v1 direction/evidence; v2 adds implementation craft defaults
   qualification-record v1 historical verdict; v2 validates referenced craft evidence
   learning-record      Four-way trials and anti-overfitting lesson promotion
@@ -51,7 +55,7 @@ function validate(parsed: ParsedArgs): CommandResult {
   }
   try {
     const json = JSON.parse(raw) as unknown;
-    const context = qualificationContext(json, file);
+    const context = deliveryContext(json, file);
     const result = validateDelivery(json, context);
     const exitCode = result.errorCount > 0 ? 1 : 0;
     if (parsed.json) return okJsonWithExit(sub, { file, ...result }, exitCode);
@@ -67,25 +71,61 @@ function validate(parsed: ParsedArgs): CommandResult {
   }
 }
 
-function qualificationContext(json: unknown, file: string): DeliveryValidationContext {
-  if (json === null || typeof json !== "object" || Array.isArray(json)) return {};
-  const record = json as Record<string, unknown>;
-  if (record["kind"] !== "qualification-record" || record["version"] !== 2 ||
-      typeof record["contractRef"] !== "string" || record["contractRef"].length === 0) return {};
+function deliveryContext(json: unknown, file: string): DeliveryValidationContext {
+  if (!isRecord(json)) return {};
+  const context: DeliveryValidationContext = {};
+
+  if (json["kind"] === "qualification-record" && json["version"] === 2 &&
+      typeof json["contractRef"] === "string" && json["contractRef"].length > 0) {
+    const contract = readSiblingJson(file, json["contractRef"]);
+    if (contract !== null) context.contract = contract;
+  }
+
+  if (json["kind"] === "design-brief" && json["version"] === 2 &&
+      typeof json["activationRef"] === "string" && json["activationRef"].length > 0) {
+    const activation = readSiblingJson(file, json["activationRef"]);
+    if (activation !== null) context.activation = activation;
+    const installed = installedCatalog();
+    if (installed !== undefined) {
+      context.capabilityCatalog = installed.catalog;
+      context.catalogDigest = installed.digest;
+    }
+  }
+
+  return context;
+}
+
+function installedCatalog(): { catalog: CapabilityCatalog; digest: string } | undefined {
   try {
-    if (isAbsolute(record["contractRef"])) return {};
-    const recordDirectory = realpathSync(resolve(dirname(file)));
-    const contractPath = resolve(recordDirectory, record["contractRef"]);
-    if (!contractPath.startsWith(`${recordDirectory}${sep}`)) return {};
-    const realContractPath = realpathSync(contractPath);
-    if (!realContractPath.startsWith(`${recordDirectory}${sep}`)) return {};
-    const contract = JSON.parse(readFileSync(realContractPath, "utf8")) as unknown;
-    return contract !== null && typeof contract === "object" && !Array.isArray(contract)
-      ? { contract: contract as Record<string, unknown> } : {};
+    const { knowledgeRoot } = resolvePackageRoots(dirname(fileURLToPath(import.meta.url)));
+    if (knowledgeRoot === null) return undefined;
+    const raw = readFileSync(resolve(knowledgeRoot, "capability-profiles.json"), "utf8");
+    const parsed = parseCapabilityCatalog(raw);
+    return parsed.ok ? { catalog: parsed.catalog, digest: digestText(raw) } : undefined;
   } catch {
-    return {};
+    return undefined;
   }
 }
+
+function readSiblingJson(file: string, ref: string): Record<string, unknown> | null {
+  try {
+    if (isAbsolute(ref)) return null;
+    const recordDirectory = dirname(realpathSync(file));
+    const candidatePath = resolve(recordDirectory, ref);
+    if (!candidatePath.startsWith(`${recordDirectory}${sep}`)) return null;
+    const realPath = realpathSync(candidatePath);
+    if (!realPath.startsWith(`${recordDirectory}${sep}`)) return null;
+    const value = JSON.parse(readFileSync(realPath, "utf8")) as unknown;
+    return isRecord(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 export const deliveryCommand = {
   name: CMD, summary: "Validate Qualified Delivery contracts and verdicts",
   hasSubcommands: true, help: DELIVERY_HELP,

--- a/src/commands/knowledge-activate.ts
+++ b/src/commands/knowledge-activate.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ParsedArgs } from "../core/cli-args.js";
+import { digestText, parseCapabilityCatalog, resolveCapabilityActivation } from "../core/capability-activation.js";
+import { resolvePackageRoots } from "../core/init-stub.js";
+import { errJson, errJsonWithData, errText, okJson } from "../core/output.js";
+import type { CommandResult } from "../core/output.js";
+
+const SUB = "knowledge activate";
+
+export function runKnowledgeActivate(parsed: ParsedArgs): CommandResult {
+  const fail = (code: string, message: string, data?: unknown): CommandResult => {
+    if (parsed.json) return data === undefined ? errJson(SUB, code, message) : errJsonWithData(SUB, code, message, data);
+    return errText(`ui: ${message}\n`);
+  };
+  const requestPath = parsed.positionals[0];
+  if (requestPath === undefined) return fail("BAD_ARG", "ui knowledge activate requires <request.json>");
+  const dirFlag = parsed.flags["dir"];
+  if (dirFlag === true) return fail("BAD_ARG", "--dir requires a repo root");
+  const knowledgeRoot = typeof dirFlag === "string"
+    ? join(resolve(dirFlag), "knowledge")
+    : resolvePackageRoots(dirname(fileURLToPath(import.meta.url))).knowledgeRoot;
+  if (knowledgeRoot === null) return fail("NO_CATALOG", "cannot locate the packaged knowledge core");
+
+  let requestRaw: string; let catalogRaw: string;
+  try { requestRaw = readFileSync(resolve(requestPath), "utf8"); }
+  catch { return fail("FILE_NOT_FOUND", `cannot read activation request '${requestPath}'`); }
+  try { catalogRaw = readFileSync(join(knowledgeRoot, "capability-profiles.json"), "utf8"); }
+  catch { return fail("NO_CATALOG", `cannot read '${join(knowledgeRoot, "capability-profiles.json")}'`); }
+
+  let request: unknown;
+  try { request = JSON.parse(requestRaw); }
+  catch { return fail("BAD_ACTIVATION", "activation request is not valid JSON"); }
+  const catalog = parseCapabilityCatalog(catalogRaw);
+  if (!catalog.ok) return fail("BAD_CATALOG", catalog.message);
+  const result = resolveCapabilityActivation(request, catalog.catalog, digestText(catalogRaw));
+  if (!result.ok) {
+    const data = result.receipt ?? result.data;
+    return fail(result.code, result.message, data);
+  }
+  if (parsed.json) return okJson(SUB, result.receipt);
+  return { exitCode: 0, stdout: `knowledge activate: ${result.receipt.requestedSurface} -> ${result.receipt.route}\n` };
+}

--- a/src/commands/knowledge-check.ts
+++ b/src/commands/knowledge-check.ts
@@ -44,6 +44,7 @@ export function runKnowledgeCheck(parsed: ParsedArgs): CommandResult {
     sourceLedgerJson,
     sourceLedgerParts: { "sources/mengto-web-techniques--202608/tree.json": sourceTree ?? "", "sources/mengto-web-techniques--202608/skills.json": sourceSkills ?? "" },
     webTechniqueCatalogJson,
+    capabilityCatalogJson: read("capability-profiles.json"),
   });
   const errorCount = findings.filter((finding) => finding.severity === "error").length; const warningCount = findings.length - errorCount;
   if (useJson) return okJsonWithExit(sub, { dir: knowledgeDir, asOf, findings, errorCount, warningCount }, errorCount > 0 ? 1 : 0);

--- a/src/commands/knowledge.ts
+++ b/src/commands/knowledge.ts
@@ -17,6 +17,7 @@ import { topLevelMarkdown } from "../core/knowledge-frontmatter-check.js";
 import { runEffectMatrix } from "./knowledge-effect-matrix.js";
 import { runGradientMatrix } from "./knowledge-gradient-matrix.js";
 import { runKnowledgeCheck, walkKnowledge } from "./knowledge-check.js";
+import { runKnowledgeActivate } from "./knowledge-activate.js";
 
 const CMD = "knowledge";
 
@@ -24,11 +25,13 @@ export const KNOWLEDGE_HELP = `ui knowledge — governance checks over the knowl
 
 Usage:
   ui knowledge check [--dir <repo-root>] [--as-of <YYYYMM>] [--json]
+  ui knowledge activate <request.json> [--dir <repo-root>] [--json]
   ui knowledge effect-matrix [--dir <repo-root>] [--json]
   ui knowledge gradient-matrix [--dir <repo-root>] [--json]
   ui knowledge index [--dir <repo-root>] [--emit]
 
 Subcommands:
+  activate       Resolve a typed requested surface against qualified capabilities; fail closed when unsupported
   check          Findings-linter over knowledge/; exit 1 on error-severity findings
   index          Emit the routing index (id / description / when) over knowledge/*.md.
                  Without --emit it prints to stdout; with --emit it writes
@@ -87,6 +90,10 @@ Error codes (check):
   READ_ERROR    A knowledge file could not be read
   WRITE_ERROR   knowledge/index.json could not be written (--emit)
 
+Error codes (activate):
+  BAD_ARG | UNKNOWN_FLAG | FILE_NOT_FOUND | BAD_ACTIVATION | NO_CATALOG | BAD_CATALOG
+  UNKNOWN_CAPABILITY | UNSUPPORTED_INPUT | CAPABILITY_UNQUALIFIED
+
 Error codes (effect-matrix / gradient-matrix):
   BAD_ARG       Missing/unknown subcommand
   UNKNOWN_FLAG  Unrecognised --flag (rejected, with a did-you-mean hint)
@@ -138,12 +145,13 @@ export const knowledgeCommand = {
   help: KNOWLEDGE_HELP,
   run(parsed: ParsedArgs): CommandResult {
     switch (parsed.subcommand) {
+      case "activate": return runKnowledgeActivate(parsed);
       case "check": return runKnowledgeCheck(parsed);
       case "effect-matrix": return runEffectMatrix(parsed);
       case "gradient-matrix": return runGradientMatrix(parsed);
       case "index": return runIndex(parsed);
       case undefined: {
-        const msg = "ui knowledge requires a subcommand (check, effect-matrix, gradient-matrix, index). Run 'ui knowledge --help'.";
+        const msg = "ui knowledge requires a subcommand (activate, check, effect-matrix, gradient-matrix, index). Run 'ui knowledge --help'.";
         return parsed.json ? errJson(CMD, "BAD_ARG", msg) : errText(`ui: ${msg}\n`);
       }
       default: {

--- a/src/core/capability-activation.ts
+++ b/src/core/capability-activation.ts
@@ -1,0 +1,179 @@
+import { createHash } from "node:crypto";
+
+export type CapabilityStatus = "qualified" | "unqualified";
+
+export interface CapabilityProfile {
+  id: string;
+  status: CapabilityStatus;
+  acceptedInputKinds: string[];
+  workflow: string | null;
+  artifact: string;
+  requiredKnowledge?: string[];
+  machineWitnesses?: string[];
+  renderedWitnesses?: string[];
+  manualWitnesses?: string[];
+  qualificationEvidence?: string;
+  refusalCode?: string;
+  action?: string;
+  advisoryKnowledge?: string[];
+  qualificationRequirements?: string[];
+}
+
+export interface CapabilityCatalog { version: 1; profiles: CapabilityProfile[] }
+
+export interface ActivationReceipt {
+  kind: "capability-activation";
+  version: 1;
+  requestDigest: string;
+  catalogDigest: string;
+  requestedSurface: string;
+  inputKind: string;
+  selectionEvidence: Record<string, unknown>;
+  disposition: "QUALIFIED" | "UNQUALIFIED";
+  route: string | null;
+  artifact: string;
+  selectedKnowledge: string[];
+  machineWitnesses: string[];
+  renderedWitnesses: string[];
+  manualWitnesses: string[];
+  action: string;
+}
+
+export type CatalogParseResult =
+  | { ok: true; catalog: CapabilityCatalog }
+  | { ok: false; message: string };
+
+export type ActivationResult =
+  | { ok: true; receipt: ActivationReceipt }
+  | { ok: false; code: string; message: string; receipt?: ActivationReceipt; data?: unknown };
+
+const objectValue = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+const nonEmpty = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+const stringList = (value: unknown): string[] | null =>
+  Array.isArray(value) && value.length > 0 && value.every(nonEmpty) ? value as string[] : null;
+const hasOnlyKeys = (value: Record<string, unknown>, allowed: readonly string[]): boolean =>
+  Object.keys(value).every((key) => allowed.includes(key));
+const PROFILE_KEYS = [
+  "id", "status", "acceptedInputKinds", "workflow", "artifact", "requiredKnowledge",
+  "machineWitnesses", "renderedWitnesses", "manualWitnesses", "qualificationEvidence",
+  "refusalCode", "action", "advisoryKnowledge", "qualificationRequirements",
+] as const;
+
+export function digestText(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function parseCapabilityCatalog(raw: string): CatalogParseResult {
+  let value: unknown;
+  try { value = JSON.parse(raw); }
+  catch { return { ok: false, message: "capability catalog is not valid JSON" }; }
+  if (!objectValue(value) || !hasOnlyKeys(value, ["version", "profiles"]) || value["version"] !== 1 ||
+      !Array.isArray(value["profiles"]) || value["profiles"].length === 0) {
+    return { ok: false, message: "capability catalog requires version 1 and profiles[]" };
+  }
+  const profiles: CapabilityProfile[] = [];
+  for (const item of value["profiles"]) {
+    if (!objectValue(item) || !hasOnlyKeys(item, PROFILE_KEYS) || !nonEmpty(item["id"]) ||
+        !["qualified", "unqualified"].includes(String(item["status"])) ||
+        stringList(item["acceptedInputKinds"]) === null ||
+        !nonEmpty(item["artifact"]) ||
+        !(item["workflow"] === null || nonEmpty(item["workflow"]))) {
+      return { ok: false, message: "every capability profile needs id, status, acceptedInputKinds, workflow and artifact" };
+    }
+    const optionalLists = ["requiredKnowledge", "machineWitnesses", "renderedWitnesses", "manualWitnesses",
+      "advisoryKnowledge", "qualificationRequirements"] as const;
+    if (optionalLists.some((key) => item[key] !== undefined && stringList(item[key]) === null)) {
+      return { ok: false, message: `capability profile '${item["id"]}' contains an invalid string list` };
+    }
+    if (item["status"] === "qualified" &&
+        (stringList(item["requiredKnowledge"]) === null || stringList(item["machineWitnesses"]) === null ||
+         stringList(item["renderedWitnesses"]) === null || stringList(item["manualWitnesses"]) === null ||
+         !nonEmpty(item["qualificationEvidence"]))) {
+      return { ok: false, message: `qualified capability '${item["id"]}' is incomplete` };
+    }
+    if (item["status"] === "unqualified" &&
+        (item["workflow"] !== null || item["refusalCode"] !== "CAPABILITY_UNQUALIFIED" ||
+         !nonEmpty(item["action"]) || stringList(item["qualificationRequirements"]) === null)) {
+      return { ok: false, message: `unqualified capability '${item["id"]}' is incomplete` };
+    }
+    profiles.push(item as unknown as CapabilityProfile);
+  }
+  return { ok: true, catalog: { version: 1, profiles } };
+}
+
+export function resolveCapabilityActivation(
+  value: unknown,
+  catalog: CapabilityCatalog,
+  catalogDigest: string,
+): ActivationResult {
+  if (!objectValue(value) || !hasOnlyKeys(value, ["kind", "version", "rawRequest", "requestedSurface", "inputKind", "selectionEvidence"]) ||
+      value["kind"] !== "capability-activation-request" ||
+      value["version"] !== 1 || !nonEmpty(value["rawRequest"]) ||
+      !nonEmpty(value["requestedSurface"]) || !nonEmpty(value["inputKind"]) ||
+      !objectValue(value["selectionEvidence"])) {
+    return bad("BAD_ACTIVATION", "activation request has an invalid kind, version, request, surface, input kind or selection evidence");
+  }
+  const evidence = value["selectionEvidence"];
+  if (evidence["kind"] === "quoted-request") {
+    if (!hasOnlyKeys(evidence, ["kind", "quote", "role"]) || !nonEmpty(evidence["quote"]) || evidence["role"] !== "requested-artifact" ||
+        !value["rawRequest"].includes(evidence["quote"])) {
+      return bad("BAD_ACTIVATION", "quoted selection evidence must be a requested-artifact substring of rawRequest");
+    }
+  } else if (evidence["kind"] === "documented-default") {
+    if (!hasOnlyKeys(evidence, ["kind", "rule"]) || evidence["rule"] !== "unspecified-page-output-defaults-to-web-marketing" ||
+        value["requestedSurface"] !== "web-marketing") {
+      return bad("BAD_ACTIVATION", "documented page default is valid only for web-marketing");
+    }
+  } else return bad("BAD_ACTIVATION", "selectionEvidence.kind must be quoted-request or documented-default");
+
+  const profile = catalog.profiles.find((candidate) => candidate.id === value["requestedSurface"]);
+  if (profile === undefined) {
+    return { ok: false, code: "UNKNOWN_CAPABILITY", message: `unknown capability '${value["requestedSurface"]}'`,
+      data: { supportedProfiles: catalog.profiles.map((item) => item.id).sort() } };
+  }
+  if (!profile.acceptedInputKinds.includes(value["inputKind"])) {
+    return bad("UNSUPPORTED_INPUT", `${profile.id} does not accept input kind '${value["inputKind"]}'`);
+  }
+  if (profile.status === "qualified" && (!nonEmpty(profile.workflow) ||
+      stringList(profile.requiredKnowledge) === null || stringList(profile.machineWitnesses) === null ||
+      stringList(profile.renderedWitnesses) === null || stringList(profile.manualWitnesses) === null)) {
+    return bad("BAD_CATALOG", `qualified capability '${profile.id}' is incomplete`);
+  }
+  if (profile.status === "unqualified" && profile.workflow !== null) {
+    return bad("BAD_CATALOG", `unqualified capability '${profile.id}' must have workflow:null`);
+  }
+  const receipt = buildReceipt(value, evidence, profile, catalogDigest);
+  if (profile.status === "unqualified") {
+    return { ok: false, code: profile.refusalCode ?? "CAPABILITY_UNQUALIFIED",
+      message: `${profile.id} has no qualified DESIGN:OS delivery profile`, receipt };
+  }
+  return { ok: true, receipt };
+}
+
+function buildReceipt(
+  request: Record<string, unknown>,
+  evidence: Record<string, unknown>,
+  profile: CapabilityProfile,
+  catalogDigest: string,
+): ActivationReceipt {
+  const qualified = profile.status === "qualified";
+  return {
+    kind: "capability-activation", version: 1,
+    requestDigest: digestText(String(request["rawRequest"])), catalogDigest,
+    requestedSurface: profile.id, inputKind: String(request["inputKind"]),
+    selectionEvidence: evidence,
+    disposition: qualified ? "QUALIFIED" : "UNQUALIFIED",
+    route: qualified ? profile.workflow : null, artifact: profile.artifact,
+    selectedKnowledge: qualified ? profile.requiredKnowledge ?? [] : profile.advisoryKnowledge ?? [],
+    machineWitnesses: profile.machineWitnesses ?? [],
+    renderedWitnesses: profile.renderedWitnesses ?? [],
+    manualWitnesses: profile.manualWitnesses ?? [],
+    action: profile.action ?? (qualified ? `Proceed with ${profile.workflow}.` : "Stop."),
+  };
+}
+
+function bad(code: string, message: string): ActivationResult {
+  return { ok: false, code, message };
+}

--- a/src/core/command-signatures.ts
+++ b/src/core/command-signatures.ts
@@ -961,6 +961,14 @@ export const COMMAND_SIGNATURES: Readonly<Record<string, CommandSchema>> = {
   knowledge: {
     summary: "Governance checks over the knowledge core (index / persona / xref / provenance / catalog and source-ledger drift) + the routing index emitter",
     subcommands: {
+      activate: {
+        summary: "Resolve a typed requested artifact surface against the packaged capability catalog",
+        positionals: [{ name: "<request.json>", required: true, summary: "Capability activation request" }],
+        flags: [
+          { name: "dir", type: "string", summary: "Repo root holding knowledge/capability-profiles.json (default: packaged knowledge)" },
+        ],
+        errorCodes: ["BAD_ARG", "UNKNOWN_FLAG", "FILE_NOT_FOUND", "BAD_ACTIVATION", "NO_CATALOG", "BAD_CATALOG", "UNKNOWN_CAPABILITY", "UNSUPPORTED_INPUT", "CAPABILITY_UNQUALIFIED"],
+      },
       check: {
         summary: "Findings-linter over knowledge/; exit 1 on error-severity findings, including catalog/card and pinned source-ledger integrity drift",
         positionals: [],

--- a/src/core/delivery/delivery-types.ts
+++ b/src/core/delivery/delivery-types.ts
@@ -19,7 +19,11 @@ export interface DeliveryResult {
 }
 export interface DeliveryValidationContext {
   contract?: Record<string, unknown>;
+  activation?: Record<string, unknown>;
+  capabilityCatalog?: CapabilityCatalog;
+  catalogDigest?: string;
 }
 export class DeliveryError extends Error {
   constructor(readonly code: "BAD_DELIVERY", message: string) { super(message); }
 }
+import type { CapabilityCatalog } from "../capability-activation.js";

--- a/src/core/delivery/delivery-v1-validation.ts
+++ b/src/core/delivery/delivery-v1-validation.ts
@@ -7,6 +7,10 @@ import {
 
 export function validateBriefV1(j: Record<string, unknown>): DeliveryFinding[] {
   requireBase(j, "design-brief", 1);
+  return validateBriefBase(j);
+}
+
+export function validateBriefBase(j: Record<string, unknown>): DeliveryFinding[] {
   const required = ["rawRequest", "audience", "context", "primaryOutcome", "primaryAction"] as const;
   const out = required.filter((k) => !str(j[k]))
     .map((k) => finding("missing-field", `${k} must be a non-empty string`));

--- a/src/core/delivery/delivery-v2-brief-validation.ts
+++ b/src/core/delivery/delivery-v2-brief-validation.ts
@@ -1,0 +1,53 @@
+import { isDeepStrictEqual } from "node:util";
+import { digestText, resolveCapabilityActivation } from "../capability-activation.js";
+import type { DeliveryFinding, DeliveryValidationContext } from "./delivery-types.js";
+import { finding, nonEmptyString as str, objectValue as obj, requireBase } from "./delivery-shared-validation.js";
+import { validateBriefBase } from "./delivery-v1-validation.js";
+
+export function validateBriefV2(
+  brief: Record<string, unknown>,
+  context: DeliveryValidationContext,
+): DeliveryFinding[] {
+  requireBase(brief, "design-brief", 2);
+  const out = validateBriefBase(brief);
+  if (!str(brief["activationRef"])) {
+    out.push(finding("missing-activation-ref", "design-brief v2 requires activationRef"));
+    return out;
+  }
+  const envelope = context.activation;
+  if (!obj(envelope) || envelope["ok"] !== true || envelope["command"] !== "knowledge activate" || !obj(envelope["data"])) {
+    out.push(finding("activation-unreadable", "activationRef must resolve to a successful knowledge activate envelope"));
+    return out;
+  }
+  const receipt = envelope["data"];
+  if (receipt["kind"] !== "capability-activation" || receipt["version"] !== 1 || receipt["disposition"] !== "QUALIFIED") {
+    out.push(finding("activation-unqualified", "design-brief v2 requires a qualified activation receipt"));
+  }
+  if (receipt["requestedSurface"] !== "web-marketing" || receipt["route"] !== "generate" || receipt["artifact"] !== "html") {
+    out.push(finding("activation-route-mismatch", "marketing brief requires web-marketing -> generate -> html activation"));
+  }
+  if (str(brief["rawRequest"]) && receipt["requestDigest"] !== digestText(brief["rawRequest"])) {
+    out.push(finding("activation-request-drift", "activation request digest does not match design-brief rawRequest"));
+  }
+  if (!str(context.catalogDigest) || receipt["catalogDigest"] !== context.catalogDigest) {
+    out.push(finding("activation-catalog-drift", "activation catalog digest does not match the installed capability catalog"));
+  }
+  if (context.capabilityCatalog === undefined || !str(context.catalogDigest)) {
+    out.push(finding("activation-catalog-unavailable", "installed capability catalog is unavailable for activation replay"));
+    return out;
+  }
+  const replay = resolveCapabilityActivation({
+    kind: "capability-activation-request",
+    version: 1,
+    rawRequest: brief["rawRequest"],
+    requestedSurface: receipt["requestedSurface"],
+    inputKind: receipt["inputKind"],
+    selectionEvidence: receipt["selectionEvidence"],
+  }, context.capabilityCatalog, context.catalogDigest);
+  if (!replay.ok) {
+    out.push(finding("activation-invalid", `activation receipt cannot be replayed: ${replay.code}`));
+  } else if (!isDeepStrictEqual(receipt, replay.receipt)) {
+    out.push(finding("activation-receipt-mismatch", "activation receipt differs from deterministic catalog resolution"));
+  }
+  return out;
+}

--- a/src/core/delivery/validate-delivery.ts
+++ b/src/core/delivery/validate-delivery.ts
@@ -2,7 +2,7 @@ import {
   DeliveryError,
 } from "./delivery-types.js";
 import type {
-  DeliveryKind, DeliveryResult, DeliveryValidationContext,
+  DeliveryFinding, DeliveryKind, DeliveryResult, DeliveryValidationContext,
 } from "./delivery-types.js";
 import { nonEmptyString as str, objectValue as obj } from "./delivery-shared-validation.js";
 import {
@@ -11,6 +11,7 @@ import {
 import { validateContractV2 } from "./delivery-v2-contract-validation.js";
 import { validateQualificationV2 } from "./delivery-v2-qualification-validation.js";
 import { validateLearningRecordV1 } from "./delivery-learning-validation.js";
+import { validateBriefV2 } from "./delivery-v2-brief-validation.js";
 
 export function validateDelivery(
   json: unknown,
@@ -27,19 +28,10 @@ export function validateDelivery(
   if (version !== 1 && version !== 2) {
     throw new DeliveryError("BAD_DELIVERY", "delivery artifact version must be 1 or 2");
   }
-  if (kind === "design-brief" && version !== 1) {
-    throw new DeliveryError("BAD_DELIVERY", "design-brief currently supports version 1 only");
-  }
   if (kind === "learning-record" && version !== 1) {
     throw new DeliveryError("BAD_DELIVERY", "learning-record currently supports version 1 only");
   }
-  const findings = kind === "learning-record"
-    ? validateLearningRecordV1(json)
-    : kind === "design-brief"
-    ? validateBriefV1(json)
-    : kind === "generation-contract"
-      ? version === 1 ? validateContractV1(json) : validateContractV2(json)
-      : version === 1 ? validateQualificationV1(json) : validateQualificationV2(json, context);
+  const findings = validateArtifact(json, kind, version, context);
   return {
     kind,
     version,
@@ -47,4 +39,22 @@ export function validateDelivery(
     warningCount: findings.filter((finding) => finding.severity === "warning").length,
     findings,
   };
+}
+
+function validateArtifact(
+  artifact: Record<string, unknown>,
+  kind: DeliveryKind,
+  version: 1 | 2,
+  context: DeliveryValidationContext,
+): DeliveryFinding[] {
+  switch (kind) {
+    case "design-brief":
+      return version === 1 ? validateBriefV1(artifact) : validateBriefV2(artifact, context);
+    case "generation-contract":
+      return version === 1 ? validateContractV1(artifact) : validateContractV2(artifact);
+    case "qualification-record":
+      return version === 1 ? validateQualificationV1(artifact) : validateQualificationV2(artifact, context);
+    case "learning-record":
+      return validateLearningRecordV1(artifact);
+  }
 }

--- a/src/core/knowledge-capability-check.ts
+++ b/src/core/knowledge-capability-check.ts
@@ -1,0 +1,114 @@
+import { parseCapabilityCatalog } from "./capability-activation.js";
+import type { CapabilityProfile } from "./capability-activation.js";
+import type { KnowledgeFinding } from "./knowledge-lint.js";
+
+export interface CapabilityCheckInput {
+  catalogJson: string | null;
+  knowledgeIndexJson: string | null;
+  needRoutingMd: string | null;
+  workflowVerbs: readonly string[];
+  commandNames: readonly string[];
+  repoFiles: readonly string[];
+}
+
+const finding = (checkId: string, message: string): KnowledgeFinding =>
+  ({ checkId, severity: "error", message });
+const strings = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+
+export function capabilityChecks(input: CapabilityCheckInput): KnowledgeFinding[] {
+  if (input.catalogJson === null) {
+    return [finding("capability-catalog-missing", "knowledge/capability-profiles.json is missing")];
+  }
+  const parsed = parseCapabilityCatalog(input.catalogJson);
+  if (!parsed.ok) return [finding("capability-catalog-bad", parsed.message)];
+  const out: KnowledgeFinding[] = [];
+  const ids = new Set<string>();
+  const knowledgeIds = indexIds(input.knowledgeIndexJson);
+  const routedProfiles = surfaceProfiles(input.needRoutingMd, input.workflowVerbs);
+  for (const profile of parsed.catalog.profiles) {
+    if (ids.has(profile.id)) out.push(finding("capability-profile-duplicate", `duplicate capability '${profile.id}'`));
+    ids.add(profile.id);
+    checkProfile(profile, input, knowledgeIds, out);
+    const routed = routedProfiles.get(profile.id);
+    if (routed === undefined) {
+      out.push(finding("capability-routing-uncovered", `capability '${profile.id}' has no Surface activation table row`));
+    } else {
+      if (routed.status !== profile.status) out.push(finding("capability-routing-status-drift", `'${profile.id}' status differs between table and catalog`));
+      if (routed.route !== profile.workflow) out.push(finding("capability-routing-route-drift", `'${profile.id}' route differs between table and catalog`));
+    }
+  }
+  for (const routed of routedProfiles.keys()) {
+    if (!ids.has(routed)) out.push(finding("capability-routing-unknown", `surface table names unknown capability '${routed}'`));
+  }
+  return out;
+}
+
+function checkProfile(
+  profile: CapabilityProfile,
+  input: CapabilityCheckInput,
+  knowledgeIds: Set<string>,
+  out: KnowledgeFinding[],
+): void {
+  const requiredKnowledge = strings(profile.requiredKnowledge);
+  const machineWitnesses = strings(profile.machineWitnesses);
+  const renderedWitnesses = strings(profile.renderedWitnesses);
+  const manualWitnesses = strings(profile.manualWitnesses);
+
+  if (profile.status === "qualified") {
+    if (profile.workflow === null || !input.workflowVerbs.includes(profile.workflow)) {
+      out.push(finding("capability-workflow-unknown", `qualified capability '${profile.id}' names unknown workflow '${profile.workflow}'`));
+    }
+    for (const witness of machineWitnesses) {
+      if (!input.commandNames.includes(witness)) out.push(finding("capability-witness-unknown", `'${profile.id}' names unknown machine witness '${witness}'`));
+    }
+    if (requiredKnowledge.length === 0 || machineWitnesses.length === 0 ||
+        renderedWitnesses.length === 0 || manualWitnesses.length === 0) {
+      out.push(finding("capability-qualified-incomplete", `qualified capability '${profile.id}' needs knowledge and all witness classes`));
+    }
+    if (typeof profile.qualificationEvidence !== "string" || !input.repoFiles.includes(profile.qualificationEvidence)) {
+      out.push(finding("capability-evidence-missing", `'${profile.id}' qualificationEvidence does not resolve`));
+    }
+  } else {
+    if (profile.workflow !== null) out.push(finding("capability-unqualified-route", `unqualified capability '${profile.id}' must have workflow:null`));
+    if (profile.refusalCode !== "CAPABILITY_UNQUALIFIED" || typeof profile.action !== "string" ||
+        strings(profile.qualificationRequirements).length === 0) {
+      out.push(finding("capability-refusal-incomplete", `unqualified capability '${profile.id}' needs refusalCode, action and qualificationRequirements`));
+    }
+  }
+  const references = [...requiredKnowledge, ...strings(profile.advisoryKnowledge)];
+  for (const id of references) {
+    if (!knowledgeIds.has(id)) out.push(finding("capability-knowledge-unknown", `'${profile.id}' names unknown knowledge id '${id}'`));
+  }
+}
+
+function indexIds(raw: string | null): Set<string> {
+  if (raw === null) return new Set();
+  try {
+    const value = JSON.parse(raw) as { entries?: Array<{ id?: unknown }> };
+    return new Set((value.entries ?? []).map((entry) => entry.id).filter((id): id is string => typeof id === "string"));
+  } catch { return new Set(); }
+}
+
+function surfaceProfiles(
+  md: string | null,
+  workflowVerbs: readonly string[],
+): Map<string, { status: string; route: string | null }> {
+  if (md === null) return new Map();
+  const heading = /^## Surface activation table\s*$/m.exec(md);
+  if (heading === null) return new Map();
+  const rest = md.slice(heading.index + heading[0].length);
+  const next = /^## /m.exec(rest);
+  const section = next === null ? rest : rest.slice(0, next.index);
+  const profiles = new Map<string, { status: string; route: string | null }>();
+  for (const row of section.split("\n")) {
+    const cells = row.split("|").map((cell) => cell.trim()).filter(Boolean);
+    const id = /^`([a-z0-9-]+)`$/.exec(cells[0] ?? "")?.[1];
+    if (id === undefined) continue;
+    const status = cells[1] ?? "";
+    const route = [...(cells[2] ?? "").matchAll(/`([a-z0-9-]+)`/g)]
+      .map((match) => match[1] as string).find((candidate) => workflowVerbs.includes(candidate)) ?? null;
+    profiles.set(id, { status, route });
+  }
+  return profiles;
+}

--- a/src/core/knowledge-lint.ts
+++ b/src/core/knowledge-lint.ts
@@ -32,7 +32,9 @@ import { frontMatterChecks } from "./knowledge-frontmatter-check.js";
 import { routingChecks } from "./knowledge-routing-check.js";
 import { sourceLedgerChecks } from "./knowledge-source-ledger-check.js";
 import { webTechniqueChecks } from "./knowledge-web-technique-check.js";
-import { SKILL_NAMES } from "../adapters/templates.js";
+import { capabilityChecks } from "./knowledge-capability-check.js";
+import { SKILL_NAMES, WORKFLOW_VERBS } from "../adapters/templates.js";
+import { COMMAND_SIGNATURES } from "./command-signatures.js";
 import { VERB_SKILL_REFS } from "../adapters/skill-refs.js";
 // monthsBetween was a third local copy of the same 12-line helper (the other two were
 // in knowledge-effect-catalog-parse.ts). Shared-layer rule: one definition, three
@@ -71,6 +73,8 @@ export interface KnowledgeLintInput {
   sourceLedgerParts?: Readonly<Record<string, string>>;
   /** Future Phase 3 technique catalog; absent is meaningful during Phase 2. */
   webTechniqueCatalogJson?: string | null;
+  /** Capability catalog. Undefined skips the check for legacy unit fixtures; null means missing. */
+  capabilityCatalogJson?: string | null;
 }
 
 const STALE_MONTHS = 6;
@@ -141,6 +145,21 @@ export function lintKnowledge(input: KnowledgeLintInput): KnowledgeFinding[] {
     // The agent-expertise ship-gate: the need→verb route table stays in exact
     // parity with the live verb registry, both directions (see routing-check).
     ...routingChecks(input.mdContents["need-routing.md"] ?? null),
+    ...(input.capabilityCatalogJson === undefined ? [] : capabilityChecks({
+      catalogJson: input.capabilityCatalogJson,
+      knowledgeIndexJson: input.committedIndex ?? null,
+      needRoutingMd: input.mdContents["need-routing.md"] ?? null,
+      workflowVerbs: WORKFLOW_VERBS,
+      commandNames: commandNames(),
+      repoFiles: input.repoFiles,
+    })),
   ];
   return sortFindings(findings);
+}
+
+function commandNames(): string[] {
+  return Object.entries(COMMAND_SIGNATURES).flatMap(([name, schema]) => [
+    name,
+    ...Object.keys(schema.subcommands ?? {}).map((subcommand) => `${name} ${subcommand}`),
+  ]);
 }

--- a/templates/workflows/generate.md
+++ b/templates/workflows/generate.md
@@ -1,5 +1,5 @@
 ---
-description: "Generate an evidence-qualified marketing or landing-page design. Use when the user asks to create UI from a plain-language request or visual reference."
+description: "Generate evidence-qualified marketing or landing-page HTML. Use when web-marketing capability activation succeeds for a plain-language request or visual reference."
 ---
 
 # Workflow: generate
@@ -16,6 +16,24 @@ candidate, and delivers it by qualification status. Read `knowledge/qualified-de
 - `--brand-hex`, `--industry`, and `--persona` remain optional DS/style constraints.
 - `--count` is accepted for compatibility, but delivery count is subordinate to qualification.
 
+## 0. Activate the requested artifact surface
+
+Before compiling a brief, read `knowledge/need-routing.md` G-1. Write
+`capability-activation-request.json` matching `schemas/capability-activation.schema.json` with the
+raw request, typed requested surface, input kind, and either quoted `requested-artifact` evidence or
+the documented page-output default. The requested artifact is not every platform noun in the copy:
+“landing page for a native macOS app” is `web-marketing`; “build a native macOS app” is
+`native-macos`.
+
+```sh
+ui knowledge activate capability-activation-request.json --json > capability-activation.json
+```
+
+Preserve the JSON result even when the command exits non-zero. Stop on every non-zero result.
+`CAPABILITY_UNQUALIFIED` with `route: null` is an honest refusal, not permission to generate HTML.
+Proceed only when `data.disposition` is `QUALIFIED`, `data.route` is `generate`, and
+`data.artifact` is `html`. Save the result beside the brief; no global telemetry is required.
+
 ## 1. Compile intent into a prompt plan
 
 Read only the relevant parts of:
@@ -25,7 +43,8 @@ Read only the relevant parts of:
 - `knowledge/prompt-modes.md` when a visual reference is supplied.
 - `knowledge/web-technique-craft.md` and `knowledge/web-techniques/catalog.json` while compiling directions.
 
-Write `design-brief.json` matching `schemas/design-brief.schema.json`. Preserve the raw request,
+Write a version 2 `design-brief.json` matching `schemas/design-brief.schema.json`, with
+`activationRef: "capability-activation.json"`. Preserve the raw request,
 tag every assumption with provenance and confidence, declare prohibited claims, and produce
 evaluable Must criteria. Ask one focused question only for design-changing ambiguity.
 

--- a/tests/capability-profile-resolution.test.ts
+++ b/tests/capability-profile-resolution.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseCapabilityCatalog,
+  resolveCapabilityActivation,
+} from "../src/core/capability-activation.js";
+
+const catalog = {
+  version: 1,
+  profiles: [
+    {
+      id: "web-marketing",
+      status: "qualified",
+      acceptedInputKinds: ["words"],
+      workflow: "generate",
+      artifact: "html",
+      requiredKnowledge: ["need-routing"],
+      machineWitnesses: ["gate"],
+      renderedWitnesses: ["1440px"],
+      manualWitnesses: ["owner-visible-acceptance"],
+      qualificationEvidence: "knowledge/qualified-delivery.md",
+    },
+    {
+      id: "native-macos",
+      status: "unqualified",
+      acceptedInputKinds: ["words"],
+      workflow: null,
+      artifact: "native-macos-application",
+      refusalCode: "CAPABILITY_UNQUALIFIED",
+      action: "Do not run generate.",
+      advisoryKnowledge: ["content-design"],
+      qualificationRequirements: ["SwiftUI knowledge"],
+    },
+  ],
+};
+
+const request = (surface: string, rawRequest: string, quote: string) => ({
+  kind: "capability-activation-request",
+  version: 1,
+  rawRequest,
+  requestedSurface: surface,
+  inputKind: "words",
+  selectionEvidence: { kind: "quoted-request", quote, role: "requested-artifact" },
+});
+
+describe("capability activation core", () => {
+  it("qualifies marketing and preserves marketing-for-native-app subject context", () => {
+    const parsed = parseCapabilityCatalog(JSON.stringify(catalog));
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    for (const raw of ["Build a landing page", "Build a landing page for a native macOS app"]) {
+      const result = resolveCapabilityActivation(
+        request("web-marketing", raw, "landing page"),
+        parsed.catalog,
+        "sha256:catalog",
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.receipt.route).toBe("generate");
+        expect(result.receipt.artifact).toBe("html");
+      }
+    }
+  });
+
+  it("refuses native macOS without an implicit HTML fallback", () => {
+    const parsed = parseCapabilityCatalog(JSON.stringify(catalog));
+    if (!parsed.ok) throw new Error(parsed.message);
+    const result = resolveCapabilityActivation(
+      request("native-macos", "Build a native macOS workspace", "native macOS workspace"),
+      parsed.catalog,
+      "sha256:catalog",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("CAPABILITY_UNQUALIFIED");
+      expect(result.receipt?.route).toBeNull();
+    }
+  });
+
+  it("rejects selection evidence whose quote is absent from the raw request", () => {
+    const parsed = parseCapabilityCatalog(JSON.stringify(catalog));
+    if (!parsed.ok) throw new Error(parsed.message);
+    const result = resolveCapabilityActivation(
+      request("web-marketing", "Build a product page", "native macOS app"),
+      parsed.catalog,
+      "sha256:catalog",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("BAD_ACTIVATION");
+  });
+
+  it("rejects catalogs that violate qualified or unqualified profile contracts", () => {
+    const missingEvidence = structuredClone(catalog);
+    delete (missingEvidence.profiles[0] as { qualificationEvidence?: string }).qualificationEvidence;
+    expect(parseCapabilityCatalog(JSON.stringify(missingEvidence)).ok).toBe(false);
+    const extraField = structuredClone(catalog) as unknown as { profiles: Array<Record<string, unknown>> };
+    extraField.profiles[1]!["fallbackWorkflow"] = "generate";
+    expect(parseCapabilityCatalog(JSON.stringify(extraField)).ok).toBe(false);
+  });
+
+  it("rejects activation request fields outside the public schema", () => {
+    const parsed = parseCapabilityCatalog(JSON.stringify(catalog));
+    if (!parsed.ok) throw new Error(parsed.message);
+    const withExtra = { ...request("web-marketing", "Build a landing page", "landing page"), trusted: true };
+    const result = resolveCapabilityActivation(withExtra, parsed.catalog, "sha256:catalog");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("BAD_ACTIVATION");
+  });
+});

--- a/tests/cmd-delivery.test.ts
+++ b/tests/cmd-delivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { run } from "../src/cli.js";
@@ -72,6 +72,88 @@ describe("ui delivery validate", () => {
     const r = capture(["delivery", "validate", file, "--json"]);
     expect(r.code).toBe(1);
     expect(JSON.parse(r.out).data.errorCount).toBeGreaterThanOrEqual(4);
+  });
+
+  it("accepts a v2 marketing brief only with a qualified generate activation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "delivery-v2-brief-"));
+    const activationRequest = join(process.cwd(), "tests", "fixtures", "capability-activation", "web-marketing-words.json");
+    const activationRun = capture(["knowledge", "activate", activationRequest, "--json"]);
+    expect(activationRun.code).toBe(0);
+    writeFileSync(join(dir, "activation.json"), activationRun.out);
+    const brief = JSON.parse(String(requireFixture("design-brief-valid.json"))) as Record<string, unknown>;
+    brief["version"] = 2;
+    brief["rawRequest"] = "Build a launch landing page for AgentTour";
+    brief["activationRef"] = "activation.json";
+    const file = join(dir, "brief.json"); writeFileSync(file, JSON.stringify(brief));
+    const result = capture(["delivery", "validate", file, "--json"]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.out).data.errorCount).toBe(0);
+  });
+
+  it("rejects v2 briefs with missing, stale, or wrong-route activation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "delivery-v2-drift-"));
+    const request = join(process.cwd(), "tests", "fixtures", "capability-activation", "web-marketing-words.json");
+    const activationRun = capture(["knowledge", "activate", request, "--json"]);
+    const brief = JSON.parse(String(requireFixture("design-brief-valid.json"))) as Record<string, unknown>;
+    brief["version"] = 2; brief["rawRequest"] = "Build a launch landing page for AgentTour";
+    const missingFile = join(dir, "missing.json"); writeFileSync(missingFile, JSON.stringify(brief));
+    expect(JSON.parse(capture(["delivery", "validate", missingFile, "--json"]).out).data.findings
+      .map((finding: { checkId: string }) => finding.checkId)).toContain("missing-activation-ref");
+
+    const envelope = JSON.parse(activationRun.out) as Record<string, unknown>;
+    const data = envelope["data"] as Record<string, unknown>;
+    data["catalogDigest"] = "sha256:" + "0".repeat(64); data["route"] = "redesign";
+    writeFileSync(join(dir, "activation.json"), JSON.stringify(envelope));
+    brief["activationRef"] = "activation.json";
+    const driftFile = join(dir, "drift.json"); writeFileSync(driftFile, JSON.stringify(brief));
+    const ids = JSON.parse(capture(["delivery", "validate", driftFile, "--json"]).out).data.findings
+      .map((finding: { checkId: string }) => finding.checkId);
+    expect(ids).toContain("activation-catalog-drift");
+    expect(ids).toContain("activation-route-mismatch");
+
+    writeFileSync(join(dir, "activation.json"), activationRun.out);
+    brief["rawRequest"] = "Build a revised landing page for AgentTour";
+    const requestDriftFile = join(dir, "request-drift.json");
+    writeFileSync(requestDriftFile, JSON.stringify(brief));
+    const requestDriftIds = JSON.parse(capture(["delivery", "validate", requestDriftFile, "--json"]).out).data.findings
+      .map((finding: { checkId: string }) => finding.checkId);
+    expect(requestDriftIds).toContain("activation-request-drift");
+  });
+
+  it("replays activation and rejects a hand-edited successful envelope", () => {
+    const dir = mkdtempSync(join(tmpdir(), "delivery-v2-forged-"));
+    const request = join(process.cwd(), "tests", "fixtures", "capability-activation", "web-marketing-words.json");
+    const envelope = JSON.parse(capture(["knowledge", "activate", request, "--json"]).out) as Record<string, unknown>;
+    const data = envelope["data"] as Record<string, unknown>;
+    data["selectedKnowledge"] = ["design-review"];
+    writeFileSync(join(dir, "activation.json"), JSON.stringify(envelope));
+    const brief = JSON.parse(String(requireFixture("design-brief-valid.json"))) as Record<string, unknown>;
+    brief["version"] = 2;
+    brief["rawRequest"] = "Build a launch landing page for AgentTour";
+    brief["activationRef"] = "activation.json";
+    const file = join(dir, "brief.json"); writeFileSync(file, JSON.stringify(brief));
+    const result = capture(["delivery", "validate", file, "--json"]);
+    expect(result.code).toBe(1);
+    const ids = JSON.parse(result.out).data.findings.map((finding: { checkId: string }) => finding.checkId);
+    expect(ids).toContain("activation-receipt-mismatch");
+  });
+
+  it("resolves activationRef beside the real brief when the brief path is a symlink", () => {
+    const realDir = mkdtempSync(join(tmpdir(), "delivery-v2-real-"));
+    const linkDir = mkdtempSync(join(tmpdir(), "delivery-v2-link-"));
+    const request = join(process.cwd(), "tests", "fixtures", "capability-activation", "web-marketing-words.json");
+    const activationRun = capture(["knowledge", "activate", request, "--json"]);
+    writeFileSync(join(realDir, "activation.json"), activationRun.out);
+    writeFileSync(join(linkDir, "activation.json"), "{}");
+    const brief = JSON.parse(String(requireFixture("design-brief-valid.json"))) as Record<string, unknown>;
+    brief["version"] = 2;
+    brief["rawRequest"] = "Build a launch landing page for AgentTour";
+    brief["activationRef"] = "activation.json";
+    const realBrief = join(realDir, "brief.json"); writeFileSync(realBrief, JSON.stringify(brief));
+    const linkedBrief = join(linkDir, "brief-link.json"); symlinkSync(realBrief, linkedBrief);
+    const result = capture(["delivery", "validate", linkedBrief, "--json"]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.out).data.errorCount).toBe(0);
   });
 });
 

--- a/tests/cmd-knowledge-activate.test.ts
+++ b/tests/cmd-knowledge-activate.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { run } from "../src/cli.js";
+
+function capture(args: string[]): { code: number; out: string; err: string } {
+  let out = ""; let err = "";
+  const oldOut = process.stdout.write.bind(process.stdout);
+  const oldErr = process.stderr.write.bind(process.stderr);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stdout.write = (chunk: any) => { out += String(chunk); return true; };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stderr.write = (chunk: any) => { err += String(chunk); return true; };
+  try { return { code: run(args), out, err }; }
+  finally { process.stdout.write = oldOut; process.stderr.write = oldErr; }
+}
+
+const fixture = (name: string): string =>
+  `${process.cwd()}/tests/fixtures/capability-activation/${name}.json`;
+
+describe("ui knowledge activate", () => {
+  it("refuses native macOS with route:null and an actionable machine envelope", () => {
+    const result = capture(["knowledge", "activate", fixture("native-macos-words"), "--json"]);
+    expect(result.code).toBe(1);
+    const envelope = JSON.parse(result.out);
+    expect(envelope.error.code).toBe("CAPABILITY_UNQUALIFIED");
+    expect(envelope.data.route).toBeNull();
+    expect(envelope.data.action).toContain("Do not run generate");
+  });
+
+  it.each(["web-marketing-words", "marketing-for-native-app"])(
+    "qualifies %s as marketing HTML",
+    (name) => {
+      const result = capture(["knowledge", "activate", fixture(name), "--json"]);
+      expect(result.code).toBe(0);
+      const envelope = JSON.parse(result.out);
+      expect(envelope.data.disposition).toBe("QUALIFIED");
+      expect(envelope.data.route).toBe("generate");
+      expect(envelope.data.artifact).toBe("html");
+      expect(envelope.data.requestDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+      expect(envelope.data.catalogDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    },
+  );
+
+  it("rejects an unknown surface with the supported profile list", () => {
+    const result = capture(["knowledge", "activate", fixture("web-marketing-words"), "--json"]);
+    const request = JSON.parse(readFileSync(fixture("web-marketing-words"), "utf8"));
+    request.requestedSurface = "native-ios";
+    const dir = mkdtempSync(join(tmpdir(), "activate-"));
+    const file = join(dir, "request.json"); writeFileSync(file, JSON.stringify(request));
+    const unknown = capture(["knowledge", "activate", file, "--json"]);
+    expect(result.code).toBe(0);
+    expect(unknown.code).toBe(1);
+    expect(JSON.parse(unknown.out).error.code).toBe("UNKNOWN_CAPABILITY");
+    expect(JSON.parse(unknown.out).data.supportedProfiles).toContain("native-macos");
+  });
+});

--- a/tests/cmd-knowledge.test.ts
+++ b/tests/cmd-knowledge.test.ts
@@ -57,9 +57,15 @@ function scaffoldConsistent(): void {
     "| `personas/<family>.md` | Persona DNA |",
     "| `benchmarks/*.dna.json` | Measured DNA |",
     "| `need-routing.md` | Need routing |",
+    "| `capability-profiles.json` | Capability profiles |",
     "",
   ].join("\n"));
-  write("knowledge/need-routing.md", fm("need-routing", "Need routing.", ["routing"]) + "# Need routing\n\n" + fullRouteTable());
+  write("knowledge/need-routing.md", fm("need-routing", "Need routing.", ["routing"]) + [
+    "# Need routing", "", "## Surface activation table", "",
+    "| Surface | Status | Candidate route |", "|---|---|---|",
+    "| `web-marketing` | qualified | `generate` |", "",
+    fullRouteTable(),
+  ].join("\n"));
   write("knowledge/taste-rubric.md", fm("taste-rubric", "The taste model.", ["taste"]) + "# Taste\n");
   write("knowledge/persona-index.md", fm("persona-index", "Persona lookup.", ["persona"]) + [
     "# Persona Index", "", "## 1. Lookup Table", "",
@@ -69,6 +75,16 @@ function scaffoldConsistent(): void {
   write("knowledge/personas/family-a.md", "# Family A\n\n## Alpha One\n\n- **Slug:** `alpha-one`\n- **Family:** family-a\n");
   write("knowledge/personas/personas.json", JSON.stringify([{ slug: "alpha-one", family: "family-a" }]));
   write("knowledge/benchmarks/stripe--202607.dna.json", "{}");
+  write("knowledge/capability-profiles.json", JSON.stringify({
+    version: 1,
+    profiles: [{
+      id: "web-marketing", status: "qualified", acceptedInputKinds: ["words"],
+      workflow: "generate", artifact: "html", requiredKnowledge: ["need-routing"],
+      machineWitnesses: ["gate"], renderedWitnesses: ["1440px"],
+      manualWitnesses: ["owner-visible-acceptance"],
+      qualificationEvidence: "knowledge/taste-rubric.md",
+    }],
+  }));
   emitIndexInto(root);
 }
 

--- a/tests/fixtures/capability-activation/marketing-for-native-app.json
+++ b/tests/fixtures/capability-activation/marketing-for-native-app.json
@@ -1,0 +1,12 @@
+{
+  "kind": "capability-activation-request",
+  "version": 1,
+  "rawRequest": "Build a landing page for a native macOS app",
+  "requestedSurface": "web-marketing",
+  "inputKind": "words",
+  "selectionEvidence": {
+    "kind": "quoted-request",
+    "quote": "landing page",
+    "role": "requested-artifact"
+  }
+}

--- a/tests/fixtures/capability-activation/native-macos-words.json
+++ b/tests/fixtures/capability-activation/native-macos-words.json
@@ -1,0 +1,12 @@
+{
+  "kind": "capability-activation-request",
+  "version": 1,
+  "rawRequest": "Build a native macOS workspace in SwiftUI",
+  "requestedSurface": "native-macos",
+  "inputKind": "words",
+  "selectionEvidence": {
+    "kind": "quoted-request",
+    "quote": "native macOS workspace",
+    "role": "requested-artifact"
+  }
+}

--- a/tests/fixtures/capability-activation/web-marketing-words.json
+++ b/tests/fixtures/capability-activation/web-marketing-words.json
@@ -1,0 +1,12 @@
+{
+  "kind": "capability-activation-request",
+  "version": 1,
+  "rawRequest": "Build a launch landing page for AgentTour",
+  "requestedSurface": "web-marketing",
+  "inputKind": "words",
+  "selectionEvidence": {
+    "kind": "quoted-request",
+    "quote": "landing page",
+    "role": "requested-artifact"
+  }
+}

--- a/tests/knowledge-capability-parity.test.ts
+++ b/tests/knowledge-capability-parity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { capabilityChecks } from "../src/core/knowledge-capability-check.js";
+
+const catalog = (overrides: Record<string, unknown> = {}) => JSON.stringify({
+  version: 1,
+  profiles: [{
+    id: "web-marketing", status: "qualified", acceptedInputKinds: ["words"],
+    workflow: "generate", artifact: "html", requiredKnowledge: ["need-routing"],
+    machineWitnesses: ["gate"], renderedWitnesses: ["1440px"],
+    manualWitnesses: ["owner-visible-acceptance"],
+    qualificationEvidence: "knowledge/qualified-delivery.md",
+    ...overrides,
+  }],
+});
+
+const input = (catalogJson: string) => ({
+  catalogJson,
+  knowledgeIndexJson: JSON.stringify({ version: 1, entries: [{ id: "need-routing" }] }),
+  needRoutingMd: "## Surface activation table\n\n| Surface | Status | Route |\n|---|---|---|\n| `web-marketing` | qualified | `generate` |\n",
+  workflowVerbs: ["generate"],
+  commandNames: ["gate"],
+  repoFiles: ["knowledge/qualified-delivery.md"],
+});
+
+describe("capability catalog parity", () => {
+  it("accepts a profile joined to routing, workflow, knowledge, witness and evidence", () => {
+    expect(capabilityChecks(input(catalog()))).toEqual([]);
+  });
+
+  it("rejects unknown workflow, knowledge and witness references", () => {
+    const findings = capabilityChecks(input(catalog({
+      workflow: "native", requiredKnowledge: ["ghost"], machineWitnesses: ["swift-build"],
+    })));
+    expect(findings.map((f) => f.checkId)).toEqual(expect.arrayContaining([
+      "capability-workflow-unknown", "capability-knowledge-unknown", "capability-witness-unknown",
+    ]));
+  });
+
+  it("rejects an unqualified profile that carries a workflow", () => {
+    const findings = capabilityChecks(input(catalog({
+      status: "unqualified", workflow: "generate", refusalCode: "CAPABILITY_UNQUALIFIED",
+      action: "Stop", qualificationRequirements: ["pilot"], advisoryKnowledge: [],
+    })));
+    expect(findings.map((f) => f.checkId)).toContain("capability-catalog-bad");
+  });
+
+  it("rejects surface table status or route drift", () => {
+    const mismatched = input(catalog());
+    mismatched.needRoutingMd = mismatched.needRoutingMd.replace("qualified | `generate`", "unqualified | none");
+    const ids = capabilityChecks(mismatched).map((finding) => finding.checkId);
+    expect(ids).toContain("capability-routing-status-drift");
+    expect(ids).toContain("capability-routing-route-drift");
+  });
+});

--- a/tests/workflow-capability-routing.test.ts
+++ b/tests/workflow-capability-routing.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string): string => readFileSync(path, "utf8");
+
+describe("workflow capability activation", () => {
+  it("routes surfaces before verbs and makes the HTML default conditional", () => {
+    const routing = read("knowledge/need-routing.md");
+    expect(routing).toContain("## Surface activation table");
+    expect(routing).toContain("`native-macos`");
+    expect(routing).toContain("CAPABILITY_UNQUALIFIED");
+    expect(routing).toContain("explicit artifact platform");
+    expect(routing).toContain("Every G4 production leg runs G-1");
+    expect(routing).toContain("Do not run G-1 for G0, G1, G2, or capture-only G3 routes");
+  });
+
+  it("requires generate to activate and stop before compiling a brief", () => {
+    const generate = read("templates/workflows/generate.md");
+    const activation = generate.indexOf("ui knowledge activate");
+    const brief = generate.indexOf("design-brief.json");
+    expect(activation).toBeGreaterThan(-1);
+    expect(activation).toBeLessThan(brief);
+    expect(generate).toContain("CAPABILITY_UNQUALIFIED");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a capability activation boundary that qualifies requested surfaces before generation and fails closed when a surface is unsupported.
- Keep the knowledge catalog, schema, runtime, tests, and maintainer documentation aligned as one public contract.
- Base reviewed: `92326e6` (`origin/main` at implementation start).

## Contract and scope
- Unsupported smoke: `native` exits 1 with `CAPABILITY_UNQUALIFIED` and `route: null`.
- Supported smoke: `marketing-for-native-app` exits 0 with `QUALIFIED` and route `generate/html`.
- No Go, Rust, NLP, network, or telemetry work is included.

## Verification
- [x] Red before fix: activation-boundary regression coverage failed against the pre-fix implementation before the behavior was added.
- [x] Typecheck, lint, and build pass.
- [x] Tests: 215/215 files; 3,724 passed; 10 skipped.
- [x] Knowledge check: 0 errors, 0 warnings.
- [x] Built CLI smokes cover both the unsupported and supported outcomes above.
- [x] Independent review: 9/10, with no Critical or High findings.
- [x] Staged diff check passed across 29 paths; targeted credential scan clean.

## Residual risk
- Low: documented-default and extra-path regression cases do not have dedicated tests.
- No coverage provider is available, so this PR makes no coverage-percentage claim.

Closes #223