### PR TITLE
fix(tell): collapse identical facts before rules see them

### DIFF
--- a/src/core/tell-rules.ts
+++ b/src/core/tell-rules.ts
@@ -24,9 +24,45 @@ export interface FactIndex {
   by: <K extends FactKind>(kind: K) => Array<Extract<DesignFact, { kind: K }>>;
 }
 
+/**
+ * A structurally identical fact, for the dedupe below.
+ *
+ * Keys are sorted so two objects that differ only in property order collapse
+ * together — an extractor is free to build a fact in whatever order suits it, and
+ * that ordering is not part of what the fact SAYS.
+ */
+function identityOf(fact: DesignFact): string {
+  return JSON.stringify(fact, (_k, v: unknown) =>
+    v !== null && typeof v === "object" && !Array.isArray(v)
+      ? Object.fromEntries(Object.entries(v as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)))
+      : v,
+  );
+}
+
 export function indexFacts(facts: readonly DesignFact[]): FactIndex {
+  // Identical facts collapse before any rule sees them.
+  //
+  // The same authored decision read twice is one decision. Two facts that agree on
+  // every field INCLUDING their provenance came from one place in one file, so a
+  // rule counting them counts the reader's stutter, not the page.
+  //
+  // This is the sink fix for a real defect, found by a metamorphic law once its
+  // inputs were widened rather than its guards weakened. Rules that print a fact
+  // COUNT into `actual` — `image-hover-transform` says "N transitions over M
+  // images", `shape-assembled-illustration` says "N stacked shapes" — changed their
+  // finding when facts were duplicated, so a `<=` count ceiling stayed green while
+  // the finding SET genuinely differed. Guarding it in either rule would leave the
+  // next count-printing rule exposed; the repo's own rule is to fix at the shared
+  // layer, and this is that layer.
+  //
+  // Two facts on DIFFERENT nodes or lines are not identical and both survive: this
+  // collapses stutter, never evidence.
+  const seen = new Set<string>();
   const buckets = new Map<FactKind, DesignFact[]>();
   for (const f of facts) {
+    const identity = identityOf(f);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
     const list = buckets.get(f.kind);
     if (list === undefined) buckets.set(f.kind, [f]);
     else list.push(f);

--- a/tests/index-facts-dedupe.test.ts
+++ b/tests/index-facts-dedupe.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Identical facts collapse before any rule sees them.
+ *
+ * The same authored decision read twice is one decision. Two facts agreeing on
+ * every field INCLUDING their provenance came from one place in one file, so a rule
+ * counting them counts the reader's stutter rather than the page.
+ *
+ * This is a sink fix, and the alternative was the trap. Rules that print a fact
+ * COUNT into `actual` — `image-hover-transform` reports "N transitions over M
+ * images", `shape-assembled-illustration` reports "N stacked shapes" — reported a
+ * DIFFERENT finding when their facts were duplicated. Guarding either rule would
+ * have left the next count-printing rule exposed.
+ *
+ * The line the collapse must not cross is the second test: facts on different nodes
+ * are different evidence, however alike their values look. This collapses stutter,
+ * never evidence.
+ *
+ * Red probe: remove the dedupe from `indexFacts` and the first and third cases fail,
+ * along with two metamorphic-law cases. The "different nodes" case stays green
+ * throughout — it is the control that would catch a dedupe made too greedy.
+ */
+import { describe, expect, it } from "vitest";
+import { indexFacts } from "../src/core/tell-rules.js";
+import type { DesignFact } from "../src/core/design-facts/index.js";
+import type { Provenance } from "../src/core/design-facts/fact-model.js";
+
+const at = (line: number, nodeRef: string): Provenance =>
+  ({ file: "f", line, extractor: "html-cascade", confidence: "resolved", nodeRef });
+
+describe("indexFacts collapses stutter, not evidence", () => {
+  it("collapses a fact read twice", () => {
+    const fact: DesignFact = { kind: "radius", px: 16, at: at(3, "n1") };
+    const index = indexFacts([fact, { ...fact }]);
+    expect(index.by("radius")).toHaveLength(1);
+  });
+
+  it("keeps identical VALUES on different nodes", () => {
+    // The control, and the line the collapse must never cross: two elements with
+    // the same radius are two elements, and `monotonous-spacing` exists to say so.
+    const index = indexFacts([
+      { kind: "radius", px: 16, at: at(3, "n1") },
+      { kind: "radius", px: 16, at: at(4, "n2") },
+    ]);
+    expect(index.by("radius")).toHaveLength(2);
+  });
+
+  it("collapses regardless of the order an extractor built the object in", () => {
+    // Property order is not part of what a fact SAYS.
+    const a = { kind: "radius", px: 16, at: at(3, "n1") } as DesignFact;
+    const b = { at: at(3, "n1"), px: 16, kind: "radius" } as unknown as DesignFact;
+    expect(indexFacts([a, b]).by("radius")).toHaveLength(1);
+  });
+
+  it("keeps the deterministic line ordering the engine relies on", () => {
+    const index = indexFacts([
+      { kind: "radius", px: 4, at: at(9, "n9") },
+      { kind: "radius", px: 8, at: at(2, "n2") },
+    ]);
+    expect(index.by("radius").map((r) => r.at.line)).toEqual([2, 9]);
+  });
+});

--- a/tests/tell-metamorphic-laws.test.ts
+++ b/tests/tell-metamorphic-laws.test.ts
@@ -47,6 +47,14 @@ const CASES: Record<string, DesignFact[]> = {
   "tight-leading": [
     { kind: "typography", sizePx: 16, lineHeight: 1.0, at: at(5, "n3") },
   ],
+  // Reaches a rule that prints a FACT COUNT into `actual`, which is what makes the
+  // difference between L3's two forms observable. See the L3 docblock.
+  "image-hover-transform": [
+    { kind: "structure", node: "img", depth: 1, ref: "i1", at: at(10, "i1") },
+    { kind: "structure", node: "img", depth: 1, ref: "i2", at: at(11, "i2") },
+    { kind: "structure", node: "img", depth: 1, ref: "i3", at: at(12, "i3") },
+    { kind: "motion", motionKind: "transition", durationMs: 200, props: ["transform"], at: at(13, "m1") },
+  ],
   "dark-glow": [
     { kind: "color", role: "bg", hex: "141c17", at: at(6, "n4") },
     { kind: "shadow", offsetXPx: 0, offsetYPx: 0, blurPx: 40, hex: "9ef5b4", at: at(6, "n4") },
@@ -141,25 +149,36 @@ describe("metamorphic law L3 — a duplicated fact changes no finding", () => {
    * is an equally real bug (a dedup key collision swallowing a distinct finding).
    * Comparing the SET of stable keys closes both directions.
    *
-   * HONESTY ABOUT WHAT THIS STRENGTHENING IS PROVEN TO ADD: nothing yet, on this
-   * engine. Three sabotages were run trying to find an input where set equality
-   * reddens and the ceiling stays green, and none of them separated the two laws:
+   * WHAT THIS STRENGTHENING CAUGHT, and how nearly it was missed.
    *
-   *   1. dedup key reduced to `checkId` alone      -> both stayed green
-   *   2. `collapseRepeated` made to DROP repeated groups instead of folding them
-   *      (the literal "duplicate-induced removal" shape)  -> both stayed green,
-   *      because the dedup pass upstream removes the duplicates before collapse
-   *      ever sees them
-   *   3. both of the above at once                 -> L3 still green; the vacuity
-   *      guard below fired instead, which is a different guard doing its job
+   * The first attempt to justify it searched the SABOTAGE axis: break a guard, see
+   * whether set equality reddens where the ceiling stays green. Three sabotages —
+   * dedup key reduced to `checkId`, `collapseRepeated` made to drop repeated groups
+   * instead of folding them, then both at once — and none separated the two laws.
+   * The conclusion drawn from that, and written here, was that the strengthening was
+   * unfalsifiable on this engine. **That was wrong**, and it was wrong because the
+   * search was on the wrong axis.
    *
-   * The reason is structural, and the file header already names it: L3 is guarded
-   * twice, and both guards are insensitive to duplication, so neither can produce a
-   * once-vs-twice difference. A rule with an UPPER bound on a fact count could —
-   * doubling would push it past the bound and the finding would vanish — and no such
-   * rule exists today. So this assertion is stronger BY CONSTRUCTION for the class
-   * the issue names, and is currently unfalsifiable in practice. It is written this
-   * way so that the day such a rule is added, the law is already waiting for it.
+   * The laws are separated by the INPUTS, not by breaking anything. `keyOf` includes
+   * `actual`, and some rules print a fact COUNT into `actual`:
+   *
+   *     image-hover-transform  once: "1 transform transitions over 3 images"
+   *                            twice: "2 transform transitions over 6 images"
+   *
+   * One finding either way, so `twice.length <= once.length` is green. A different
+   * finding, so set equality is red. The `image-hover-transform` case in CASES exists
+   * for exactly this: it is the shortest input that tells the two forms apart, and it
+   * failed on the first run.
+   *
+   * That red was a real defect, not a strictness artefact — duplicated facts changed
+   * what the engine reported. It is fixed at the sink, in `indexFacts`, which now
+   * collapses structurally identical facts before any rule sees them. Fixing it
+   * inside `image-hover-transform` would have left `shape-assembled-illustration`
+   * ("N stacked shapes") and every future count-printing rule exposed.
+   *
+   * The lesson worth keeping: a probe that only breaks the code searches half the
+   * space. "No input distinguishes these" is a claim about inputs, and it has to be
+   * tested by varying inputs.
    */
   it.each(Object.entries(CASES))("%s reports the same finding SET when its facts are duplicated", (_name, facts) => {
     const once = keysFor(facts);


### PR DESCRIPTION
Answers **H3** from the independent review, and it is the finding I most needed.

## The law was green for the wrong reason

L3 says duplicating a fact must not change what the engine reports. **It did change it.** The law was green because its inputs were four tiny fact sets, none of which reached a rule that prints a fact COUNT into `actual`:

```
image-hover-transform  once   "1 transform transitions over 3 images"
                       twice  "2 transform transitions over 6 images"
```

One finding either way → a count ceiling is satisfied. A **different** finding → set equality is not. `CASES` now carries the shortest input that tells the two forms apart, and it **failed on the first run**.

## Fixed at the sink

`indexFacts` collapses structurally identical facts — every field equal, provenance included — before any rule sees them. The same authored decision read twice is one decision.

Guarding it inside `image-hover-transform` would have left `shape-assembled-illustration` (`"N stacked shapes"`) and every future count-printing rule exposed. A missing-rule bug is fixed at the shared layer.

Facts on **different nodes or lines are not identical** and both survive. This collapses stutter, never evidence — there is a control test standing on that line.

## Correcting what I wrote one commit ago

#264 put this into the test:

> *no sabotage separated the two laws … the assertion is currently unfalsifiable in practice*

**That was false.** I searched the sabotage axis — break a guard, see if set equality reddens where the ceiling stays green — ran three sabotages, and concluded from their failure that no input could separate the forms. The reviewer separated them immediately by changing the **inputs** instead.

> *"No input distinguishes these" is a claim about INPUTS. Testing it by breaking guards searches half the space.*

The docblock now records what actually happened. The prior counsel on this work had flagged count-printing rules as duplicate-sensitive and I wrote it into my own phase plan, then searched the wrong axis anyway.

## Red probe

Remove the dedupe: both new law cases fail, plus two of four dedupe assertions. The `identical values on different nodes` case stays green throughout — the control that catches a collapse made too greedy.

## Gates

typecheck, lint, bundler clean; **249 files / 4317 passed / 0 failed**; field corpus 49/49 unchanged.

Review report: `plans/reports/code-reviewer-260831-1550-tell-closeout-round2.md`