### PR TITLE
fix(activation): bind digest to typed request metadata

### DIFF
--- a/src/core/capability-activation.ts
+++ b/src/core/capability-activation.ts
@@ -65,6 +65,21 @@ export function digestText(value: string): string {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`;
 }
 
+export function digestActivationRequest(request: Record<string, unknown>): string {
+  return digestText(stableJson({
+    kind: request["kind"], version: request["version"], rawRequest: request["rawRequest"],
+    requestedSurface: request["requestedSurface"], inputKind: request["inputKind"],
+    selectionEvidence: request["selectionEvidence"],
+  }));
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (objectValue(value)) return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+  return JSON.stringify(value) ?? "null";
+}
+
 export function parseCapabilityCatalog(raw: string): CatalogParseResult {
   let value: unknown;
   try { value = JSON.parse(raw); }
@@ -161,7 +176,7 @@ function buildReceipt(
   const qualified = profile.status === "qualified";
   return {
     kind: "capability-activation", version: 1,
-    requestDigest: digestText(String(request["rawRequest"])), catalogDigest,
+    requestDigest: digestActivationRequest(request), catalogDigest,
     requestedSurface: profile.id, inputKind: String(request["inputKind"]),
     selectionEvidence: evidence,
     disposition: qualified ? "QUALIFIED" : "UNQUALIFIED",

--- a/src/core/delivery/delivery-v2-brief-validation.ts
+++ b/src/core/delivery/delivery-v2-brief-validation.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { digestText, resolveCapabilityActivation } from "../capability-activation.js";
+import { digestActivationRequest, resolveCapabilityActivation } from "../capability-activation.js";
 import type { DeliveryFinding, DeliveryValidationContext } from "./delivery-types.js";
 import { finding, nonEmptyString as str, objectValue as obj, requireBase } from "./delivery-shared-validation.js";
 import { validateBriefBase } from "./delivery-v1-validation.js";
@@ -26,8 +26,13 @@ export function validateBriefV2(
   if (receipt["requestedSurface"] !== "web-marketing" || receipt["route"] !== "generate" || receipt["artifact"] !== "html") {
     out.push(finding("activation-route-mismatch", "marketing brief requires web-marketing -> generate -> html activation"));
   }
-  if (str(brief["rawRequest"]) && receipt["requestDigest"] !== digestText(brief["rawRequest"])) {
-    out.push(finding("activation-request-drift", "activation request digest does not match design-brief rawRequest"));
+  const activationRequest = {
+    kind: "capability-activation-request", version: 1, rawRequest: brief["rawRequest"],
+    requestedSurface: receipt["requestedSurface"], inputKind: receipt["inputKind"],
+    selectionEvidence: receipt["selectionEvidence"],
+  };
+  if (str(brief["rawRequest"]) && receipt["requestDigest"] !== digestActivationRequest(activationRequest)) {
+    out.push(finding("activation-request-drift", "activation request digest does not match the typed activation request"));
   }
   if (!str(context.catalogDigest) || receipt["catalogDigest"] !== context.catalogDigest) {
     out.push(finding("activation-catalog-drift", "activation catalog digest does not match the installed capability catalog"));
@@ -36,14 +41,7 @@ export function validateBriefV2(
     out.push(finding("activation-catalog-unavailable", "installed capability catalog is unavailable for activation replay"));
     return out;
   }
-  const replay = resolveCapabilityActivation({
-    kind: "capability-activation-request",
-    version: 1,
-    rawRequest: brief["rawRequest"],
-    requestedSurface: receipt["requestedSurface"],
-    inputKind: receipt["inputKind"],
-    selectionEvidence: receipt["selectionEvidence"],
-  }, context.capabilityCatalog, context.catalogDigest);
+  const replay = resolveCapabilityActivation(activationRequest, context.capabilityCatalog, context.catalogDigest);
   if (!replay.ok) {
     out.push(finding("activation-invalid", `activation receipt cannot be replayed: ${replay.code}`));
   } else if (!isDeepStrictEqual(receipt, replay.receipt)) {

--- a/tests/capability-profile-resolution.test.ts
+++ b/tests/capability-profile-resolution.test.ts
@@ -11,7 +11,7 @@ const catalog = {
     {
       id: "web-marketing",
       status: "qualified",
-      acceptedInputKinds: ["words"],
+      acceptedInputKinds: ["words", "visual-reference"],
       workflow: "generate",
       artifact: "html",
       requiredKnowledge: ["need-routing"],
@@ -44,6 +44,37 @@ const request = (surface: string, rawRequest: string, quote: string) => ({
 });
 
 describe("capability activation core", () => {
+  const receiptFor = (value: ReturnType<typeof request>) => {
+    const parsed = parseCapabilityCatalog(JSON.stringify(catalog));
+    if (!parsed.ok) throw new Error(parsed.message);
+    const result = resolveCapabilityActivation(value, parsed.catalog, "sha256:catalog");
+    if (result.ok) return result.receipt;
+    if (result.receipt !== undefined) return result.receipt;
+    throw new Error(result.message);
+  };
+
+  it.each([
+    ["requestedSurface", (value: ReturnType<typeof request>) => ({ ...value, requestedSurface: "native-macos" })],
+    ["inputKind", (value: ReturnType<typeof request>) => ({ ...value, inputKind: "visual-reference" })],
+    ["selectionEvidence", (value: ReturnType<typeof request>) => ({
+      ...value,
+      selectionEvidence: { kind: "quoted-request", quote: "AgentTour", role: "requested-artifact" },
+    })],
+  ])("binds requestDigest to %s", (_field, mutate) => {
+    const base = request("web-marketing", "Build a landing page for AgentTour", "landing page");
+    expect(receiptFor(mutate(base)).requestDigest).not.toBe(receiptFor(base).requestDigest);
+  });
+
+  it("canonicalizes typed request and selectionEvidence key ordering in requestDigest", () => {
+    const base = request("web-marketing", "Build a landing page for AgentTour", "landing page");
+    const reordered: ReturnType<typeof request> = {
+      selectionEvidence: { role: "requested-artifact", quote: "landing page", kind: "quoted-request" },
+      inputKind: base.inputKind, requestedSurface: base.requestedSurface, rawRequest: base.rawRequest,
+      version: base.version, kind: base.kind,
+    };
+    expect(receiptFor(reordered).requestDigest).toBe(receiptFor(base).requestDigest);
+  });
+
   it("qualifies marketing and preserves marketing-for-native-app subject context", () => {
     const parsed = parseCapabilityCatalog(JSON.stringify(catalog));
     expect(parsed.ok).toBe(true);

--- a/tests/cmd-delivery.test.ts
+++ b/tests/cmd-delivery.test.ts
@@ -120,6 +120,28 @@ describe("ui delivery validate", () => {
     expect(requestDriftIds).toContain("activation-request-drift");
   });
 
+  it.each([
+    ["requestedSurface", (data: Record<string, unknown>) => { data["requestedSurface"] = "native-macos"; }],
+    ["inputKind", (data: Record<string, unknown>) => { data["inputKind"] = "visual-reference"; }],
+    ["selectionEvidence", (data: Record<string, unknown>) => {
+      data["selectionEvidence"] = { kind: "quoted-request", quote: "AgentTour", role: "requested-artifact" };
+    }],
+  ])("rejects v2 receipt %s drift through the request digest", (_field, mutate) => {
+    const dir = mkdtempSync(join(tmpdir(), "delivery-v2-metadata-drift-"));
+    const request = join(process.cwd(), "tests", "fixtures", "capability-activation", "web-marketing-words.json");
+    const envelope = JSON.parse(capture(["knowledge", "activate", request, "--json"]).out) as Record<string, unknown>;
+    mutate(envelope["data"] as Record<string, unknown>);
+    writeFileSync(join(dir, "activation.json"), JSON.stringify(envelope));
+    const brief = JSON.parse(String(requireFixture("design-brief-valid.json"))) as Record<string, unknown>;
+    brief["version"] = 2;
+    brief["rawRequest"] = "Build a launch landing page for AgentTour";
+    brief["activationRef"] = "activation.json";
+    const file = join(dir, "brief.json"); writeFileSync(file, JSON.stringify(brief));
+    const ids = JSON.parse(capture(["delivery", "validate", file, "--json"]).out).data.findings
+      .map((finding: { checkId: string }) => finding.checkId);
+    expect(ids).toContain("activation-request-drift");
+  });
+
   it("replays activation and rejects a hand-edited successful envelope", () => {
     const dir = mkdtempSync(join(tmpdir(), "delivery-v2-forged-"));
     const request = join(process.cwd(), "tests", "fixtures", "capability-activation", "web-marketing-words.json");


### PR DESCRIPTION
## Summary

- Bind activation receipt digests to the complete typed request: kind, version, raw request, requested surface, input kind, and selection evidence.
- Canonicalize object key ordering while preserving the existing sha256:<hex> receipt format.
- Use the same digest helper for receipt issuance and delivery-v2 replay, so metadata drift produces activation-request-drift.

## Root cause

requestDigest previously hashed only rawRequest. A receipt could therefore retain the same digest after requestedSurface, inputKind, or selectionEvidence changed, allowing altered metadata to evade the intended drift check.

## Verification

- Red before fix: focused regression suite reproduced 6 failures across digest binding and delivery-v2 drift detection.
- Focused tests: 27/27 passed.
- Typecheck, lint, and build passed.
- Full suite: 215 files passed; 3,731 tests passed; 10 skipped.
- Knowledge check: 0 findings.
- Independent review: no Critical or High findings.
- Staged secret scan: no credential values found. requestDigest is a schema identifier, not a credential.
- npm ci reported inherited audit advisories; dependency files are unchanged.

This change provides deterministic request-drift binding and replay integrity. It does not claim cryptographic authenticity or signing.

Closes #225
