### PR TITLE
release: ease-design 0.6.0 — the polyglot release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2026-08-30 - ease-design 0.6.0
+
+The polyglot release. Ten weeks of work reaches npm: design:os can now read an app in
+any language its registry knows, judge it against rules written once, and it carries the
+instruments that keep those judgements honest.
+
+### Added
+- **`ui tell-lint`** — 43 design-tell rules over 8 extractors (HTML cascade, JSX/Tailwind,
+  Vue/Svelte SFC, bare CSS, SwiftUI, Flutter, Figma nodes, a rendered CDP tier). One
+  DesignFacts IR, N readers, no rule edited per language.
+- **`tell` joins `ui gate`** as a sixth family, so one call still gives one verdict.
+- **Native execution arms** for macOS, iOS and iPadOS, each with its own craft knowledge
+  and evidence contract.
+- **A capability-activation boundary** that fails closed on an unsupported surface rather
+  than routing it anyway.
+- **The honesty instruments**: a field corpus of real pages with adjudicated verdicts, a
+  fact census so `0 findings` can be read as clean-or-blind, every rule threshold in one
+  table pinned by an executable boundary pair, three metamorphic laws, and a nightly
+  mutation audit.
+
+### Fixed
+- stdout no longer truncates at 64KB when piped (#209).
+- `tight-leading` no longer reports `clamp()` display headlines as 16px body copy.
+- A page whose stylesheets all fail to load is reported UNDERCOUNT instead of clean.
+- `ui gate --help` listed five families while the gate ran six; the list is now derived
+  from `GATE_FAMILIES` and a test fails on drift in either direction.
+
+### Note for 0.5.0 users
+`ui gate` gained a family, and three tell rules carry `error` severity. A project that
+passed the gate on 0.5.0 can fail on 0.6.0 — that is the point of the new family, not a
+regression. Most tell findings are advisory and never affect the exit code.
+
 ## 2026-08-29 - TocChien becomes the retained iOS proof
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@ The recent wave, newest first — full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Date | Change | Commit |
 |---|---|---|
+| 2026-08-30 | **`ease-design@0.6.0`** — the polyglot release: `ui tell-lint` reads HTML, JSX/TSX, Vue, Svelte, CSS, SwiftUI and Flutter with 43 rules written once; `tell` joins `ui gate`; native macOS/iOS/iPadOS arms; and the instruments that keep the verdicts honest — an adjudicated field corpus, a fact census, thresholds pinned by executable boundary pairs, and a nightly mutation audit | `v0.6.0` |
 | 2026-08-29 | **TocChien becomes the retained iOS proof** — three image-first SwiftUI screens, 16 controller-replayed simulator tests, paired light/dark evidence, independent visual review, and exact-hash owner acceptance; Tier 2 provenance and physical/live-accessibility limits remain explicit | `#242` |
 | 2026-08-29 | **Native iOS and iPadOS proof becomes inspectable** — two held-out SwiftUI apps, 26 passing simulator tests, retained render evidence, independent fail-then-pass curation, and a content-addressed board; hardware and owner gates remain explicitly open | `#240` |
 | 2026-08-28 | **The tell rules are kept honest by measurement** — a field corpus of real pages with adjudicated verdicts (a fix that silences a true positive goes red, naming it and quoting the reason), a printed live false-positive rate, a fact census so a zero can be read, every threshold in one table pinned by an executable boundary pair, three metamorphic laws, and a nightly mutation audit | `feat/design-facts-ir` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ease-design",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Multi-runtime design-cli \u2014 describe what you want, get pro-taste UI.",
   "type": "module",
   "keywords": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,7 +65,7 @@ import { promptPlanCommand } from "./commands/prompt-plan.js";
 
 // Keep in sync with package.json "version". A test (tests/cli-version.test.ts)
 // asserts these match, so drift fails CI rather than shipping silently.
-const VERSION = "0.5.0";
+const VERSION = "0.6.0";
 
 // ─── Command registry ─────────────────────────────────────────────────────────
 

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -26,6 +26,7 @@ Runs, in one call:
   layout    ui validate-layout   (structure + mobile + hover floors)
   a11y      ui a11y-lint         (Tier-1 WCAG floors)
   taste     ui taste-lint        (rubric machine floors; --tokens enables raw-hex)
+  tell      ui tell-lint         (generated-UI tells; mostly advisory)
   content   ui content-lint      (UX-writing floors)
   autofix   DRY-RUN cleanliness  (pending repairs = error "autofix-not-clean")
 

--- a/tests/cmd-gate.test.ts
+++ b/tests/cmd-gate.test.ts
@@ -9,6 +9,8 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { run } from "../src/cli.js";
+import { GATE_FAMILIES } from "../src/core/gate.js";
+import { GATE_HELP } from "../src/commands/gate.js";
 
 function capture(args: string[]): { code: number; out: string } {
   let out = "";
@@ -203,5 +205,29 @@ describe("nodeRef stability — the stuck detector's identity contract", () => {
       .map((x: { nodeRef: string }) => x.nodeRef);
     expect(refs).toHaveLength(2);
     expect(new Set(refs).size).toBe(2);
+  });
+});
+
+describe("the help text lists every family the gate actually runs", () => {
+  /**
+   * `tell` shipped inside `ui gate` while `ui gate --help` still listed five families.
+   * The gate ran six; a reader of the help had no way to know the sixth existed. Caught
+   * by smoking a fresh clone before a release tag, not by any test — so this is the test.
+   *
+   * Derived from GATE_FAMILIES rather than hand-listed, for the same reason the README
+   * check counts are derived from CHECK_CATALOG: a hand-kept copy of a list drifts from
+   * the list, and the drift is silent.
+   */
+  it("names each of GATE_FAMILIES in the help output", () => {
+    const missing = GATE_FAMILIES.filter((f) => !new RegExp(`^\\s+${f}\\s`, "m").test(GATE_HELP));
+    expect(missing, `families that run but are undocumented in \`ui gate --help\``).toEqual([]);
+  });
+
+  it("does not advertise a family the gate cannot run", () => {
+    // The other direction: a family deleted from the runner but left in the help would
+    // promise a check that never happens, which is worse than an undocumented one.
+    const advertised = [...GATE_HELP.matchAll(/^ {2}([a-z0-9-]+) {2,}(?:ui |DRY-RUN)/gm)].map((m) => m[1] as string);
+    expect(advertised.length).toBeGreaterThan(0);
+    expect(advertised.filter((f) => !(GATE_FAMILIES as readonly string[]).includes(f))).toEqual([]);
   });
 });


