### PR TITLE
feat(agents): graduate native iOS craft routing

### DIFF
--- a/knowledge/apple-swiftui-craft.md
+++ b/knowledge/apple-swiftui-craft.md
@@ -35,6 +35,33 @@ Use SwiftUI for normal surface structure. A UIKit bridge is allowed only when a 
 capability is unavailable in SwiftUI. Record the missing capability, the smallest bridge, state
 ownership, accessibility ownership, and the condition for deleting the bridge.
 
+## Authorized product language continuity
+
+When modernizing an existing product, inventory its authorized product language before composing a new
+surface: content roles, dominant visual medium, canonical labels, information rhythm, and recognizable
+interaction conventions. Treat those elements as a content and interaction contract, not as optional
+styling references.
+
+Preserve the product's intent and recognition path, not its legacy pixels. Typography, spacing,
+materials, and container behavior may become more native and adaptive without replacing an image-led
+experience with generic cards, renaming canonical concepts, flattening authored hierarchy, or moving
+familiar actions without a product reason.
+
+## Content-shaped composition
+
+Choose composition from the content's primary job:
+
+- **Image-led collections** let authorized imagery carry identity and scan order. Labels support the
+  imagery instead of turning every item into a padded text container.
+- **Authored detail surfaces** compose media, identity, metadata, and narrative as one hierarchy. Keep
+  the next meaningful section discoverable so the opening surface does not become an isolated poster.
+- **Text-led reference lists** prioritize complete term-definition or label-value units, predictable
+  dividers, and rapid scanning. Decorative media must not displace the reference task.
+
+Reserve safe areas and persistent chrome before assigning space to content. At a viewport boundary,
+finish the current content unit; use a meaningful section heading or deliberate continuation cue for
+discoverability rather than an accidentally clipped row.
+
 ## Layout is proposal-driven
 
 - Derive composition from the container's available space, safe areas, content, locale, and Dynamic
@@ -69,6 +96,17 @@ Motion, Reduce Transparency, Increased Contrast, Differentiate Without Color, an
 `manualWitnesses` names required evidence that remains outstanding; presence in an activation receipt
 never means the witness passed. Accessibility Inspector/tree output supplements live assistive-
 technology use. It does not replace VoiceOver, Switch Control, Full Keyboard Access, or device testing.
+
+## Evidence is subject-bound
+
+Evidence must bind the exact subject, appearance, and reviewer it supports. Record the capability and
+artifact plus the relevant content or source revision; the rendered state, appearance, and container;
+and the reviewer's identity, role, and review basis.
+
+Do not transfer a verdict across a changed source, a different capture, light and dark appearances,
+normal and stress states, or different reviewers. Owner-direct acceptance and independent review are
+separate witnesses: report each at its actual scope, and never relabel one as the other or infer owner
+acceptance for an appearance the owner did not directly review.
 
 ## Evidence ladder
 

--- a/knowledge/native-ios-craft.md
+++ b/knowledge/native-ios-craft.md
@@ -21,6 +21,21 @@ safe-area changes, and keyboard-driven height loss.
 Let proposals and content choose the layout. Avoid hard-coded screen bounds, model checks, or a
 geometry reader used as a global layout engine. Preserve content state when a container adapts.
 
+## Compact vertical budget and structural reflow
+
+On iPhone, allocate the compact vertical budget after safe areas, navigation, persistent bottom chrome,
+and any active keyboard reservation. Media may remain the dominant visual language without consuming
+the opening surface: keep identity readable and the next meaningful section discoverable.
+
+Collections and text-led lists should end the visible content region on complete rows or complete
+content units. Keep those units clear of persistent chrome; a clipped next item is not a valid cue that
+more content exists.
+
+Accessibility-triggered reflow is structural, not a scaled-down copy of the default layout. When text
+growth or reduced height makes the composition fail, change multi-column collections to one column,
+stack side-by-side regions, rebalance media, and preserve semantic reading order. Do not recover space
+by clipping primary content, shrinking text, or letting a hero dominate the task.
+
 ## Navigation and presentation
 
 Use `NavigationStack` for hierarchical push navigation and value-based destinations. Use tabs only for

