### PR TITLE
test(mutation): put the field corpus in the audit, and print both numbers

### DIFF
--- a/stryker.config.json
+++ b/stryker.config.json
@@ -12,7 +12,8 @@
     "!tsconfig.json",
     "!vitest.config.ts",
     "!vitest.mutation.config.ts",
-    "tests/field-corpus/**"
+    "!showcase/world-class-benchmark/evidence/repeatability-study/runs/d03-orchestrated-r2/**",
+    "!site/deck.css"
   ],
   "testRunner": "vitest",
   "vitest": {
@@ -49,7 +50,9 @@
   },
   "timeoutMS": 60000,
   "concurrency": 4,
-  "sandbox_comment": "Stryker copies the repo into a sandbox per run, and this repo root holds things that cannot be copied \u2014 a socket named `taste`, and Swift .build sockets under plans/. Rather than chase each one, the sandbox is an ALLOW-LIST: nothing enters except the sources, the tests and the config the audit actually needs.",
+  "sandbox_comment": "Stryker copies the repo into a sandbox per run, and this repo root holds things that cannot be copied \u2014 a socket named `taste`, and Swift .build sockets under plans/. Rather than chase each one, the sandbox is an ALLOW-LIST: nothing enters except the sources, the tests and the config the audit actually needs. tests/field-corpus/** used to be re-excluded here, which quietly made the corpus unusable by the audit; it is 352K and now enters. The two pages the corpus pins by repo-path are allow-listed EXACTLY rather than by taking showcase/** wholesale, which is 72M of sandbox copy per run.",
   "mutations_comment": "String, regex and object-literal mutants are excluded deliberately. Mutating a fixHint or a message produces noise with no signal \u2014 the guards live in the predicates, and mutation testing is known to over-report on cosmetic code.",
-  "audit_comment": "Mutation audit, NOT a gate. It automates the red-probe discipline that failed 13 times out of 63 by hand: it mutates a rule predicate and reports whether any test noticed. Run nightly or on demand, never per-PR \u2014 per-PR it is slow, noisy, and gets argued with until someone disables it. As an audit it prints 'these guards do not guard', which is exactly the list that was previously compiled by hand."
+  "audit_comment": "Mutation audit, NOT a gate. It automates the red-probe discipline that failed 13 times out of 63 by hand: it mutates a rule predicate and reports whether any test noticed. Run nightly or on demand, never per-PR \u2014 per-PR it is slow, noisy, and gets argued with until someone disables it. As an audit it prints 'these guards do not guard', which is exactly the list that was previously compiled by hand.",
+  "disableTypeChecks": "src/**/*.ts",
+  "disable_type_checks_comment": "Scoped to src/ deliberately. Stryker's default rewrites every TS file in the sandbox to prepend @ts-nocheck, and two field-corpus pages ARE TypeScript \u2014 so the harness edited the very evidence the corpus pins by sha256, and the corpus correctly failed the dry run saying the page had changed. Only the mutated sources need type checks off."
 }

--- a/vitest.mutation.config.ts
+++ b/vitest.mutation.config.ts
@@ -4,6 +4,31 @@
  * Stryker re-runs tests once per mutant, so pointing it at all 4,000+ tests would produce
  * a job nobody waits for and therefore nobody reads. The audit only mutates rule
  * predicates, so it only needs the tests that judge them.
+ *
+ * The field corpus is IN that set, and its absence was a measurement bug rather than a
+ * cost decision. Without it the score answered "how well do the FIXTURES guard these
+ * predicates" while being read as "how well are these predicates guarded" — and the
+ * corpus exists precisely because fixtures cannot state what real pages state. It is
+ * nine real pages, not four thousand tests, so the sentence above still holds.
+ *
+ * Two numbers come out of this, and they are not interchangeable. Measured 2026-08-31
+ * on 1,772 mutants over the six mutated files:
+ *
+ *   fixtures only     60.74%   738 killed   418 survived   59 with no coverage   1m30
+ *   fixtures + corpus 74.16%   899 killed   293 survived   21 with no coverage   2m46
+ *
+ * The corpus is worth +13.42 points, and the number that says the most is the last
+ * column: 38 mutants that no fixture ever reached are now executed by real pages. Per
+ * file the gain runs from +4.4 (role-synthesis) to +25.8 (tell-rules-labels).
+ *
+ * The old figure quoted in the issue that prompted this, 62.91%, is not comparable —
+ * the sources have changed since it was taken. It was re-measured rather than reused.
+ *
+ * CAVEAT, because the number is otherwise easy to over-read: three `fp-open` rows remain
+ * on `showcase-d03-orchestrated-r2`. Those kills defend behavior nobody has yet agreed is
+ * correct, so 74.16% is slightly generous and will move when they are adjudicated. Never
+ * quote the fixtures-only figure as rule coverage either — it answers a different
+ * question, which is the whole reason both are printed.
  */
 import { defineConfig } from "vitest/config";
 
