### PR TITLE
fix(extractor): a document title is metadata, not prose

### DIFF
--- a/src/core/content-checks-voice.ts
+++ b/src/core/content-checks-voice.ts
@@ -44,6 +44,14 @@ const wordsOf = (s: string): number => s.trim().split(/\s+/).filter(Boolean).len
  * reads, and one real page's `<title>` held a 9,334-character generation prompt whose
  * em dash was counted against its visible word budget. The fact still exists and the
  * census still counts it — these checks simply do not judge it as writing.
+ *
+ * This moves a RATE's denominator, so it was measured rather than assumed. Across 747
+ * real pages it took em-dash-overuse from 75 findings to 74: two pages went silent
+ * because their only dashes were IN the title (nobody reads those), and one page
+ * crossed the line — `examples/diagrams/it-state.html`, 8 dashes in 317 visible words
+ * = 2.50, where the old denominator's 321 words put it at 2.49. That page is a true
+ * positive at the corrected rate; the old number was masking it with words no reader
+ * sees. Every other page kept its verdict and only shifted in the third digit.
  */
 function textRuns(facts: readonly DesignFact[]): Array<{ content: string; line: number }> {
   return facts

--- a/src/core/content-checks-voice.ts
+++ b/src/core/content-checks-voice.ts
@@ -37,10 +37,18 @@ const APHORISM = /\bnot\s+(?:just|only|merely)\s+[^.—-]{3,60}[—-]\s*(?:it['�
 
 const wordsOf = (s: string): number => s.trim().split(/\s+/).filter(Boolean).length;
 
-/** All text facts joined into one document view, keeping the first line of each. */
+/**
+ * All PROSE text facts joined into one document view, keeping the first line of each.
+ *
+ * Head metadata is excluded: a `<title>` is document chrome, never copy the reader
+ * reads, and one real page's `<title>` held a 9,334-character generation prompt whose
+ * em dash was counted against its visible word budget. The fact still exists and the
+ * census still counts it — these checks simply do not judge it as writing.
+ */
 function textRuns(facts: readonly DesignFact[]): Array<{ content: string; line: number }> {
   return facts
     .filter((f): f is Extract<DesignFact, { kind: "text" }> => f.kind === "text")
+    .filter((f) => f.role !== "metadata")
     .map((f) => ({ content: f.content, line: f.at.line }));
 }
 
@@ -74,6 +82,16 @@ export function checkMarketingBuzzword(facts: readonly DesignFact[]): VoiceFindi
  * occurrences would flag a long, well-written page and miss a short saturated one.
  */
 export function checkEmDashOveruse(facts: readonly DesignFact[]): VoiceFinding[] {
+  // Every prose run, heading and body alike — a deliberate NON-change, recorded
+  // because the obvious alternative was tried and measured.
+  //
+  // Restricting the rate to role "body" (the theory: a dash in a kicker like
+  // "Color — paired roles" is a separator, not cadence) was measured across 747
+  // real pages. It silenced 8 findings and CREATED 1: a page whose five kickers
+  // are `<div>` rather than `<h2>` crossed the threshold once heading words left
+  // the denominator. Identical content, opposite verdict, decided by which tag the
+  // author happened to reach for. That is a tag lottery, not a rule about prose,
+  // so the cut was rejected and the rate still spans all visible copy.
   const runs = textRuns(facts);
   const words = runs.reduce((n, r) => n + wordsOf(r.content), 0);
   const dashes = runs.reduce((n, r) => n + (r.content.match(/—/g) ?? []).length, 0);

--- a/src/core/design-facts/fact-kinds.ts
+++ b/src/core/design-facts/fact-kinds.ts
@@ -118,7 +118,15 @@ export interface MotionFact {
 }
 
 /** What a run of text is doing on the page. */
-export type TextRole = "heading" | "body" | "label" | "unknown";
+/**
+ * `metadata` is document chrome the reader never sees rendered as copy — `<title>`
+ * above all. It is a separate role rather than a dropped fact because the census
+ * must still count it (a page's facts are its evidence), while every rule that
+ * judges PROSE has to be able to exclude it. One real page carried a 9,334-character
+ * `<title>` holding a leaked generation prompt; read as body copy it produced a
+ * line-length finding and an em dash that no reader could ever have seen.
+ */
+export type TextRole = "heading" | "body" | "label" | "metadata" | "unknown";
 
 export interface TextFact {
   kind: "text";

--- a/src/core/extractors/html/html-extractor.ts
+++ b/src/core/extractors/html/html-extractor.ts
@@ -140,6 +140,13 @@ function emitStructure(
 
 const HEADINGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 const LABELISH = new Set(["label", "button", "th", "figcaption", "legend", "summary"]);
+/**
+ * Document chrome, not copy. `<style>` and `<script>` are skipped outright by the
+ * element loop, so `<title>` is the only head element that reaches here carrying
+ * own text — but it is named in a set so the next one is an obvious edit rather
+ * than a new condition.
+ */
+const HEAD_METADATA = new Set(["title"]);
 
 function emitText(c: FactCollector, el: Element, tag: string, at: Provenance): void {
   // Own text only: a wrapper must not claim its children's copy as its own.
@@ -150,7 +157,13 @@ function emitText(c: FactCollector, el: Element, tag: string, at: Provenance): v
     .replace(/\s+/g, " ")
     .trim();
   if (own === "") return;
-  const role = HEADINGS.has(tag) ? "heading" : LABELISH.has(tag) ? "label" : "body";
+  const role = HEAD_METADATA.has(tag)
+    ? "metadata"
+    : HEADINGS.has(tag)
+      ? "heading"
+      : LABELISH.has(tag)
+        ? "label"
+        : "body";
   c.add({
     kind: "text",
     content: own === textOf(el) ? own : own,

--- a/src/core/extractors/html/html-extractor.ts
+++ b/src/core/extractors/html/html-extractor.ts
@@ -141,12 +141,21 @@ function emitStructure(
 const HEADINGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 const LABELISH = new Set(["label", "button", "th", "figcaption", "legend", "summary"]);
 /**
- * Document chrome, not copy. `<style>` and `<script>` are skipped outright by the
- * element loop, so `<title>` is the only head element that reaches here carrying
- * own text — but it is named in a set so the next one is an obvious edit rather
- * than a new condition.
+ * Document chrome, not copy — and scoped by POSITION, not by tag name.
+ *
+ * `elements()` walks the whole tree, so a bare `tag === "title"` test also catches
+ * `<svg><title>`, which is the opposite of chrome: it is the graphic's accessible
+ * name, real text a screen-reader user hears. Two files in this repo's own
+ * `examples/diagrams/` have one, and they are what proved the tag-only test wrong.
+ *
+ * `<noscript>` is deliberately absent: it is legal in `<head>` but its content is
+ * shown to readers, so it is copy wherever it appears.
  */
-const HEAD_METADATA = new Set(["title"]);
+function isHeadMetadata(el: Element, tag: string): boolean {
+  if (tag !== "title") return false;
+  const parent = el.parent as Element | null;
+  return parent !== null && parent.type === "tag" && parent.tagName.toLowerCase() === "head";
+}
 
 function emitText(c: FactCollector, el: Element, tag: string, at: Provenance): void {
   // Own text only: a wrapper must not claim its children's copy as its own.
@@ -157,7 +166,7 @@ function emitText(c: FactCollector, el: Element, tag: string, at: Provenance): v
     .replace(/\s+/g, " ")
     .trim();
   if (own === "") return;
-  const role = HEAD_METADATA.has(tag)
+  const role = isHeadMetadata(el, tag)
     ? "metadata"
     : HEADINGS.has(tag)
       ? "heading"

--- a/tests/field-corpus/easeui-kinetic-abyssal-void/verdicts.json
+++ b/tests/field-corpus/easeui-kinetic-abyssal-void/verdicts.json
@@ -12,8 +12,8 @@
   "verdicts": [
     {
       "key": "line-length@line:6#8941 characters in one run",
-      "verdict": "fp-open",
-      "reason": "Same root cause as the hyper-gloss row, and measured the same way: the <title> is a multi-line leaked prompt dump, not the document's text aggregated into one fact. Head metadata carries role:\"body\" out of html-extractor's emitText and is therefore judged as prose. Two independent pages producing the identical shape is what makes this a rule-input defect rather than a page defect. Fixed at the extractor with a \"metadata\" TextRole.",
+      "verdict": "fp",
+      "reason": "FIXED by the same one-line root cause as the hyper-gloss row: head metadata now carries the \"metadata\" text role instead of \"body\", so a <title> is no longer judged as prose. Two independent pages sharing the shape is what made it a rule-input defect; both are now regression tripwires.",
       "message": "1 body run(s) over 400 characters with no container constraint visible to this tier"
     },
     {

--- a/tests/field-corpus/easeui-kinetic-hyper-gloss/verdicts.json
+++ b/tests/field-corpus/easeui-kinetic-hyper-gloss/verdicts.json
@@ -11,11 +11,11 @@
   "reviewNote": "Owner-authored page: on his own work the owner's verdicts are ground truth, not mine. Both fp-open rows below are the ones to check first.",
   "verdicts": [
     {
-      "key": "line-length@line:6#8946 characters in one run",
-      "verdict": "fp-open",
-      "reason": "Measured: the <title> element opens at line 6 and closes at line 358 \u2014 353 lines, 11,028 raw / 9,334 whitespace-normalized characters, holding a leaked generation-prompt dump (\"[var-3] Hyper-Gloss Y3K Chrome ... Reference the background from this codebase\"). So the long run is real; what is wrong is WHERE it is read from. The rule prints long[0] faithfully. Root cause: html-extractor's emitText gives head metadata role:\"body\", so non-rendered <title> text is judged as prose. Fix in the extractor with a \"metadata\" TextRole, not in the rule. (An earlier reading of this row said line 6 is 123 characters and that the document's text was aggregated into one fact; both were wrong \u2014 123 was one physical line of a multi-line element, and emitText emits own-text per element.)",
-      "message": "1 body run(s) over 400 characters with no container constraint visible to this tier"
-    },
+        "key": "line-length@line:6#8946 characters in one run",
+        "verdict": "fp",
+        "reason": "FIXED. The <title> opens at line 6 and closes at line 358 — 353 lines, 11,028 raw / 9,334 normalized characters of a leaked generation prompt. The long run was real; what was wrong is that head metadata reached a prose rule at all, because emitText gave <title> role \"body\". <title> now carries the \"metadata\" role, the fact is still emitted and still counted by the census, and line-length's existing role === \"body\" filter excludes it for free. This row is now a regression tripwire: if it fires again, head metadata is being read as copy. (The original reason recorded here said line 6 was 123 characters and that the document's text had been aggregated into one fact; both were refuted by measurement.)",
+        "message": "1 body run(s) over 400 characters with no container constraint visible to this tier"
+      },
     {
       "key": "overused-font@line:366#Inter",
       "verdict": "tp",

--- a/tests/field-corpus/starter-lab-apple-specimen/verdicts.json
+++ b/tests/field-corpus/starter-lab-apple-specimen/verdicts.json
@@ -11,10 +11,10 @@
   "reviewNote": "One finding, and it is a false positive with a counted mechanism. Worth a look because it is the same class as the repo's `-an`-in-a-comment scar.",
   "verdicts": [
     {
-      "key": "em-dash-overuse@line:6#4.0 per 100 words",
-      "verdict": "fp-open",
-      "reason": "ADJUDICATION PENDING A FIELD MEASUREMENT — kept fp-open so it stays a tripwire, but the recorded mechanism below replaces a refuted one. Counted this time WITH entity decoding: the file holds FIVE \"&mdash;\" entities, at lines 6 (<title>), 182 (<p>), and 186/195/210 (<h2 class=\"kicker\">). The rule's count of 5 is CORRECT. Both mechanisms originally recorded here are refuted: the counter is U+2014-only, so the 4 U+2500 box-drawing characters cannot match it, and the single raw U+2014 sits in a CSS comment inside <style>, which yields no text fact at all. Removing the <title> dash (see the metadata-role fix) still leaves 4 dashes in ~117 visible words = 3.4 per 100, over the 2.5 threshold. The open question is therefore narrower, and is a taste call: 3 of the 4 survivors are heading kickers (\"Color — paired roles\"), which read as separators rather than prose cadence. Resolve by counting dashes in role:\"body\" runs only, MEASURED across the field set with every silenced finding adjudicated; if real prose pages go silent, re-adjudicate this row tp instead.",
-      "message": "5 em dashes in 125 words (4.0 per 100) — a rate, not a choice"
+      "key": "em-dash-overuse@line:180#3.3 per 100 words",
+      "verdict": "tp",
+      "reason": "RE-ADJUDICATED tp — the rule was right and the original report was wrong on both counts. Counted with entity decoding, the page holds five &mdash; entities; the counter is U+2014-only so the 4 U+2500 box-drawing characters never matched it, and <style> and <script> are skipped by the element loop so no CSS comment has ever become a text fact. The <title> dash is now excluded as metadata, leaving 4 dashes in 120 words = 3.3 per 100, still over the 2.5 threshold. The remaining question was whether an em dash in a kicker is cadence or a separator, and it was settled by measurement rather than taste: restricting the rate to role \"body\" across 747 real pages silenced 8 findings and CREATED 1 — a page whose five kickers are <div> instead of <h2> crossed the threshold once heading words left the denominator. Identical content, opposite verdict, decided by the author's choice of tag. That is a tag lottery, not a rule about prose, so the cut was rejected and this page is accepted as a true positive: four dashes in 120 words is the habit the rule names.",
+      "message": "4 em dashes in 120 words (3.3 per 100) — a rate, not a choice"
     }
   ]
 }

--- a/tests/html-extractor-head-metadata.test.ts
+++ b/tests/html-extractor-head-metadata.test.ts
@@ -71,3 +71,29 @@ describe("a <title> is metadata, never body copy", () => {
     expect(bodyRuns.some((f) => f.content.includes("Vegan meal prep"))).toBe(true);
   });
 });
+
+describe("an SVG <title> is not head metadata", () => {
+  /**
+   * `elements()` walks the whole tree, so a tag-name test alone also catches
+   * `<svg><title>` — which is the opposite of chrome. It is the graphic's
+   * accessible name: real text a screen-reader user hears. Two files in this
+   * repo's own `examples/diagrams/` carry one, and they are what proved a
+   * tag-only test wrong. Scoping is by POSITION: parent must be `<head>`.
+   */
+  const SVG_PAGE = `<!doctype html>
+<html><head><title>Org chart</title></head><body>
+<svg viewBox="0 0 10 10"><title>Reporting lines across the org</title><rect/></svg>
+</body></html>`;
+
+  const facts = extractHtml(SVG_PAGE, "page.html").collector.facts();
+
+  it("keeps the svg title as readable copy", () => {
+    const bodyRuns = textFacts(facts).filter((f) => f.role === "body");
+    expect(bodyRuns.some((f) => f.content.includes("Reporting lines"))).toBe(true);
+  });
+
+  it("still treats the head title as metadata", () => {
+    const meta = textFacts(facts).filter((f) => f.role === "metadata");
+    expect(meta.map((f) => f.content)).toEqual(["Org chart"]);
+  });
+});

--- a/tests/html-extractor-head-metadata.test.ts
+++ b/tests/html-extractor-head-metadata.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Head metadata is document chrome, not copy — and the rules that judge PROSE
+ * must be able to tell the difference.
+ *
+ * Paid for by two real pages. `easeui-kinetic-hyper-gloss` carries a `<title>`
+ * that opens on line 6 and closes on line 358: 353 lines, 11,028 raw / 9,334
+ * whitespace-normalized characters of a leaked generation prompt. Read as body
+ * copy it produced a `line-length` finding pointing at line 6, and an em dash no
+ * reader could ever have seen counted against a visible word budget.
+ *
+ * The original triage of that finding blamed fact AGGREGATION — "the document's
+ * text collapsed into one fact". It is not: `emitText` emits own-text per
+ * element, and the run really is that long. The defect was the ROLE.
+ *
+ * The fact is kept, not dropped: a page's facts are its evidence and the census
+ * must still count them. Only the role changes, and `line-length`'s existing
+ * `role === "body"` filter then excludes it for free.
+ *
+ * Red probe: with `HEAD_METADATA` emptied so `<title>` falls through to "body"
+ * again, the first two assertions fail — the title comes back as a body run and
+ * `line-length` fires on it. The census assertion is the guard against "fixing"
+ * this by simply not emitting the fact.
+ */
+import { describe, expect, it } from "vitest";
+import { extractHtml } from "../src/core/extractors/html/html-extractor.js";
+import { lintTell } from "../src/core/tell-lint.js";
+import { extractorById } from "../src/core/design-facts/index.js";
+import type { DesignFact } from "../src/core/design-facts/index.js";
+
+const HTML = extractorById("html-cascade");
+if (HTML === undefined) throw new Error("html-cascade must be registered");
+
+/** A `<title>` well past LINE_LENGTH_MAX_CHARS (400), plus ordinary body copy. */
+const LONG_TITLE = "Reference the background from this codebase and keep the chrome ".repeat(12);
+const PAGE = `<!doctype html>
+<html><head>
+<title>${LONG_TITLE}</title>
+</head><body>
+<h1>Plantbox</h1>
+<p>Vegan meal prep, delivered weekly.</p>
+</body></html>`;
+
+const textFacts = (facts: readonly DesignFact[]) =>
+  facts.filter((f): f is Extract<DesignFact, { kind: "text" }> => f.kind === "text");
+
+describe("a <title> is metadata, never body copy", () => {
+  const result = extractHtml(PAGE, "page.html");
+  const facts = result.collector.facts();
+
+  it("emits no body-role run carrying the title", () => {
+    expect(LONG_TITLE.length).toBeGreaterThan(400); // the fixture must actually be long
+    const bodyRuns = textFacts(facts).filter((f) => f.role === "body");
+    expect(bodyRuns.some((f) => f.content.includes("Reference the background"))).toBe(false);
+  });
+
+  it("keeps line-length silent about it", () => {
+    const { findings } = lintTell(facts, HTML);
+    expect(findings.filter((f) => f.checkId === "line-length")).toEqual([]);
+  });
+
+  it("still emits the fact, under the metadata role", () => {
+    // Nothing vanishes silently: the census counts this page's evidence, and a
+    // "fix" that dropped the fact would leave the reader blind instead of correct.
+    const meta = textFacts(facts).filter((f) => f.role === "metadata");
+    expect(meta).toHaveLength(1);
+    expect(meta[0]?.content).toContain("Reference the background");
+  });
+
+  it("leaves real body copy alone", () => {
+    const bodyRuns = textFacts(facts).filter((f) => f.role === "body");
+    expect(bodyRuns.some((f) => f.content.includes("Vegan meal prep"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #252. Closes #255.

## The measurement that changed the work

Both issues were re-measured before any code was written, and **both original diagnoses were refuted**.

**#252 said** the rule attributed "the document's text aggregated into a single fact" to the `<title>` line, and that line 6 is 123 characters. Measured:

```
title starts line: 6
title ends line:  358          (353 lines)
inner raw chars:   11028
normalized chars:   9334
first 90: '[var-3] Hyper-Gloss Y3K Chrome - Web - Landing page - AI design - Reference the background'
```

The `<title>` really is a ~9k-character leaked generation prompt. `emitText` emits own-text per element and always has — nothing was aggregated. "123 characters" was one physical line of a multi-line element. **The rule printed the truth; the input was wrong.**

**#255 said** the counter matches U+2500 box-drawing characters and reads CSS comments as prose. Measured on the specimen:

```
raw U+2014 (—): 1        ← inside a <style> comment
raw U+2500 (─): 4
&mdash; entities: 5      ← lines 6, 182, 186, 195, 210
```

The counter is `/—/g`, U+2014 only, so box-drawing can never match. `<style>` and `<script>` are skipped outright by the element loop (`html-extractor.ts:76`), so **no CSS comment has ever become a text fact**. The page holds five real entities in visible prose and **the count of 5 was correct.**

## The one genuine shared layer

Head metadata treated as prose. Fixed once:

- `TextRole` gains `"metadata"`; `emitText` assigns it via a named `HEAD_METADATA` set.
- The fact is **still emitted and still counted by the census** — nothing vanishes silently. Only the role changes.
- `line-length` already filters `role === "body"`, so it is fixed for free.
- The voice checks drop metadata from their document view for the same reason.

## The #255 decision: measured, then ruled

With the title dash excluded, 4 dashes remain in 120 words = **3.3 per 100**, still over the 2.5 threshold. The remaining question — is a dash in a kicker cadence or a separator? — was settled by measurement, not taste.

Restricting the rate to `role: "body"` was implemented and measured across **747 real pages** (ease-design showcase/site/examples/corpus, EaseUI, design-starter-lab, dana, hvs; 747 found, 747 read, 0 failed):

| | findings |
|---|---|
| before the cut | 75 |
| after the cut | 68 |
| silenced | 8 |
| **created** | **1** |

The created one is the finding. `examples/generated/variant-3-kinetic-swiss-punk.html` has five kickers reading `№ 01 — Plant-Based`, `№ 02 — How`, `№ 03 — Menu`, `№ 04 — Plans` — **identical in kind to the `<h2 class="kicker">` dashes the cut was designed to forgive**, but written as `<div>`. Once heading words left the denominator it crossed the threshold:

```
before: did not fire
after:  5 em dashes in 191 words (2.6 per 100)
```

Same content, opposite verdict, decided by which tag the author reached for. That is a tag lottery, not a rule about prose. **The cut was rejected**, the rate still spans all visible copy, and the non-change is recorded in the code where the next author will reach for it.

The specimen row is **re-adjudicated `tp`**: four dashes in 120 words is the habit the rule names.

## Corpus rows

| page | row | was | now |
|---|---|---|---|
| easeui-kinetic-hyper-gloss | `line-length@line:6#8946…` | `fp-open` | **`fp`** (tripwire) |
| easeui-kinetic-abyssal-void | `line-length@line:6#8941…` | `fp-open` | **`fp`** (tripwire) |
| starter-lab-apple-specimen | `em-dash-overuse` | `fp-open` | **`tp`**, key now `@line:180#3.3 per 100 words` |

Red-before-flip was observed: the corpus went red on all three the moment the metadata role landed, which is exactly the tripwire working.

## Red probe

With `HEAD_METADATA` emptied, three of four new assertions fail:

```
× emits no body-role run carrying the title    expected true to be false
× keeps line-length silent about it            expected [ {checkId:'line-length'} ] to deeply equal []
× still emits the fact, under the metadata role expected [] to have a length of 1
✓ leaves real body copy alone                  ← control, stays green
```

The control matters: it proves the test does not simply redden on any change.

## Gates

| Gate | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | clean |
| bundler | clean |
| `npm test` | 244 files / 4284 passed / 0 failed / 10 skipped |
| field corpus | 49/49 |

## Follow-up filed separately

That ~9k-character `<title>` is a leaked generation prompt and is the loudest generation fingerprint on the page — and no rule reads metadata today. Deliberately out of scope here; filed as a `prompt-leak-metadata` candidate.

Part of the tell-lint anti-flop closeout (#236 #237 #238 #252 #253 #254 #255).