--- a/src/adapters/templates.ts
+++ b/src/adapters/templates.ts
@@ -63,7 +63,7 @@ export type WorkflowVerb = (typeof WORKFLOW_VERBS)[number];
  * dead config, pruned by review.
  */
 export const AGENT_TEMPLATE_COMMAND_ALLOWLIST: Record<string, readonly string[]> = {
-  designer: ["ui ds context", "ui gate", "ui memory record", "ui schema"],
+  designer: ["ui ds context", "ui gate", "ui knowledge activate", "ui memory record", "ui schema"],
   curator: ["ui ds context", "ui gate", "ui ds a11y", "ui memory record", "ui schema", "design-os audit"],
   "figma-hand": ["ui ds context", "ui memory record", "ui schema"],
 };

--- a/templates/agents/curator.md
+++ b/templates/agents/curator.md
@@ -19,6 +19,17 @@ NEVER generate — that is the designer's job.
 `knowledge/need-routing.md` (the need→verb gates, the three sanctioned asks, the
 selection route). Never guess an invocation — form commands from `ui schema --json`.
 
+**Capability receipt — report-only:** for a capability-routed review, require the exact
+activation receipt kept with the artifact or reuse a receipt that matches that artifact.
+Use the receipt's `route` only to verify the review scope; never execute it, generate,
+or edit the artifact. Read only the packets named in `selectedKnowledge` for
+report-only judgment. If the receipt is absent, refused, or mismatched, report the
+evidence gap instead of substituting a route or artifact.
+
+**Evidence separation:** report owner-direct acceptance, rendered states, independent
+review, accessibility, device or hardware behavior, and qualification as separate
+judgments. No receipt, build, render, or one reviewer verdict settles another judgment.
+
 {{KNOWLEDGE_ANCHOR}}
 
 **Non-negotiables:**

--- a/templates/agents/designer.md
+++ b/templates/agents/designer.md
@@ -20,7 +20,15 @@ ambiguity costs ZERO questions — it costs variants the user picks from. Never
 guess an invocation — form commands from `ui schema --json`; check what is
 verifiable in THIS project with `ui gate coverage`.
 
-For generate-shaped work, read `knowledge/web-technique-craft.md` and
+**Capability receipt — mandatory for capability-routed work:** follow G-1 in
+`knowledge/need-routing.md`. Form the request from `ui schema --json`, then run
+`ui knowledge activate capability-activation-request.json --json`. A non-zero or
+`REFUSED` result stops the task; never substitute a surface. For a `ROUTED` receipt,
+execute exactly its `route`; do not infer a sibling route or a command from memory.
+Read only the packets named in its `selectedKnowledge` for capability work, and keep
+the exact receipt with the artifact.
+
+For a receipt with `route: "generate"` only, read `knowledge/web-technique-craft.md` and
 `knowledge/web-techniques/catalog.json`. Preserve exactly three directions; each can carry zero or
 at most one primary imported technique formatted `<ID> — <brief-specific adaptation>`, or an
 original free-string technique when no row earns fit. Do not ask a technique-preference question.

--- a/templates/skills/native-ios-craft.md
+++ b/templates/skills/native-ios-craft.md
@@ -6,14 +6,17 @@ description: "Use when applying shared Apple SwiftUI craft plus compact iOS navi
 
 ## What to read
 
-1. `knowledge/apple-swiftui-craft.md` — shared semantic controls, adaptive layout, accessibility, and evidence tiers.
-2. `knowledge/native-ios-craft.md` — compact composition, navigation, touch, software keyboard, and iOS pilot limits.
+Read these packets in full. They own the doctrine; this skill only routes to them.
+
+1. `knowledge/apple-swiftui-craft.md` — product-language continuity, content-shaped composition, shared Apple behavior, and evidence binding.
+2. `knowledge/native-ios-craft.md` — compact vertical budget, persistent chrome, complete content units, media balance, and accessibility reflow.
 3. `knowledge/content-design.md` — hierarchy, labels, empty states, and recovery copy.
 4. `knowledge/design-review.md` and `knowledge/verification-honesty.md` — independent judgment and truthful status.
 
 ## What to enforce
 
 - Require the exact `native-ios` activation receipt; never use iPadOS or web fallback.