@@ -15,6 +40,7 @@ export default defineConfig({
       "tests/tell-metamorphic-laws.test.ts",
       "tests/tell-fact-census.test.ts",
       "tests/role-synthesis.test.ts",
+      "tests/field-corpus.test.ts",
     ],
   },
 });


### PR DESCRIPTION
Closes #236.

## What the score was actually measuring

The audit mutates rule predicates and ran only the fixture tests, so it answered *"how well do the FIXTURES guard these predicates"* while being read as *"how well are these predicates guarded"*. The corpus exists precisely because fixtures cannot state what real pages state.

Nine real pages, not four thousand tests — the runtime sentence the config already carried still holds, and was **measured** rather than assumed: the projection runs 225 tests in 691ms against a 60s per-mutant timeout.

## The two numbers

1,772 mutants over the six mutated files:

| | fixtures only | fixtures + corpus |
|---|---|---|
| **score** | **60.74%** | **74.16%** |
| killed | 738 | 899 |
| survived | 418 | 293 |
| **no coverage** | **59** | **21** |
| runtime | 1m30 | 2m46 |

**+13.42 points.** The column that says the most is the last one: **38 mutants no fixture ever reached** are now executed by real pages.

Per file:

| file | fixtures | + corpus | Δ |
|---|---|---|---|
| `tell-rules-labels.ts` | 46.71 | 72.46 | **+25.75** |
| `tell-rules-motion.ts` | 46.33 | 66.06 | +19.73 |
| `tell-rules-color.ts` | 60.81 | 75.23 | +14.42 |
| `tell-rules-surface.ts` | 66.51 | 77.06 | +10.55 |
| `tell-rules-type.ts` | 71.83 | 78.17 | +6.34 |
| `role-synthesis.ts` | 71.01 | 75.36 | +4.35 |

The **62.91%** in the issue was NOT reused. The sources have changed since it was taken, so it is not comparable — it was re-measured. Count before you target.

## Three traps; two were predicted

1. **Sandbox.** The allow-list re-excluded `tests/field-corpus/**` right after including `tests/**` — that is what made the corpus unusable by the audit. Fixed.
2. **repo-path pins.** The corpus pins two pages by repo path, outside the allow-list. Listed **exactly**, not by taking `showcase/**` — that is 72M copied into the sandbox every run.
3. **Not predicted, found by running it.** Stryker`'`s preprocessor rewrites every TS file in the sandbox to prepend `@ts-nocheck`, and two corpus pages **are TypeScript**. The harness edited the very evidence the corpus pins by sha256, and the dry run failed:

```
WorkspaceSettings.tsx changed since dana-workspace-settings-tsx was adjudicated
  expected '83c8c2de…' to be '60129e88…'
```

That is the corpus guard working — on the harness. `disableTypeChecks` is now scoped to the mutated sources, which is all that needs it.

## Caveat, recorded next to the number

Three `fp-open` rows remain on `showcase-d03-orchestrated-r2` (pre-existing, unrelated to this closeout). Those kills defend behavior nobody has agreed is correct yet, so **74.16% is slightly generous** and will move when they are adjudicated. And the fixtures-only figure must never be quoted as rule coverage — it answers a different question, which is the whole reason both are printed.

## Gates

typecheck, lint, bundler clean; **248 files / 4311 passed / 0 failed**; Stryker dry run succeeds.

Last of the tell-lint anti-flop closeout (#236 #237 #238 #252 #253 #254 #255).