### PR DESCRIPTION
Cuts **`ease-design@0.6.0`** — the first release since 0.5.0 (2026-08-20), which is 17 commits behind `main`.

## What reaches users

- **`ui tell-lint`** — 43 design-tell rules over 8 extractors (HTML cascade, JSX/Tailwind, Vue/Svelte SFC, bare CSS, SwiftUI, Flutter, Figma nodes, rendered CDP). One DesignFacts IR, N readers, no rule edited per language.
- **`tell` joins `ui gate`** as a sixth family — one call, one verdict.
- **Native macOS / iOS / iPadOS arms**, each with its own craft knowledge and evidence contract.
- **Activation fails closed** on an unsupported surface instead of routing it anyway.
- **The honesty instruments** — adjudicated field corpus, fact census, thresholds pinned by executable boundary pairs, three metamorphic laws, nightly mutation audit.

## Why 0.6.0 and not 1.0.0

`tell` in the gate is breaking-capable: three tell rules carry `error` severity, so a project that passed `ui gate` on 0.5.0 can fail on 0.6.0. Under 0.x a minor is the honest signal for that. 1.0.0 is a stability promise that cannot be made while the corpus exists precisely to find out whether the rules lie.

## Defect this release process caught

`ui gate --help` listed five families while the gate ran six — a reader had no way to learn `tell` existed. Found by smoking a fresh clone before tagging, not by any test. The help list is now derived from `GATE_FAMILIES`, with a test that fails on drift in **either** direction: a family that runs but is undocumented, or one advertised that the gate cannot run. Both red-probed.

## Pre-ship verification

| Check | Result |
|---|---|
| Tarball | 206 files / 4.2 MB (0.5.0: 172 / 2.76 MB), **no forbidden path ships** |
| Confidential sweep | **clean** — the name masked in #202 is absent; only hits were the intentional `client-portal` mask and sentences documenting the private corpus is excluded |
| Fresh clone of `origin/main` | builds; binary runs standalone **outside** the source repo |
| Four gates | typecheck · lint · build · **243 files / 4,260 tests** — green after the last edit |

The sweep is a Python script (macOS `/usr/bin/grep` is BSD and has no `-P`; POSIX ERE has no `\b`, which is how an earlier sweep for this same name returned a false clean).

## Note for 0.5.0 users

The gate gained a family and three tell rules are `error` severity. A previously-passing project can now fail — that is the new family working, not a regression. Most tell findings are advisory and never affect the exit code.

## After merge

Tag `v0.6.0` triggers `release.yml`, which publishes via npm OIDC trusted publishing. Verification will query the registry JSON and watch the run whose `headBranch` equals the tag.