+- Execute only the receipt's `route`, and read only the knowledge named in its `selectedKnowledge`.
 - Start with SwiftUI system behavior and app-owned state; document every UIKit escalation.
 - Verify orientation, keyboard, locale, Dynamic Type, error recovery, focus, and touch targets.
 - Keep deterministic, rendered, accessibility, reviewer, and owner witnesses separate.

--- a/templates/workflows/native-ios.md
+++ b/templates/workflows/native-ios.md
@@ -27,13 +27,17 @@ Stop on non-zero. Proceed only when the receipt has every value below:
 - `route: "native-ios"`; and
 - `artifact: "native-ios-application"`.
 
-Do not substitute iPadOS or web. Preserve the receipt beside the work.
+Do not substitute iPadOS or web. Preserve the receipt beside the work. Its
+`selectedKnowledge` is the exclusive knowledge index for this capability work.
 
 ## 1. Establish the app contract
 
-Read `knowledge/apple-swiftui-craft.md` and `knowledge/native-ios-craft.md`. Define the primary task,
-content hierarchy, navigation ownership, loading/empty/error/recovery states, editable focus flow, and
-supported orientation before styling.
+Read the packets named in the receipt's `selectedKnowledge`, including
+`knowledge/apple-swiftui-craft.md` and `knowledge/native-ios-craft.md`. Those packets own
+product-language continuity, content-shaped composition, compact vertical budget,
+accessibility reflow, and evidence binding; apply them here without restating their doctrine.
+Then define the primary task, content hierarchy, navigation ownership,
+loading/empty/error/recovery states, editable focus flow, and supported orientation before styling.
 
 Use SwiftUI semantic controls and app-owned route/state data. Escalate to UIKit only for a documented
 SwiftUI capability gap, with the smallest bridge and explicit accessibility ownership.

