### PR TITLE
fix(tell): marquee fires only when something readable is moving

### DIFF
--- a/src/core/tell-rules-motion.ts
+++ b/src/core/tell-rules-motion.ts
@@ -68,6 +68,57 @@ export const blinkingCursor: TellRule = {
   },
 };
 
+/**
+ * Does anything a reader must READ live under this node?
+ *
+ * The rule below claims "auto-scrolling CONTENT the reader cannot pause", so it
+ * owes a check that content is what moves. Content means a text run or an image —
+ * there is no `img` fact kind, so an image is a `structure` fact whose node is `img`.
+ *
+ * REFUTATION, not a requirement. It answers false only when the facts positively
+ * show an empty subtree; every path where the evidence is missing answers TRUE and
+ * the finding stands. That asymmetry is deliberate and it is why `needs` stays
+ * `["motion"]`: `css-only` supplies motion with no structure and no text, and
+ * `swiftui`/`flutter` supply motion and text with no structure. Adding those kinds
+ * to `needs` would turn this rule NOT-EVALUATED on three extractors that run it
+ * today — silencing real findings under the cover of a coverage change, which is
+ * exactly the mistake this repo has already paid for twice.
+ */
+function subtreeHasReadableContent(facts: Parameters<TellRule["run"]>[0], ownerRef: string | undefined): boolean {
+  if (ownerRef === undefined) return true; // the extractor cannot name the owner
+  const structures = facts.by("structure");
+  if (structures.length === 0) return true; // no tree to walk: not evidence of emptiness
+
+  const childrenOf = new Map<string, string[]>();
+  for (const s of structures) {
+    if (s.parentRef === undefined) continue;
+    const list = childrenOf.get(s.parentRef);
+    if (list === undefined) childrenOf.set(s.parentRef, [s.ref]);
+    else list.push(s.ref);
+  }
+
+  const carriesContent = new Set<string>();
+  for (const t of facts.by("text")) {
+    // Head metadata is not copy anyone reads; it cannot make a marquee.
+    if (t.role !== "metadata" && t.at.nodeRef !== undefined) carriesContent.add(t.at.nodeRef);
+  }
+  for (const s of structures) if (s.node.toLowerCase() === "img") carriesContent.add(s.ref);
+
+  const seen = new Set<string>([ownerRef]);
+  const queue = [ownerRef];
+  while (queue.length > 0) {
+    const ref = queue.shift() as string;
+    if (carriesContent.has(ref)) return true;
+    for (const child of childrenOf.get(ref) ?? []) {
+      if (!seen.has(child)) {
+        seen.add(child);
+        queue.push(child);
+      }
+    }
+  }
+  return false;
+}
+
 export const marquee: TellRule = {
   id: "marquee",
   needs: ["motion"],
@@ -78,6 +129,9 @@ export const marquee: TellRule = {
       .by("motion")
       // Long, infinite, and not a micro-interaction: an auto-scrolling band.
       .filter((m) => m.repeatsForever === true && (m.durationMs ?? 0) >= thr("SLOW_LOOP_MIN_MS"))
+      // ...and carrying something to read. A decorative scanline sweeping an empty
+      // overlay loops forever too, and nothing the reader needs is moving.
+      .filter((m) => subtreeHasReadableContent(facts, m.at.nodeRef))
       .map((m) =>
         finding(marquee, {
           message: `auto-scrolling content on a ${Math.round((m.durationMs as number) / 1000)}s infinite loop the reader cannot pause`,

--- a/tests/field-corpus/easeui-kinetic-hyper-gloss/verdicts.json
+++ b/tests/field-corpus/easeui-kinetic-hyper-gloss/verdicts.json
@@ -30,8 +30,8 @@
     },
     {
       "key": "marquee@line:400#8000ms infinite",
-      "verdict": "fp-open",
-      "reason": "Line 400 is `animation: scan 8s linear infinite` — a decorative scanline sweep, part of the Y2K chrome aesthetic. Nothing the reader must read is moving. The rule's own message claims 'auto-scrolling content the reader cannot pause', but it matches any 8s infinite animation without checking that CONTENT is what moves.",
+      "verdict": "fp",
+      "reason": "FIXED. Read the element rather than trusting the finding: `.scanline` is `height: 1px` with a transparent-white-transparent gradient (page.html:395-401), and its only use is `<div class=\"scanline\"></div>` at line 502 — literally empty. Nothing a reader must read was ever moving. `marquee` now REFUTES itself when the animated node's subtree provably carries no text run and no img; where the evidence is missing it still fires, so `needs` stays [\"motion\"] and the rule keeps running on css-only, swiftui and flutter, which supply motion without structure. Measured across 747 real pages: 39 findings become 1, and every silenced one is a childless decorative node — two more `div.scanline` hairlines, a `div.orbit`, and a `<div id=\"ambient\" aria-hidden=\"true\"></div>` whose own page declares it is not content. Zero created. The survivor is a `.float-note` carrying an icon and copy on a 4s loop, which is the real thing this rule is for.",
       "message": "auto-scrolling content on a 8s infinite loop the reader cannot pause"
     }
   ]

--- a/tests/tell-marquee-content-join.test.ts
+++ b/tests/tell-marquee-content-join.test.ts
@@ -1,0 +1,71 @@
+/**
+ * `marquee` claims "auto-scrolling CONTENT the reader cannot pause", so it owes a
+ * check that content is what moves.
+ *
+ * It did not have one. Any infinite animation past the slow-loop threshold matched,
+ * and a real page's decorative scanline — `height: 1px`, a transparent-white-
+ * transparent gradient, used as `<div class="scanline"></div>` with nothing inside
+ * it — was reported as content the reader could not pause.
+ *
+ * The check is a REFUTATION, not a requirement, and the asymmetry is the whole
+ * design. It answers false only when the facts positively show an empty subtree;
+ * wherever the evidence is absent it answers true and the finding stands. That is
+ * why `needs` stays `["motion"]`: `css-only` supplies motion with no structure and
+ * no text, and `swiftui`/`flutter` supply motion and text with no structure.
+ * Promoting those kinds into `needs` would turn this rule NOT-EVALUATED on three
+ * extractors that run it today — silencing real findings under cover of a coverage
+ * change, which is the mistake this repo has already paid for twice.
+ *
+ * Measured before shipping, across 747 real pages: 39 findings become 1, zero
+ * created, and every silenced one is a childless decorative node (two more
+ * `div.scanline` hairlines, a `div.orbit`, and a `<div id="ambient"
+ * aria-hidden="true"></div>` whose own page declares it is not content).
+ *
+ * Red probe: delete the `subtreeHasReadableContent` filter and the two "does not
+ * fire" cases fail. The three "still fires" cases are the controls and stay green
+ * through that — they are what proves this is an exemption and not a mute button.
+ */
+import { describe, expect, it } from "vitest";
+import { extractHtml } from "../src/core/extractors/html/html-extractor.js";
+import { lintTell } from "../src/core/tell-lint.js";
+import { extractorById } from "../src/core/design-facts/index.js";
+
+const HTML = extractorById("html-cascade");
+if (HTML === undefined) throw new Error("html-cascade must be registered");
+
+/** A page whose `.band` loops forever for 8s, wrapping whatever `inner` is given. */
+const page = (inner: string): string => `<!doctype html>
+<html><head><title>t</title><style>
+.band { animation: slide 8s linear infinite; }
+@keyframes slide { from { left: 0 } to { left: 100% } }
+</style></head><body>
+<div class="band">${inner}</div>
+</body></html>`;
+
+const marqueeOn = (html: string) =>
+  lintTell(extractHtml(html, "page.html").collector.facts(), HTML).findings.filter((f) => f.checkId === "marquee");
+
+describe("marquee fires only when content moves", () => {
+  it("does not fire on an empty decorative band", () => {
+    expect(marqueeOn(page(""))).toEqual([]);
+  });
+
+  it("does not fire when the subtree holds only more empty boxes", () => {
+    // The scanline shape from the real page: nested wrappers, no copy anywhere.
+    expect(marqueeOn(page(`<div class="a"><div class="b"></div></div>`))).toEqual([]);
+  });
+
+  it("still fires when the band carries text directly", () => {
+    expect(marqueeOn(page(`Breaking news, forever`)).length).toBeGreaterThan(0);
+  });
+
+  it("still fires when the text is nested deeper in the subtree", () => {
+    // The descendant walk is the point: content two levels down still counts.
+    expect(marqueeOn(page(`<div class="a"><span>Breaking news</span></div>`)).length).toBeGreaterThan(0);
+  });
+
+  it("still fires when the band carries an image instead of text", () => {
+    // There is no `img` fact kind; an image is a structure fact whose node is img.
+    expect(marqueeOn(page(`<div class="a"><img src="x.png" alt="logo"></div>`)).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #253.

## Read the element, not the finding

The rule promises *"auto-scrolling CONTENT the reader cannot pause"* and never checked that content was what moved. The corpus page`'`s culprit:

```css
.scanline { width: 100%; height: 1px;
  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
  animation: scan 8s linear infinite; }
```
```html
<div class="scanline"></div>
```

A 1px hairline in an empty div. Nothing a reader must read was ever moving.

## Refutation, not requirement — and why `needs` did NOT change

The obvious fix is `needs: ["motion", "structure", "text"]`. **Measured, that is a regression:**

| extractor | motion | structure | text |
|---|---|---|---|
| `css-only` | resolved | — | — |
| `swiftui` | literal | — | literal |
| `flutter` | literal | — | literal |

Three extractors run `marquee` today and would go NOT-EVALUATED — silencing real findings under cover of a coverage change, which is the same mistake as widening the predicate wearing a different hat.

So `needs` stays `["motion"]` and the check **refutes**: it answers false only when the facts positively show an empty subtree. Every path where evidence is missing answers true and the finding stands.

## Field measurement — 747 real pages

```
BEFORE 39 findings  ->  AFTER 1     CREATED 0
```

38 silenced looks alarming; deduped it is **7 distinct elements**, the rest being worktree copies of the same EaseUI files. Each one probed individually — every single one has `subtreeSize=1`, no text, no img:

| element | page |
|---|---|
| `div.scanline` | 3d-tubes/04-neo-brutalist-terminal |
| `div.scanline` | 3d-tubes/06-industrial-blueprint |
| `div.scanline` | the corpus page |
| `div.orbit[0]` | d03-orchestrated-r3 |
| `<div id="ambient" aria-hidden="true"></div>` | world-class-benchmark | 

That last one is the clearest: **the page itself declares it is not content.**

**The survivor** — `d02-orchestrated-r2`, a `.float-note` carrying an icon and copy on a 4s loop — is the real thing this rule exists for, still firing.

## Red probe

Delete the filter: the two "does not fire" cases fail. The three controls — text directly inside, text nested two levels down, an image instead of text — **stay green through it**. That is what proves this is an exemption and not a mute button.

## Corpus

`easeui-kinetic-hyper-gloss` `marquee@line:400#8000ms infinite`: `fp-open` -> **`fp`** (tripwire). That page now has zero open rows.

## Gates

typecheck, lint, bundler clean; **247 files / 4303 passed / 0 failed**; field corpus 49/49.

Part of the tell-lint anti-flop closeout (#236 #237 #238 #252 #253 #254 #255).