### PR TITLE
fix(jsx-tailwind): one typography fact per element, and read text-transform

### DIFF
--- a/src/core/extractors/web/jsx-extractor.ts
+++ b/src/core/extractors/web/jsx-extractor.ts
@@ -106,9 +106,30 @@ function kebab(prop: string): string {
   return prop.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 
+/** Typography fields an element's utilities contribute, before they become one fact. */
+type TypeAccum = {
+  sizePx?: number;
+  weight?: number;
+  letterSpacingEm?: number;
+  lineHeight?: number;
+  align?: never;
+  italic?: boolean;
+  transform?: never;
+};
+
 function emitClasses(c: FactCollector, classes: readonly string[], at: Provenance): void {
   const sides: Side[] = [];
   let borderWidth: number | undefined;
+  // ONE typography fact per element, exactly as the html-cascade extractor emits
+  // it — the reference every other extractor is measured against.
+  //
+  // These used to be one fact per utility, which silently broke every rule that
+  // correlates two typography properties on the same element. `wide-tracking`
+  // exempts uppercase text and could never see `uppercase`; `tight-leading` needs
+  // lineHeight AND sizePx together and never had both. Neither showed up as
+  // NOT-EVALUATED, because `needs` is kind-granular and `typography` was present
+  // the whole time — they just quietly read `undefined` and fired anyway.
+  const type: TypeAccum = {};
 
   for (const token of classes) {
     const resolved = resolveClass(token);
@@ -130,22 +151,25 @@ function emitClasses(c: FactCollector, classes: readonly string[], at: Provenanc
           if (r.value !== undefined) c.add({ kind: "radius", px: r.value, at });
           break;
         case "fontSize":
-          if (r.value !== undefined) c.add({ kind: "typography", sizePx: r.value, at });
+          if (r.value !== undefined) type.sizePx = r.value;
           break;
         case "weight":
-          if (r.value !== undefined) c.add({ kind: "typography", weight: r.value, at });
+          if (r.value !== undefined) type.weight = r.value;
           break;
         case "tracking":
-          if (r.value !== undefined) c.add({ kind: "typography", letterSpacingEm: r.value, at });
+          if (r.value !== undefined) type.letterSpacingEm = r.value;
           break;
         case "leading":
-          if (r.value !== undefined) c.add({ kind: "typography", lineHeight: r.value, at });
+          if (r.value !== undefined) type.lineHeight = r.value;
           break;
         case "align":
-          if (r.text !== undefined) c.add({ kind: "typography", align: r.text as never, at });
+          if (r.text !== undefined) type.align = r.text as never;
           break;
         case "italic":
-          c.add({ kind: "typography", italic: true, at });
+          type.italic = true;
+          break;
+        case "transform":
+          if (r.text !== undefined) type.transform = r.text as never;
           break;
         case "color":
           if (r.hex !== undefined && r.role !== undefined) c.add({ kind: "color", hex: r.hex, role: r.role, at });
@@ -159,6 +183,8 @@ function emitClasses(c: FactCollector, classes: readonly string[], at: Provenanc
       }
     }
   }
+
+  if (Object.keys(type).length > 0) c.add({ kind: "typography", ...type, at });
 
   // One border fact per element, carrying every side the classes named — this is
   // what makes `border-l-4 rounded-2xl` readable as a side-tab.

--- a/src/core/extractors/web/tailwind-resolver.ts
+++ b/src/core/extractors/web/tailwind-resolver.ts
@@ -52,6 +52,18 @@ export const LEADING: Record<string, number> = {
 export const BORDER_WIDTHS: Record<string, number> = { "": 1, "0": 0, "2": 2, "4": 4, "8": 8 };
 
 /**
+ * Tailwind's text-transform utilities, mapped to the CSS values `TextTransform`
+ * already names. `normal-case` is the explicit reset and resolves to `none`, so a
+ * later utility can undo an earlier one rather than leaving the field undefined.
+ */
+export const TEXT_TRANSFORMS: Record<string, "uppercase" | "lowercase" | "capitalize" | "none"> = {
+  uppercase: "uppercase",
+  lowercase: "lowercase",
+  capitalize: "capitalize",
+  "normal-case": "none",
+};
+
+/**
  * The default palette, abbreviated to the hues a tell actually keys on.
  *
  * Not the whole palette: the rules that read colour ask "is this the AI purple",
@@ -71,7 +83,7 @@ export const PALETTE: Record<string, string> = {
 };
 
 export interface Resolved {
-  kind: "spacing" | "radius" | "fontSize" | "weight" | "tracking" | "leading" | "borderWidth" | "color" | "align" | "italic";
+  kind: "spacing" | "radius" | "fontSize" | "weight" | "tracking" | "leading" | "borderWidth" | "color" | "align" | "italic" | "transform";
   /** Numeric value, in px or em or a ratio depending on kind. */
   value?: number;
   hex?: string;
@@ -216,6 +228,17 @@ export function resolveClass(raw: string, overrides: Partial<Record<string, numb
   }
 
   if (token === "italic") out.push({ kind: "italic", value: 1 });
+
+  // text-transform. Bare tokens, like `italic` — no `text-` prefix to key on.
+  //
+  // These are not cosmetic to resolve. `wide-tracking` already EXEMPTS uppercase
+  // text, because wide tracking on small all-caps is correct typography; that
+  // exemption simply never fired, because this resolver dropped the token and the
+  // rule saw `transform: undefined`. An exemption that cannot fire does not read
+  // as NOT-EVALUATED — it reads as a false positive, silently, because `needs` is
+  // kind-granular and `typography` was present all along.
+  const transform = TEXT_TRANSFORMS[token];
+  if (transform !== undefined) out.push({ kind: "transform", text: transform });
   return out;
 }
 

--- a/tests/field-corpus/dana-workspace-settings-tsx/verdicts.json
+++ b/tests/field-corpus/dana-workspace-settings-tsx/verdicts.json
@@ -1,11 +1,11 @@
 {
   "page": "WorkspaceSettings.tsx",
   "pinnedBy": "snapshot",
-  "why": "Real React from the dana-ui product, outside this repo. Snapshotted because a corpus that follows a live external project is not a measurement — it drifts under you and the verdicts stop meaning anything. Origin: dana-ui/src/desktop-ui/components/WorkspaceSettings.tsx, copied 2026-08-28.",
+  "why": "Real React from the dana-ui product, outside this repo. Snapshotted because a corpus that follows a live external project is not a measurement — it drifts under you and the verdicts stop meaning anything. Origin: dana-ui/src/desktop-ui/components/WorkspaceSettings.tsx, copied 2026-08-28. CENSUS FLOOR LOWERED 219 -> 210 on 2026-08-31, and the reason is consolidation, not blindness: the jsx-tailwind extractor now emits ONE typography fact per element (as the html-cascade reference extractor always has) instead of one per utility. Measured on this page before and after: 31 typography facts carrying 31 field values became 22 facts carrying 31. Not one field value was lost, and the fact-count delta of 9 is exactly the drop in the census.",
   "sha256": "60129e8874d9d2843c9fab3a9d0e4ee258c86ddf4454e7be39b76ea93e578746",
   "extractor": "jsx-tailwind",
   "censusFloor": {
-    "total": 219,
+    "total": 210,
     "kinds": [
       "border",
       "radius",

--- a/tests/field-corpus/hvs-cta-section-tsx/verdicts.json
+++ b/tests/field-corpus/hvs-cta-section-tsx/verdicts.json
@@ -1,10 +1,10 @@
 {
   "page": "CtaSection.tsx",
   "pinnedBy": "snapshot",
-  "why": "A real working product screen from hvs — a marketing CTA with a form, which is a different component genre from the settings panel already pinned from dana-ui. Genre drives which rules can fire, so a second jsx-tailwind page of the same kind would have added nothing. Origin: hvs/components/marketing/cta-section.tsx, copied 2026-08-30, parity verified.",
+  "why": "A real working product screen from hvs — a marketing CTA with a form, which is a different component genre from the settings panel already pinned from dana-ui. Genre drives which rules can fire, so a second jsx-tailwind page of the same kind would have added nothing. Origin: hvs/components/marketing/cta-section.tsx, copied 2026-08-30, parity verified. CENSUS FLOOR LOWERED 102 -> 92 on 2026-08-31, and the reason is consolidation, not blindness: the jsx-tailwind extractor now emits ONE typography fact per element (as the html-cascade reference extractor always has) instead of one per utility. Measured on this page before and after: 24 typography facts carrying 24 field values became 14 facts carrying 32. The reader sees MORE than before: the 8 extra field values are text-transform, which the resolver used to drop on the floor. The fact-count delta of 10 is exactly the drop in the census.",
   "sha256": "08b6912138cd681fdb4cb44b738a55f1f7a68a013369077b5ac433207b39dc02",
   "extractor": "jsx-tailwind",
-  "censusFloor": { "total": 102, "kinds": ["border", "color", "radius", "spacing", "structure", "text", "typography"] },
+  "censusFloor": { "total": 92, "kinds": ["border", "color", "radius", "spacing", "structure", "text", "typography"] },
   "adjudicatedOn": "2026-08-30",
   "adjudicatedBy": "tell-family author",
   "needsOwnerReview": true,
@@ -12,8 +12,8 @@
   "verdicts": [
     {
       "key": "wide-tracking@line:97#0.20em",
-      "verdict": "fp-open",
-      "reason": "The element is `className=\"text-[12px] font-sans font-[900] uppercase tracking-[0.2em] ...\"` — it IS uppercase, and `wide-tracking` already exempts uppercase text (`t.transform !== \"uppercase\"`). Wide tracking on small all-caps is correct typography, which the rule knows. The exemption never applies because the jsx-tailwind extractor does not resolve Tailwind's `uppercase` utility into a `text-transform` fact, so the rule cannot see what it is designed to check. Fixable in the extractor, not the rule.",
+      "verdict": "fp",
+      "reason": "FIXED, and one layer deeper than the row first recorded. The element is className=\"text-[12px] font-sans font-[900] uppercase tracking-[0.2em] ...\": it IS uppercase, and wide-tracking already exempts uppercase because wide tracking on small all-caps is correct typography. Two things had to change. The resolver never mapped Tailwind's uppercase utility to a text-transform value, so the field was empty; and even once it did, the exemption still could not fire, because this extractor emitted ONE TYPOGRAPHY FACT PER UTILITY — the tracking fact and the transform fact were different facts, and no rule that correlates two typography properties on one element could ever work here. The extractor now emits one typography fact per element, as the html-cascade reference extractor always has. tight-leading, which needs lineHeight and sizePx together, was blind on this extractor for the same reason and is fixed by the same change. Note the shape of this class of bug: needs is kind-granular, so typography was present and the rule RAN; an exemption whose field is never populated does not report NOT-EVALUATED, it reports a false positive, silently. The corpus is the only instrument that catches it.",
       "message": "letter-spacing 0.20em on non-uppercase text — 3 elements, first at line 97"
     }
   ]

--- a/tests/jsx-typography-one-fact-per-element.test.ts
+++ b/tests/jsx-typography-one-fact-per-element.test.ts
@@ -1,0 +1,107 @@
+/**
+ * One typography fact per element — the shape `html-cascade` has always emitted,
+ * and the thing `jsx-tailwind` was missing.
+ *
+ * Found through a false positive on a real page. `hvs/components/marketing/
+ * cta-section.tsx` has `className="text-[12px] font-sans font-[900] uppercase
+ * tracking-[0.2em]"`, and `wide-tracking` fired on it — even though that rule
+ * already EXEMPTS uppercase text, because wide tracking on small all-caps is
+ * correct typography.
+ *
+ * Two separate causes had to be removed, and the second is the interesting one:
+ *
+ *  1. `resolveClass` never mapped Tailwind's `uppercase` utility to anything, so
+ *     the `transform` field was empty.
+ *  2. Even once it did, the exemption still could not fire — this extractor
+ *     emitted one typography fact PER UTILITY, so the tracking value and the
+ *     transform value lived on different facts. No rule that correlates two
+ *     typography properties on one element could work here at all.
+ *
+ * `tight-leading` needs `lineHeight` and `sizePx` together and was blind on this
+ * extractor for exactly the same reason. It is guarded below so the next person
+ * to touch this cannot fix one victim and leave the other.
+ *
+ * The class of bug is worth naming: `needs` is KIND-granular. `typography` was
+ * present the whole time, so the rules RAN. An exemption whose field is never
+ * populated does not report NOT-EVALUATED — it reports a false positive, in
+ * silence.
+ *
+ * Red probe: revert either cause and this file reddens. Dropping the
+ * TEXT_TRANSFORMS branch fails "resolves the uppercase utility"; going back to
+ * one fact per utility fails "carries tracking and transform on the SAME fact"
+ * and both end-to-end rule assertions. The two control cases stay green through
+ * all of it.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveClass } from "../src/core/extractors/web/tailwind-resolver.js";
+import { extractJsx } from "../src/core/extractors/web/jsx-extractor.js";
+import { lintTell } from "../src/core/tell-lint.js";
+import { extractorById } from "../src/core/design-facts/index.js";
+import type { DesignFact } from "../src/core/design-facts/index.js";
+
+const JSX = extractorById("jsx-tailwind");
+if (JSX === undefined) throw new Error("jsx-tailwind must be registered");
+
+const typography = (facts: readonly DesignFact[]) =>
+  facts.filter((f): f is Extract<DesignFact, { kind: "typography" }> => f.kind === "typography");
+
+const fire = (src: string, checkId: string) =>
+  lintTell(extractJsx(src, "page.tsx").collector.facts(), JSX).findings.filter((f) => f.checkId === checkId);
+
+describe("the tailwind resolver reads text-transform", () => {
+  it("resolves the uppercase utility", () => {
+    expect(resolveClass("uppercase")).toEqual([{ kind: "transform", text: "uppercase" }]);
+  });
+
+  it("resolves the rest of the family, including the reset", () => {
+    expect(resolveClass("lowercase")).toEqual([{ kind: "transform", text: "lowercase" }]);
+    expect(resolveClass("capitalize")).toEqual([{ kind: "transform", text: "capitalize" }]);
+    expect(resolveClass("normal-case")).toEqual([{ kind: "transform", text: "none" }]);
+  });
+
+  it("still refuses tokens it does not carry", () => {
+    // The control. A resolver that answered everything would be worse than one
+    // that answers nothing, because the unresolved count is what keeps the report honest.
+    expect(resolveClass("uppercased")).toEqual([]);
+    expect(resolveClass("text-balance")).toEqual([]);
+  });
+});
+
+describe("an element's utilities become one typography fact", () => {
+  it("carries tracking and transform on the SAME fact", () => {
+    const facts = extractJsx(`<p className="text-[12px] uppercase tracking-[0.2em]">Go</p>`, "page.tsx")
+      .collector.facts();
+    const withTracking = typography(facts).filter((t) => t.letterSpacingEm !== undefined);
+    expect(withTracking).toHaveLength(1);
+    expect(withTracking[0]?.transform).toBe("uppercase");
+    expect(withTracking[0]?.sizePx).toBe(12);
+  });
+
+  it("keeps two elements apart", () => {
+    // The merge is per element, not per file: uppercase on one must not exempt the other.
+    const facts = extractJsx(
+      `<div><p className="uppercase">A</p><p className="tracking-[0.2em] text-[12px]">B</p></div>`,
+      "page.tsx",
+    ).collector.facts();
+    const withTracking = typography(facts).filter((t) => t.letterSpacingEm !== undefined);
+    expect(withTracking).toHaveLength(1);
+    expect(withTracking[0]?.transform).toBeUndefined();
+  });
+});
+
+describe("the rules that correlate two typography fields now work here", () => {
+  it("wide-tracking stays silent on small all-caps", () => {
+    expect(fire(`<p className="text-[12px] uppercase tracking-[0.2em]">Ship</p>`, "wide-tracking")).toEqual([]);
+  });
+
+  it("wide-tracking still fires when the text is NOT uppercase", () => {
+    // The control that proves the exemption is an exemption and not a mute button.
+    expect(fire(`<p className="text-[12px] tracking-[0.2em]">Ship</p>`, "wide-tracking").length).toBeGreaterThan(0);
+  });
+
+  it("tight-leading sees line-height and size together", () => {
+    // The sibling victim. `leading-3` is 0.75 and `text-[16px]` is body-sized, so
+    // the rule has both halves of its predicate for the first time on this extractor.
+    expect(fire(`<p className="text-[16px] leading-3">Ship</p>`, "tight-leading").length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #254.

## The issue understated the cause

`#254` called this an extractor gap: Tailwind `uppercase` never resolved, so `wide-tracking` could not apply its own uppercase exemption. True, and **not sufficient** — fixing only that changed nothing.

This extractor emitted **one typography fact per utility**. The tracking value and the transform value lived on different facts, so no rule correlating two typography properties on one element could ever work here. `tight-leading` (needs `lineHeight` AND `sizePx`) was blind for the same reason and is fixed by the same change.

The extractor now emits **one typography fact per element** — the shape `html-cascade` (the reference extractor) has always used — following the one-border-fact precedent already in that function.

## The class of bug, named for the next author

`needs` is **kind-granular**. `typography` was present the whole time, so the rules RAN. An exemption whose field is never populated does not report NOT-EVALUATED; it reports a false positive, silently. The corpus is currently the only instrument that catches this.

## Census floors drop — consolidation, not blindness

Measured on each page before and after, by reverting the change and re-running:

| page | facts before | values before | facts after | values after | census |
|---|---|---|---|---|---|
| dana | 31 | 31 | 22 | **31** | 219 -> 210 |
| hvs | 24 | 24 | 14 | **32** | 102 -> 92 |

dana loses **zero** field values; its 9 fewer facts are exactly its census delta. hvs **gains 8** values (the `text-transform` the resolver used to drop) and its 10 fewer facts are exactly its delta. The arithmetic is written into each `why` field so nobody has to trust this description.

## Red probes — both knobs, separately

| sabotage | result |
|---|---|
| drop the resolver `TEXT_TRANSFORMS` branch | 4 of 8 fail |
| restore one-fact-per-utility | 3 of 8 fail, incl. `tight-leading` |

Two controls stay green through both: a token the resolver must still refuse, and `wide-tracking` on text that is NOT uppercase (proving the exemption is an exemption, not a mute button).

## Corpus

`hvs-cta-section-tsx` `wide-tracking@line:97#0.20em`: `fp-open` -> **`fp`** (tripwire).

## Gates

typecheck, lint, bundler clean; **245 files / 4292 passed / 0 failed**; field corpus 49/49.

Part of the tell-lint anti-flop closeout (#236 #237 #238 #252 #253 #254 #255).