--- a/tests/generated-agent-capability-routing.test.ts
+++ b/tests/generated-agent-capability-routing.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Capability-routing contract for generated agents. This stays separate from
+ * the generic emitter and CLI command tests so the native routing concern has
+ * one focused, independently readable home.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { ROSTER, renderAgent } from "../src/core/agents-gen.js";
+import { run } from "../src/cli.js";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const KNOWLEDGE_ROOT = join(REPO_ROOT, "knowledge").replaceAll("\\", "/");
+const PERSONA_DATA = fileURLToPath(new URL("../knowledge/personas/personas.json", import.meta.url));
+const savedHome = process.env["EASE_DESIGN_HOME"];
+const tempDirs: string[] = [];
+let home: string;
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function capture(args: string[]): { exitCode: number; stdout: string } {
+  let stdout = "";
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stdout.write = (chunk: any) => { stdout += String(chunk); return true; };
+  try {
+    return { exitCode: run(args), stdout };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+function initDesignSystem(dir: string): void {
+  const result = capture([
+    "ds", "init", "fixture-project",
+    "--persona", "liquid-glass",
+    "--intent", "generated agent capability routing",
+    "--dir", dir,
+    "--persona-data", PERSONA_DATA,
+    "--bare",
+  ]);
+  expect(result.exitCode).toBe(0);
+}
+
+function renderRealTemplate(role: (typeof ROSTER)[number]): string {
+  const template = readFileSync(join(REPO_ROOT, "templates", "agents", `${role}.md`), "utf8");
+  return renderAgent(template, {
+    name: `${role}-fixture-project`,
+    project: "fixture-project",
+    studio: null,
+    knowledgeRoot: KNOWLEDGE_ROOT,
+  });
+}
+
+function expectReceiptBoundKnowledge(text: string): void {
+  expect(text).toContain(`\`${KNOWLEDGE_ROOT}\``);
+  expect(text).toContain("knowledge/need-routing.md");
+  expect(text).toMatch(/(?:activation|receipt)[^.\n]*\broute\b/i);
+  expect(text).toMatch(/(?:only[^.\n]*\bselectedKnowledge\b|\bselectedKnowledge\b[^.\n]*only)/i);
+}
+
+beforeEach(() => {
+  home = makeTempDir("ease-generated-agent-home-");
+  process.env["EASE_DESIGN_HOME"] = home;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env["EASE_DESIGN_HOME"];
+  else process.env["EASE_DESIGN_HOME"] = savedHome;
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe("generated agent capability routing", () => {
+  it("renders designer and curator from the real templates with receipt-bound knowledge", () => {
+    const designer = renderRealTemplate("designer");
+    const curator = renderRealTemplate("curator");
+
+    expectReceiptBoundKnowledge(designer);
+    expectReceiptBoundKnowledge(curator);
+    expect(designer).toMatch(/ui knowledge activate/i);
+    expect(designer).toMatch(/route:\s*"generate"/i);
+    expect(curator).toMatch(/(?:require|reuse)[^.\n]*receipt/i);
+    expect(curator).toMatch(/report-only/i);
+    expect(curator).toMatch(/never execute it, generate,\s*or edit the artifact/i);
+    expect(curator).toMatch(/owner-direct acceptance[^.\n]*rendered states[^.\n]*independent/i);
+    expect(curator).toMatch(/accessibility[^.\n]*device[^.\n]*qualification/i);
+  });
+
+  it("keeps the real figma-hand template free of native craft preload", () => {
+    const figmaHand = renderRealTemplate("figma-hand");
+    expect(figmaHand).not.toMatch(/(?:apple-swiftui|native-ios|native-ipados|native-macos)-craft/i);
+  });
+
+  it("preserves the receipt contract after a fresh ui agents init", () => {
+    const project = makeTempDir("ease-generated-agent-project-");
+    initDesignSystem(project);
+
+    const result = capture(["agents", "init", "--dir", project, "--json"]);
+    expect(result.exitCode).toBe(0);
+
+    const agentsDir = join(project, ".claude", "agents");
+    const designer = readFileSync(join(agentsDir, "designer-fixture-project.md"), "utf8");
+    const curator = readFileSync(join(agentsDir, "curator-fixture-project.md"), "utf8");
+    const figmaHand = readFileSync(join(agentsDir, "figma-fixture-project.md"), "utf8");
+
+    expectReceiptBoundKnowledge(designer);
+    expectReceiptBoundKnowledge(curator);
+    expect(designer).toMatch(/ui knowledge activate/i);
+    expect(designer).toMatch(/route:\s*"generate"/i);
+    expect(curator).toMatch(/(?:require|reuse)[^.\n]*receipt/i);
+    expect(curator).toMatch(/report-only/i);
+    expect(figmaHand).not.toMatch(/(?:apple-swiftui|native-ios|native-ipados|native-macos)-craft/i);
+  });
+});

--- a/tests/native-mobile-arms.test.ts
+++ b/tests/native-mobile-arms.test.ts
@@ -44,11 +44,42 @@ const EXPECTED_PILOT_IDENTITIES = {
   },
 } as const;
 
+const NATIVE_ARM_CASES = [
+  {
+    name: "native-ios",
+    artifact: "native-ios-application",
+    siblingCraft: "native-ipados-craft",
+    selectedKnowledge: [
+      "need-routing",
+      "apple-swiftui-craft",
+      "native-ios-craft",
+      "content-design",
+      "design-review",
+      "verification-honesty",
+    ],
+  },
+  {
+    name: "native-ipados",
+    artifact: "native-ipados-application",
+    siblingCraft: "native-ios-craft",
+    selectedKnowledge: [
+      "need-routing",
+      "apple-swiftui-craft",
+      "native-ipados-craft",
+      "content-design",
+      "design-review",
+      "verification-honesty",
+    ],
+  },
+] as const;
+
 describe("native iOS and iPadOS arms", () => {
-  it.each([
-    ["native-ios", "native-ios-application", "native-ios-craft"],
-    ["native-ipados", "native-ipados-application", "native-ipados-craft"],
-  ])("routes %s only through its provisional native arm", (name, artifact, craft) => {
+  it.each(NATIVE_ARM_CASES)("routes $name only through its provisional native arm", ({
+    name,
+    artifact,
+    siblingCraft,
+    selectedKnowledge,
+  }) => {
     const result = capture(["knowledge", "activate", activationFixture(`${name}-words`), "--json"]);
     expect(result.code).toBe(0);
     const receipt = JSON.parse(result.out).data as Record<string, unknown>;
@@ -60,7 +91,8 @@ describe("native iOS and iPadOS arms", () => {
       route: name,
       artifact,
     });
-    expect(receipt["selectedKnowledge"]).toEqual(expect.arrayContaining(["apple-swiftui-craft", craft]));
+    expect(receipt["selectedKnowledge"]).toEqual(selectedKnowledge);
+    expect(receipt["selectedKnowledge"]).not.toContain(siblingCraft);
     expect(receipt["route"]).not.toBe("generate");
     expect(receipt["artifact"]).not.toBe("html");
   });
@@ -144,5 +176,25 @@ describe("native iOS and iPadOS arms", () => {
     expect(ipad).toContain("NavigationSplitView");
     expect(ipad).toContain("pointer");
     expect(ipad).toContain("hardware keyboard");
+  });
+
+  it("keeps retained iOS doctrine product-neutral, content-shaped, and evidence-bound", () => {
+    const shared = readRepositoryFile("knowledge/apple-swiftui-craft.md").replace(/\s+/g, " ");
+    const ios = readRepositoryFile("knowledge/native-ios-craft.md").replace(/\s+/g, " ");
+
+    expect(shared).toContain("Preserve the product's intent and recognition path, not its legacy pixels.");
+    expect(shared).toContain("Image-led collections");
+    expect(shared).toContain("Authored detail surfaces");
+    expect(shared).toContain("Text-led reference lists");
+    expect(shared).toContain("Reserve safe areas and persistent chrome before assigning space to content.");
+    expect(shared).toContain("finish the current content unit");
+    expect(shared).toContain("Do not transfer a verdict across a changed source, a different capture, light and dark appearances");
+    expect(shared).toContain("Owner-direct acceptance and independent review are separate witnesses");
+    expect(ios).toContain("allocate the compact vertical budget after safe areas, navigation, persistent bottom chrome");
+    expect(ios).toContain("complete rows or complete content units");
+    expect(ios).toContain("Accessibility-triggered reflow is structural");
+    expect(ios).toContain("change multi-column collections to one column");
+    expect(ios).toContain("stack side-by-side regions, rebalance media, and preserve semantic reading order");
+    expect(ios).toContain("Do not recover space by clipping primary content, shrinking text, or letting a hero dominate the task.");
   });
 });


### PR DESCRIPTION
## Summary

- graduate retained iOS product-language, content-shaped composition, compact reflow, and evidence-bound review guidance into the shared knowledge core
- make generated designer and curator agents obey exact capability receipts and selected knowledge without preloading native craft into the Figma hand
- add exact-set routing, generated-agent, sibling-exclusion, and doctrine regression tests

## Verification

- focused Vitest: 92 passed
- full Vitest: 4,258 passed, 10 skipped
- typecheck, lint, build, knowledge check, and diff hygiene passed
- independent review: approved with no Critical or Important findings
- held-out designer, curator, and Figma-hand probes behaved according to scope

## Boundaries

This improves task-routed agent knowledge. It does not change native arm qualification, assurance claims, capability profiles, or Figma-hand scope.

Closes #247