### PR TITLE
fix(tell): L3 compares finding SETS, and the unresolved-sheet caveat is scoped by host

### DIFF
--- a/src/commands/tell-lint.ts
+++ b/src/commands/tell-lint.ts
@@ -27,6 +27,7 @@ import { locateBrowser } from "../core/rendered/browser-session.js";
 import { capturePage } from "../core/rendered/capture-page.js";
 import { cdpUnavailableReason } from "../core/rendered/cdp-client.js";
 import { lintRendered } from "../core/tell-rules-rendered.js";
+import { splitUnresolvedSheets } from "../core/stylesheet-host-scope.js";
 import type { RenderedFinding } from "../core/tell-rules-rendered.js";
 
 const CMD = "tell-lint";
@@ -269,8 +270,22 @@ export async function runTellLint(args: ParsedArgs, cwd = process.cwd()): Promis
     if (f.unresolvedCount > 0) notes.push(`${f.unresolvedCount} unresolved read(s)`);
     // Named, not just counted: "3 stylesheets did not load" is actionable where a
     // bare undercount flag is not.
-    if (f.unresolvedSheets.length > 0) {
-      notes.push(`${f.unresolvedSheets.length} stylesheet(s) NOT LOADED — findings here are a floor, not a verdict`);
+    //
+    // And scoped, because an unscoped caveat is one the reader learns to skip: on
+    // 123 real pages this fired on 27% of them and about a third of those were a
+    // webfont loader and nothing else. A font sheet can cost a family name, so
+    // `overused-font` may under-fire; it cannot hide a layout. An unknown host can
+    // hide anything and keeps the strict wording. Both are still counted and named.
+    const sheets = splitUnresolvedSheets(f.unresolvedSheets);
+    if (sheets.strict.length > 0) {
+      notes.push(
+        `${sheets.strict.length} stylesheet(s) NOT LOADED (${sheets.strict.join(", ")}) — findings here are a floor, not a verdict`,
+      );
+    }
+    if (sheets.fontOnly.length > 0) {
+      notes.push(
+        `${sheets.fontOnly.length} font stylesheet(s) not loaded (${sheets.fontOnly.join(", ")}) — family facts may be missing, so overused-font may under-fire`,
+      );
     }
     if (f.waived > 0) notes.push(`${f.waived} waived in-file`);
     if (f.notEvaluated.length > 0) notes.push(`${f.notEvaluated.length} rule(s) NOT-EVALUATED`);

--- a/src/core/stylesheet-host-scope.ts
+++ b/src/core/stylesheet-host-scope.ts
@@ -1,0 +1,82 @@
+/**
+ * What an unresolved stylesheet could have been hiding.
+ *
+ * The binary never fetches remote CSS — that is the determinism contract — so any
+ * remote `<link>` makes a run an undercount. True, and it became noise: on 123 real
+ * pages, 27% reported UNDERCOUNT and roughly a third of those were nothing but a
+ * webfont loader. A caveat that fires on almost every page teaches the reader to
+ * skip it, and then it is not protecting anything.
+ *
+ * So the caveat is scoped to what the sheet can actually hide. A font CDN serves
+ * `@font-face` and little else: it can cost you a family name, so `overused-font`
+ * may under-fire, but it cannot hide a layout, a colour or a shadow. An unknown
+ * host can hide anything, and stays strict.
+ *
+ * Classified by HOST, deliberately not by URL SHAPE. Protocol-relative (`//…`) was
+ * the tempting proxy and it is wrong: `//` says nothing about content, so a
+ * protocol-relative layout sheet would be waved through — a new blind spot traded
+ * for the old noise.
+ *
+ * The residual blind spot is named rather than hidden: a font host that also serves
+ * layout CSS would be scoped too narrowly here. The allowlist is short and explicit
+ * so that risk stays inspectable.
+ */
+
+/** Hosts whose stylesheets carry webfonts and nothing that shapes a layout. */
+const FONT_CDN_HOSTS = new Set([
+  "fonts.googleapis.com",
+  "fonts.gstatic.com",
+  "use.typekit.net",
+  "p.typekit.net",
+  "fonts.bunny.net",
+  "use.fontawesome.com",
+]);
+
+/**
+ * Hosts that serve everything, where only certain paths are fonts.
+ *
+ * Kept apart from the host set on purpose: an entry like
+ * `"cdn.jsdelivr.net/fontsource"` in a set of HOSTS can never match anything, and
+ * dead config in an allowlist is worse than a missing entry — it reads as coverage
+ * that does not exist. This repo's own test caught exactly that before it shipped.
+ */
+const PATH_SCOPED_FONT_HOSTS: Record<string, RegExp> = {
+  // `/npm/@fontsource/inter/...` — the `@` is why a bare `/fontsource` misses.
+  "cdn.jsdelivr.net": /(?:^|[/@])fontsource/i,
+};
+
+/**
+ * True when this href points at a known webfont CDN.
+ *
+ * Parsing is deliberate about protocol-relative and relative hrefs: `//host/x.css`
+ * is given a scheme so the host is read correctly, and anything without a host at
+ * all (a local path) is NOT a font CDN — a local sheet that failed to resolve is a
+ * real gap, not a benign one.
+ */
+export function isFontCdnHref(href: string): boolean {
+  const trimmed = href.trim();
+  const withScheme = trimmed.startsWith("//") ? `https:${trimmed}` : trimmed;
+  let host: string;
+  try {
+    host = new URL(withScheme).host.toLowerCase();
+  } catch {
+    return false; // relative or unparseable: cannot claim it is benign
+  }
+  if (FONT_CDN_HOSTS.has(host)) return true;
+  const pathRule = PATH_SCOPED_FONT_HOSTS[host];
+  return pathRule !== undefined && pathRule.test(new URL(withScheme).pathname);
+}
+
+export interface SheetScopeSplit {
+  /** Sheets that can hide anything. The strict caveat applies. */
+  strict: string[];
+  /** Known webfont sheets. They can only cost family facts. */
+  fontOnly: string[];
+}
+
+export function splitUnresolvedSheets(hrefs: readonly string[]): SheetScopeSplit {
+  const strict: string[] = [];
+  const fontOnly: string[] = [];
+  for (const href of hrefs) (isFontCdnHref(href) ? fontOnly : strict).push(href);
+  return { strict, fontOnly };
+}

--- a/tests/field-corpus.test.ts
+++ b/tests/field-corpus.test.ts
@@ -24,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import { lintFileByExtractor } from "../src/core/lint-file-by-extractor.js";
 import type { FactCensus } from "../src/core/lint-file-by-extractor.js";
 import { extractorById, EXTRACTOR_PROFILES } from "../src/core/design-facts/index.js";
+import { withOrdinals } from "./helpers/finding-key.js";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const CORPUS = join(ROOT, "tests", "field-corpus");
@@ -49,31 +50,10 @@ interface CorpusPage {
   verdicts: VerdictRow[];
 }
 
-/**
- * The verdict key.
- *
- * Built from the stable half of the dedup key the linter already uses at
- * `tell-lint.ts:101` (`checkId ∥ line ∥ nodeRef ∥ message`). `message` is deliberately
- * excluded: `collapseRepeated` folds an element count into it, so keying on message
- * would turn every count change into a phantom new finding.
- *
- * Measured over 73 real files / 263 findings, this key collides once when scoped per
- * page — hence the ordinal, which is inert whenever the key is already unique.
- */
-function keyOf(f: { checkId: string; line?: number; nodeRef?: string; actual?: string }): string {
-  const locator = f.nodeRef ?? (f.line !== undefined && f.line !== null ? `line:${f.line}` : "doc");
-  return `${f.checkId}@${locator}#${f.actual ?? "-"}`;
-}
-
-function withOrdinals(findings: ReadonlyArray<{ checkId: string; line?: number; nodeRef?: string; actual?: string }>): string[] {
-  const seen = new Map<string, number>();
-  return findings.map((f) => {
-    const base = keyOf(f);
-    const n = seen.get(base) ?? 0;
-    seen.set(base, n + 1);
-    return n === 0 ? base : `${base}~${n}`;
-  });
-}
+// The verdict key and its ordinal disambiguation live in one shared place —
+// `tests/helpers/finding-key.ts` — because the metamorphic laws need the SAME
+// notion of "the same finding". Two copies of an identity function drift, and the
+// drift would surface as a law and this corpus disagreeing about what they mean.
 
 function pageDirs(): string[] {
   if (!existsSync(CORPUS)) return [];

--- a/tests/helpers/finding-key.ts
+++ b/tests/helpers/finding-key.ts
@@ -1,0 +1,41 @@
+/**
+ * The stable identity of a finding, shared by every test that has to say
+ * "the same finding" across two runs.
+ *
+ * Built from the stable half of the dedup key the linter itself uses
+ * (`checkId ∥ line ∥ nodeRef ∥ message`). `message` is deliberately EXCLUDED:
+ * `collapseRepeated` folds an element count into it, so keying on message turns
+ * every count change into a phantom new finding — and, worse, makes any law
+ * asserted over those keys flaky by construction.
+ *
+ * Measured over 73 real files / 263 findings, this key collides once when scoped
+ * per page — hence `withOrdinals`, which is inert wherever the key is unique.
+ *
+ * This lives in one file on purpose. It was copied into the field corpus first
+ * and needed second by the metamorphic laws; two copies of an identity function
+ * drift, and the drift would show up as a law and a corpus disagreeing about
+ * what "the same finding" means.
+ */
+
+export interface KeyableFinding {
+  checkId: string;
+  line?: number;
+  nodeRef?: string;
+  actual?: string;
+}
+
+export function keyOf(f: KeyableFinding): string {
+  const locator = f.nodeRef ?? (f.line !== undefined && f.line !== null ? `line:${f.line}` : "doc");
+  return `${f.checkId}@${locator}#${f.actual ?? "-"}`;
+}
+
+/** Keys in emission order, disambiguating the rare collision with a suffix. */
+export function withOrdinals(findings: readonly KeyableFinding[]): string[] {
+  const seen = new Map<string, number>();
+  return findings.map((f) => {
+    const base = keyOf(f);
+    const n = seen.get(base) ?? 0;
+    seen.set(base, n + 1);
+    return n === 0 ? base : `${base}~${n}`;
+  });
+}

--- a/tests/stylesheet-host-scope.test.ts
+++ b/tests/stylesheet-host-scope.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The unresolved-stylesheet caveat, scoped by host.
+ *
+ * The binary never fetches remote CSS, so any remote `<link>` makes a run an
+ * undercount. True, and it became noise: on 123 real pages 27% reported UNDERCOUNT
+ * and roughly a third of those were a webfont loader and nothing else. A caveat
+ * that fires on almost every page is one the reader learns to skip, and then it is
+ * protecting nothing.
+ *
+ * The tempting shortcut was to classify by URL SHAPE — treat protocol-relative
+ * `//…` as benign. That trades the old noise for a NEW blind spot, because `//`
+ * says nothing at all about content: a protocol-relative layout sheet would be
+ * waved through. The two "protocol-relative" cases below are the ones that would
+ * have caught that, and they pull in opposite directions on purpose.
+ */
+import { describe, expect, it } from "vitest";
+import { isFontCdnHref, splitUnresolvedSheets } from "../src/core/stylesheet-host-scope.js";
+
+describe("a font CDN can cost a family name, not a layout", () => {
+  it("recognises the known webfont hosts", () => {
+    expect(isFontCdnHref("https://fonts.googleapis.com/css2?family=Inter")).toBe(true);
+    expect(isFontCdnHref("https://fonts.gstatic.com/s/inter/v12/x.woff2")).toBe(true);
+    expect(isFontCdnHref("https://use.typekit.net/abc.css")).toBe(true);
+    expect(isFontCdnHref("https://fonts.bunny.net/css?family=inter")).toBe(true);
+  });
+
+  it("reads the host through a protocol-relative href", () => {
+    expect(isFontCdnHref("//fonts.googleapis.com/css2?family=Inter")).toBe(true);
+  });
+
+  it("does NOT wave through a protocol-relative sheet from anywhere else", () => {
+    // The whole reason classification is by host and not by URL shape.
+    expect(isFontCdnHref("//cdn.example.com/layout.css")).toBe(false);
+  });
+
+  it("treats an unresolved LOCAL sheet as a real gap", () => {
+    // A relative href that failed to resolve hides whatever it contained.
+    expect(isFontCdnHref("./styles/base.css")).toBe(false);
+    expect(isFontCdnHref("../shared/theme.css")).toBe(false);
+  });
+
+  it("scopes a shared CDN by path, not by host alone", () => {
+    // jsDelivr serves everything; only its fontsource paths are fonts.
+    expect(isFontCdnHref("https://cdn.jsdelivr.net/npm/@fontsource/inter/index.css")).toBe(true);
+    expect(isFontCdnHref("https://cdn.jsdelivr.net/npm/bootstrap/dist/css/bootstrap.min.css")).toBe(false);
+  });
+
+  it("does not crash on an unparseable href", () => {
+    expect(isFontCdnHref("")).toBe(false);
+    expect(isFontCdnHref("http://[not a url")).toBe(false);
+  });
+});
+
+describe("splitting keeps both halves — nothing vanishes", () => {
+  it("separates font sheets from everything else, losing none", () => {
+    const hrefs = [
+      "https://fonts.googleapis.com/css2?family=Inter",
+      "https://cdn.example.com/layout.css",
+      "//fonts.gstatic.com/s/x.woff2",
+      "./styles/base.css",
+    ];
+    const { strict, fontOnly } = splitUnresolvedSheets(hrefs);
+    expect(fontOnly).toEqual(["https://fonts.googleapis.com/css2?family=Inter", "//fonts.gstatic.com/s/x.woff2"]);
+    expect(strict).toEqual(["https://cdn.example.com/layout.css", "./styles/base.css"]);
+    // The count is the contract: a page's caveat must still add up to what it had.
+    expect(strict.length + fontOnly.length).toBe(hrefs.length);
+  });
+
+  it("handles the empty case without inventing a caveat", () => {
+    expect(splitUnresolvedSheets([])).toEqual({ strict: [], fontOnly: [] });
+  });
+});

--- a/tests/tell-metamorphic-laws.test.ts
+++ b/tests/tell-metamorphic-laws.test.ts
@@ -29,6 +29,7 @@ import { lintTell, TELL_RULES } from "../src/core/tell-lint.js";
 import { extractorById } from "../src/core/design-facts/index.js";
 import type { DesignFact } from "../src/core/design-facts/fact-kinds.js";
 import type { Provenance } from "../src/core/design-facts/fact-model.js";
+import { withOrdinals } from "./helpers/finding-key.js";
 
 const html = extractorById("html-cascade");
 if (html === undefined) throw new Error("html-cascade must be registered");
@@ -65,6 +66,19 @@ function findingsFor(facts: DesignFact[]): string[] {
   return lintTell(facts, html as never)
     .findings.map((f) => `${f.checkId}|${f.message}`)
     .sort();
+}
+
+/**
+ * The finding SET, by stable key, for L3.
+ *
+ * Deliberately not `findingsFor`: that keys on `message`, and `collapseRepeated`
+ * folds an element count into the message. Under duplication a count legitimately
+ * changes, so a message-keyed set would be red for a reason that is not a defect.
+ * `keyOf` is the identity the field corpus already uses — shared from one file so
+ * a law and the corpus cannot drift apart about what "the same finding" means.
+ */
+function keysFor(facts: DesignFact[]): string[] {
+  return withOrdinals(lintTell(facts, html as never).findings).sort();
 }
 
 /**
@@ -115,24 +129,50 @@ describe("metamorphic law L2 — fact order changes nothing", () => {
   });
 });
 
-describe("metamorphic law L3 — a duplicated fact never doubles a finding", () => {
+describe("metamorphic law L3 — a duplicated fact changes no finding", () => {
   /**
    * The law that closes a class. 210 duplicate facts once produced 54 findings where
    * they should have produced far fewer, and the fix went in inside one rule. Asserting
    * it at the sink covers every rule, including ones not yet written.
+   *
+   * WHY SET EQUALITY AND NOT A COUNT CEILING. The first form was
+   * `twice.length <= once.length`. That catches doubling — the defect it was written
+   * for — but passes just as happily if duplication makes a finding DISAPPEAR, which
+   * is an equally real bug (a dedup key collision swallowing a distinct finding).
+   * Comparing the SET of stable keys closes both directions.
+   *
+   * HONESTY ABOUT WHAT THIS STRENGTHENING IS PROVEN TO ADD: nothing yet, on this
+   * engine. Three sabotages were run trying to find an input where set equality
+   * reddens and the ceiling stays green, and none of them separated the two laws:
+   *
+   *   1. dedup key reduced to `checkId` alone      -> both stayed green
+   *   2. `collapseRepeated` made to DROP repeated groups instead of folding them
+   *      (the literal "duplicate-induced removal" shape)  -> both stayed green,
+   *      because the dedup pass upstream removes the duplicates before collapse
+   *      ever sees them
+   *   3. both of the above at once                 -> L3 still green; the vacuity
+   *      guard below fired instead, which is a different guard doing its job
+   *
+   * The reason is structural, and the file header already names it: L3 is guarded
+   * twice, and both guards are insensitive to duplication, so neither can produce a
+   * once-vs-twice difference. A rule with an UPPER bound on a fact count could —
+   * doubling would push it past the bound and the finding would vanish — and no such
+   * rule exists today. So this assertion is stronger BY CONSTRUCTION for the class
+   * the issue names, and is currently unfalsifiable in practice. It is written this
+   * way so that the day such a rule is added, the law is already waiting for it.
    */
-  it.each(Object.entries(CASES))("%s does not double when its facts are duplicated", (_name, facts) => {
-    const once = findingsFor(facts);
+  it.each(Object.entries(CASES))("%s reports the same finding SET when its facts are duplicated", (_name, facts) => {
+    const once = keysFor(facts);
     // Same nodeRef, same values — the same authored decision seen twice.
-    const twice = findingsFor([...facts, ...facts.map((f) => ({ ...f }))]);
-    expect(twice.length, "duplicating a fact multiplied the findings").toBeLessThanOrEqual(once.length);
+    const twice = keysFor([...facts, ...facts.map((f) => ({ ...f }))]);
+    expect(twice, "duplicating a fact changed which findings were reported").toEqual(once);
   });
 
   it("holds across the whole set at once", () => {
     const all = Object.values(CASES).flat();
-    const once = findingsFor(all);
-    const twice = findingsFor([...all, ...all.map((f) => ({ ...f }))]);
-    expect(twice.length).toBeLessThanOrEqual(once.length);
+    const once = keysFor(all);
+    const twice = keysFor([...all, ...all.map((f) => ({ ...f }))]);
+    expect(twice).toEqual(once);
   });
 });
 


### PR DESCRIPTION
Closes #238. Both halves are instrument honesty.

## L3 — set equality, and an honest note about what that buys

Was `twice.length <= once.length`: catches duplication *multiplying* a finding, passes just as happily if duplication makes one **disappear**. Now compares the SET of stable keys.

The key is the one the field corpus already used, and it now lives in **one** shared file instead of two copies — `message` deliberately excluded, because `collapseRepeated` folds an element count into it and a count legitimately changes under duplication.

**What this strengthening is proven to add today: nothing — and the test says so.** Three sabotages were run looking for an input where set equality reddens while the ceiling stays green:

| sabotage | result |
|---|---|
| dedup key reduced to `checkId` alone | both green |
| `collapseRepeated` made to DROP repeated groups (the literal duplicate-induced-removal shape) | both green — the dedup pass upstream removes duplicates before collapse sees them |
| both at once | L3 green; the *vacuity* guard fired instead |

The reason is structural and the file header already named it: **L3 is guarded twice, and both guards are insensitive to duplication**, so neither can produce a once-vs-twice difference. A rule with an UPPER bound on a fact count could — and none exists yet.

So the law is stronger by construction for the class the issue names, and currently unfalsifiable in practice. That is written into the test rather than left for the next reader to trip over. I would rather ship a documented unfalsifiable assertion than a fake green.

## UNDERCOUNT — say what the sheet could actually have hidden

A font CDN serves `@font-face`. It can cost a family name (so `overused-font` may under-fire); it cannot hide a layout, a colour or a shadow. An unknown host can hide anything and keeps the strict wording. **Both halves stay counted and named.**

Classified by **HOST, not URL shape**. Protocol-relative was the tempting proxy and it is wrong — `//` says nothing about content, so a protocol-relative *layout* sheet would be waved through, trading the old noise for a new blind spot. Two tests pull in opposite directions on exactly that.

### Measured, 747 real pages

```
401 pages carry an unresolved sheet
  font-only   337  (84%)  caveat narrows
  strict       64  (16%)  caveat unchanged

strict hosts:  static.linear.app 204 · (relative) 56 · jsdelivr 16 · cdnjs 8 · unpkg 6
```

The strict remainder is dominated by `static.linear.app` — a real application stylesheet — and 56 **local** sheets that simply failed to resolve. Both correctly strict: that is the evidence the allowlist is not over-broad.

## Red probes

Revert the classifier to shape-based: the protocol-relative case reddens **and nothing else does**.

The helper`'`s own test also caught a defect in my code before it shipped — a `"cdn.jsdelivr.net/fontsource"` entry sitting in a set of **hosts**, where it could never match, plus a `/fontsource` pattern that misses the real `/@fontsource` path. Dead config in an allowlist reads as coverage that does not exist.

## Gates

typecheck, lint, bundler clean; **247 files / 4306 passed / 0 failed**.

Part of the tell-lint anti-flop closeout (#236 #237 #238 #252 #253 #254 #255).