### PR TITLE
fix(tell-lint): attribute rendered findings to the page they came from

### DIFF
--- a/src/commands/tell-lint.ts
+++ b/src/commands/tell-lint.ts
@@ -72,7 +72,7 @@ Error codes:
   FILE_NOT_FOUND  A named path does not exist (also reported per-target as a skip)
   READ_ERROR      A target could not be read`;
 
-interface PerFile {
+export interface PerFile {
   file: string;
   extractor: string;
   tier: string;
@@ -87,6 +87,49 @@ interface PerFile {
   /** What the reader actually saw. A zero finding count is only readable next to this. */
   census: FactCensus;
   unresolvedSheets: string[];
+}
+
+/** The rendered tier's findings, kept with the target whose capture produced them. */
+export interface RenderedPerTarget {
+  targetPath: string;
+  findings: RenderedFinding[];
+}
+
+/**
+ * Fold the rendered tier back into the per-file records, each finding landing on
+ * the page it was captured from.
+ *
+ * `perFile` and `targetPaths` are parallel: index i of one describes index i of the
+ * other. The pairing is kept out here rather than added to `PerFile` because
+ * `PerFile` is the command's serialized JSON contract and an absolute local path
+ * has no business in it.
+ *
+ * Anything that cannot be attributed is RETURNED, never dropped — a rendered
+ * capture with no matching per-file record means the caller's two lists disagree,
+ * and a silently swallowed finding is worse than a loud one.
+ */
+export function mergeRenderedFindings(
+  perFile: PerFile[],
+  targetPaths: readonly string[],
+  byTarget: readonly RenderedPerTarget[],
+): { unattributed: RenderedPerTarget[] } {
+  const indexByPath = new Map<string, number>();
+  targetPaths.forEach((p, i) => {
+    if (!indexByPath.has(p)) indexByPath.set(p, i);
+  });
+
+  const unattributed: RenderedPerTarget[] = [];
+  for (const entry of byTarget) {
+    if (entry.findings.length === 0) continue;
+    const i = indexByPath.get(entry.targetPath);
+    const dest = i === undefined ? undefined : perFile[i];
+    if (dest === undefined) {
+      unattributed.push(entry);
+      continue;
+    }
+    dest.findings.push(...(entry.findings as unknown as TellFinding[]));
+  }
+  return { unattributed };
 }
 
 /** Extract facts for one target. Only the HTML tier is implemented so far. */
@@ -160,9 +203,16 @@ export async function runTellLint(args: ParsedArgs, cwd = process.cwd()): Promis
   const hideAdvisory = args.flags["no-advisory"] === true;
 
   const perFile: PerFile[] = [];
+  // Parallel to `perFile`: the absolute path each record came from, so the rendered
+  // tier can be folded back onto the right page without putting a local path in the
+  // command's JSON contract.
+  const targetPaths: string[] = [];
   for (const target of resolution.targets) {
     const r = analyze(target, cwd);
-    if (r !== undefined) perFile.push(r);
+    if (r !== undefined) {
+      perFile.push(r);
+      targetPaths.push(target.path);
+    }
   }
 
   // The rendered tier. Without --render its seven rules stay NOT-EVALUATED and
@@ -178,9 +228,12 @@ export async function runTellLint(args: ParsedArgs, cwd = process.cwd()): Promis
     });
     renderedNote = pass.notEvaluated;
     renderedEngine = pass.engine;
-    if (pass.findings.length > 0) {
-      const byFile = perFile[0];
-      if (byFile !== undefined) byFile.findings.push(...(pass.findings as unknown as TellFinding[]));
+    const { unattributed } = mergeRenderedFindings(perFile, targetPaths, pass.byTarget);
+    if (unattributed.length > 0) {
+      const n = unattributed.reduce((sum, u) => sum + u.findings.length, 0);
+      const where = unattributed.map((u) => u.targetPath).join(", ");
+      const lost = `${n} rendered finding(s) had no per-file record and were not attributed: ${where}`;
+      renderedNote = renderedNote === undefined ? lost : `${renderedNote}; ${lost}`;
     }
   }
 
@@ -284,17 +337,17 @@ export const tellLintCommand = {
 export async function runRenderedPass(
   targets: readonly LintTarget[],
   opts: { browser?: string; viewport?: { width: number; height: number } },
-): Promise<{ findings: RenderedFinding[]; notEvaluated?: string; engine?: string }> {
+): Promise<{ byTarget: RenderedPerTarget[]; notEvaluated?: string; engine?: string }> {
   // Two independent reasons the tier cannot run, and BOTH are reported by name rather
   // than counted as clean. The runtime check exists because `WebSocket` only became a
   // Node global in 22 while this package supports >=20 — found by CI, not by a laptop.
   const runtimeBlocked = cdpUnavailableReason();
-  if (runtimeBlocked !== undefined) return { findings: [], notEvaluated: runtimeBlocked };
+  if (runtimeBlocked !== undefined) return { byTarget: [], notEvaluated: runtimeBlocked };
 
   const located = locateBrowser(opts.browser);
-  if (located.path === undefined) return { findings: [], notEvaluated: located.reason };
+  if (located.path === undefined) return { byTarget: [], notEvaluated: located.reason };
 
-  const findings: RenderedFinding[] = [];
+  const byTarget: RenderedPerTarget[] = [];
   let engine: string | undefined;
   for (const target of targets) {
     if (target.extractorId !== "html-cascade") continue;
@@ -305,14 +358,16 @@ export async function runRenderedPass(
         viewport: opts.viewport,
       });
       engine = capture.engine.browser;
-      findings.push(...lintRendered(capture));
+      // Kept with its target: a multi-page run must not report page B against page A.
+      byTarget.push({ targetPath: target.path, findings: lintRendered(capture) });
     } catch (err) {
       // A browser or protocol failure mid-run must not take the whole command down and
       // must not read as a clean page. Report the tier NOT-EVALUATED, naming the cause.
-      return { findings, notEvaluated: `rendered capture failed: ${(err as Error).message}` };
+      // Captures already taken keep their attribution rather than being discarded.
+      return { byTarget, notEvaluated: `rendered capture failed: ${(err as Error).message}` };
     }
   }
-  return { findings, engine };
+  return { byTarget, engine };
 }
 
 /** `--viewport 390x844` → a size, or undefined when unparseable. */

--- a/tests/tell-lint-rendered-attribution.test.ts
+++ b/tests/tell-lint-rendered-attribution.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The rendered tier must blame the page it actually looked at.
+ *
+ * `runRenderedPass` used to return one flat findings array with no target
+ * attribution, and the caller folded the whole thing into `perFile[0]`. With a
+ * single file that is invisible — which is exactly why it survived: every real
+ * run in this repo passed one page. Give it two and page B's findings are
+ * reported against page A.
+ *
+ * Tested at the merge seam rather than through the command, because the command
+ * path needs a browser and this defect has nothing to do with capture. The
+ * capture loop's job is only to keep each finding next to its target path; the
+ * decision this test guards is the fold.
+ *
+ * Red probe run before the fix landed: with the old `perFile[0]` body in place,
+ * "lands on the page it came from" fails with page B's finding on page A, and
+ * "does not touch a page that had none" fails with a leaked finding. Both go
+ * green on the keyed merge. The unattributed case reddens by returning [].
+ */
+import { describe, expect, it } from "vitest";
+import { mergeRenderedFindings } from "../src/commands/tell-lint.js";
+import type { PerFile, RenderedPerTarget } from "../src/commands/tell-lint.js";
+import type { RenderedFinding } from "../src/core/tell-rules-rendered.js";
+
+function perFile(file: string): PerFile {
+  return {
+    file,
+    extractor: "html-cascade",
+    tier: "static",
+    undercount: false,
+    findings: [],
+    notEvaluated: [],
+    notComputable: 0,
+    unresolvedCount: 0,
+    waived: 0,
+    census: { byKind: {}, total: 0, nodes: 0 },
+    unresolvedSheets: [],
+  };
+}
+
+function rendered(checkId: string): RenderedFinding {
+  return {
+    checkId,
+    severity: "advisory",
+    engine: "test-engine",
+    message: `${checkId} fired`,
+    fixHint: "n/a",
+  };
+}
+
+describe("rendered findings are attributed to the page that produced them", () => {
+  it("lands each finding on the page it came from", () => {
+    const files = [perFile("a.html"), perFile("b.html")];
+    const paths = ["/abs/a.html", "/abs/b.html"];
+    const byTarget: RenderedPerTarget[] = [{ targetPath: "/abs/b.html", findings: [rendered("offscreen-text")] }];
+
+    const { unattributed } = mergeRenderedFindings(files, paths, byTarget);
+
+    expect(unattributed).toEqual([]);
+    expect(files[1]?.findings.map((f) => f.checkId)).toEqual(["offscreen-text"]);
+  });
+
+  it("does not touch a page that had none", () => {
+    const files = [perFile("a.html"), perFile("b.html")];
+    const paths = ["/abs/a.html", "/abs/b.html"];
+    const byTarget: RenderedPerTarget[] = [{ targetPath: "/abs/b.html", findings: [rendered("offscreen-text")] }];
+
+    mergeRenderedFindings(files, paths, byTarget);
+
+    // The whole defect in one assertion: page A never saw the browser.
+    expect(files[0]?.findings).toEqual([]);
+  });
+
+  it("keeps both pages' findings apart when both fired", () => {
+    const files = [perFile("a.html"), perFile("b.html")];
+    const paths = ["/abs/a.html", "/abs/b.html"];
+    const byTarget: RenderedPerTarget[] = [
+      { targetPath: "/abs/a.html", findings: [rendered("clipped-heading")] },
+      { targetPath: "/abs/b.html", findings: [rendered("offscreen-text")] },
+    ];
+
+    mergeRenderedFindings(files, paths, byTarget);
+
+    expect(files[0]?.findings.map((f) => f.checkId)).toEqual(["clipped-heading"]);
+    expect(files[1]?.findings.map((f) => f.checkId)).toEqual(["offscreen-text"]);
+  });
+
+  it("reports findings it cannot attribute instead of dropping them", () => {
+    const files = [perFile("a.html")];
+    const paths = ["/abs/a.html"];
+    const byTarget: RenderedPerTarget[] = [{ targetPath: "/abs/ghost.html", findings: [rendered("offscreen-text")] }];
+
+    const { unattributed } = mergeRenderedFindings(files, paths, byTarget);
+
+    expect(unattributed).toHaveLength(1);
+    expect(unattributed[0]?.targetPath).toBe("/abs/ghost.html");
+    expect(files[0]?.findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #237.

## What was wrong

`runRenderedPass` returned one flat `findings[]` with no attribution, and the caller did:

```ts
const byFile = perFile[0];
if (byFile !== undefined) byFile.findings.push(...pass.findings);
```

With two pages, page B's rendered findings were reported against page A. Single-file runs are unaffected, which is why this survived: every real run in this repo has passed one page.

## What changed

- The capture loop keeps each page's findings beside the path it captured from.
- A new `mergeRenderedFindings` folds them onto the matching per-file record.
- The pairing rides in a parallel array rather than a new `PerFile` field — `PerFile` is the command's serialized JSON contract, and an absolute local path has no business in it. **The JSON output shape is unchanged.**
- Findings that cannot be attributed are **returned and reported** in the rendered note, never dropped.
- A partial run (capture throws mid-way) keeps the attribution of the captures already taken.

## Red probe

This is the evidence, not the green run. With the old `perFile[0]` body temporarily reinstated, all four new assertions fail — each with the defect's real shape:

```
× lands each finding on the page it came from
    expected [] to deeply equal [ 'offscreen-text' ]
× does not touch a page that had none
    expected [ { checkId: 'offscreen-text' } ] to deeply equal []
× keeps both pages' findings apart when both fired
    expected [ 'clipped-heading', 'offscreen-text' ] to deeply equal [ 'clipped-heading' ]
× reports findings it cannot attribute instead of dropping them
    expected [] to have a length of 1 but got +0
```

All four go green on the keyed merge.

## Seam

Tested at the merge seam, not through the command — the command path needs a browser, and this defect has nothing to do with capture. The capture loop's only job here is keeping each finding next to its page; the decision under test is the fold.

## Gates

Run in this tree after the last edit:

| Gate | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | clean |
| bundler | clean |
| `npm test` | 244 files / 4284 passed / 0 failed / 10 skipped |

Baseline measured on `main` before this work: 243 files / 4260 passed / 0 failed. The delta is 20 tests from the corpus merged in #251 plus the 4 added here.

## Corpus

No pinned row flips here — no `fp-open` row covers `--render`.

Part of the tell-lint anti-flop closeout (#236 #237 #238 #252 #253 #254 #255).
