### PR TITLE
fix(tell): marquee sees more than text, and its own justification was false

### DIFF
--- a/src/core/extractors/web/jsx-extractor.ts
+++ b/src/core/extractors/web/jsx-extractor.ts
@@ -16,6 +16,7 @@
 import { FactCollector } from "../../design-facts/fact-collector.js";
 import { extractorById } from "../../design-facts/extractor-registry.js";
 import type { Provenance, SpacingProp, Side } from "../../design-facts/index.js";
+import type { TypographyFact } from "../../design-facts/fact-kinds.js";
 import { stripNoise, lineIndex, scan, num, UNRESOLVABLE } from "../scanner/line-scanner.js";
 import { resolveClass, looksLikeUtility } from "./tailwind-resolver.js";
 import { parseColor, parseLengthPx } from "../html/css-values.js";
@@ -106,16 +107,18 @@ function kebab(prop: string): string {
   return prop.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 
-/** Typography fields an element's utilities contribute, before they become one fact. */
-type TypeAccum = {
-  sizePx?: number;
-  weight?: number;
-  letterSpacingEm?: number;
-  lineHeight?: number;
-  align?: never;
-  italic?: boolean;
-  transform?: never;
-};
+/**
+ * Typography fields an element's utilities contribute, before they become one fact.
+ *
+ * Typed off the fact's own payload rather than restated. The first version declared
+ * `align?: never` and `transform?: never` and then wrote through `as never`, which
+ * type-checks by asserting the values do not exist instead of checking that they are
+ * the values the fact accepts — so a resolver typo would have compiled.
+ */
+type TypeAccum = Partial<Pick<
+  TypographyFact,
+  "sizePx" | "weight" | "letterSpacingEm" | "lineHeight" | "align" | "italic" | "transform"
+>>;
 
 function emitClasses(c: FactCollector, classes: readonly string[], at: Provenance): void {
   const sides: Side[] = [];
@@ -163,13 +166,13 @@ function emitClasses(c: FactCollector, classes: readonly string[], at: Provenanc
           if (r.value !== undefined) type.lineHeight = r.value;
           break;
         case "align":
-          if (r.text !== undefined) type.align = r.text as never;
+          if (r.text !== undefined) type.align = r.text as TypographyFact["align"];
           break;
         case "italic":
           type.italic = true;
           break;
         case "transform":
-          if (r.text !== undefined) type.transform = r.text as never;
+          if (r.text !== undefined) type.transform = r.text as TypographyFact["transform"];
           break;
         case "color":
           if (r.hex !== undefined && r.role !== undefined) c.add({ kind: "color", hex: r.hex, role: r.role, at });

--- a/src/core/tell-rules-motion.ts
+++ b/src/core/tell-rules-motion.ts
@@ -69,20 +69,36 @@ export const blinkingCursor: TellRule = {
 };
 
 /**
- * Does anything a reader must READ live under this node?
+ * Nodes that are content in themselves, with no text underneath them.
+ *
+ * There is no `img` fact kind, so a picture is a `structure` fact whose node names
+ * it. An inline `<svg>` is the one that matters most in practice: a partner-logo
+ * marquee is a band of SVGs and not a word of copy, and it is the canonical thing
+ * this rule exists to catch.
+ */
+const CONTENT_NODES = new Set(["img", "svg", "picture", "video", "canvas", "iframe", "object", "embed"]);
+
+/**
+ * Does anything a reader must READ or LOOK AT live under this node?
  *
  * The rule below claims "auto-scrolling CONTENT the reader cannot pause", so it
- * owes a check that content is what moves. Content means a text run or an image —
- * there is no `img` fact kind, so an image is a `structure` fact whose node is `img`.
+ * owes a check that content is what moves.
  *
- * REFUTATION, not a requirement. It answers false only when the facts positively
- * show an empty subtree; every path where the evidence is missing answers TRUE and
- * the finding stands. That asymmetry is deliberate and it is why `needs` stays
- * `["motion"]`: `css-only` supplies motion with no structure and no text, and
- * `swiftui`/`flutter` supply motion and text with no structure. Adding those kinds
- * to `needs` would turn this rule NOT-EVALUATED on three extractors that run it
- * today — silencing real findings under the cover of a coverage change, which is
- * exactly the mistake this repo has already paid for twice.
+ * REFUTATION, not a requirement: it answers false only when the facts positively
+ * show a subtree with nothing in it. Every path where the evidence is missing or
+ * unusable answers TRUE and the finding stands. That asymmetry is the whole design
+ * — a rule must not go quiet because a reader was blind.
+ *
+ * `needs` stays `["motion"]` because that is what the rule REQUIRES to run;
+ * structure and text are refutation evidence, not inputs. An earlier version of
+ * this comment justified that by claiming `css-only`, `swiftui` and `flutter` would
+ * lose findings if those kinds were promoted. **That justification was false** and
+ * is recorded here so nobody rebuilds on it: `sfc-extractor` (which serves both
+ * `sfc` and `css-only`) emits `repeatsForever` and never sets `durationMs`, and
+ * `flutter` emits easing, duration and repeat as three DISJOINT motion facts — so
+ * on all three, `repeatsForever && durationMs >= SLOW_LOOP_MIN_MS` cannot be true
+ * of one fact, and none of them can fire this rule at all. In practice `marquee` is
+ * html-cascade-only. The conclusion happened to be right; the reason was not.
  */
 function subtreeHasReadableContent(facts: Parameters<TellRule["run"]>[0], ownerRef: string | undefined): boolean {
   if (ownerRef === undefined) return true; // the extractor cannot name the owner
@@ -96,13 +112,18 @@ function subtreeHasReadableContent(facts: Parameters<TellRule["run"]>[0], ownerR
     if (list === undefined) childrenOf.set(s.parentRef, [s.ref]);
     else list.push(s.ref);
   }
+  // An extractor that names nodes but not their parents gives a tree with no edges,
+  // and a walk over it reaches exactly one node and reports "empty" for every
+  // element on the page. That is blindness reported as a verdict. If nothing here
+  // carries a parent link, refuse to refute.
+  if (childrenOf.size === 0) return true;
 
   const carriesContent = new Set<string>();
   for (const t of facts.by("text")) {
     // Head metadata is not copy anyone reads; it cannot make a marquee.
     if (t.role !== "metadata" && t.at.nodeRef !== undefined) carriesContent.add(t.at.nodeRef);
   }
-  for (const s of structures) if (s.node.toLowerCase() === "img") carriesContent.add(s.ref);
+  for (const s of structures) if (CONTENT_NODES.has(s.node.toLowerCase())) carriesContent.add(s.ref);
 
   const seen = new Set<string>([ownerRef]);
   const queue = [ownerRef];

--- a/tests/tell-marquee-content-join.test.ts
+++ b/tests/tell-marquee-content-join.test.ts
@@ -68,4 +68,16 @@ describe("marquee fires only when content moves", () => {
     // There is no `img` fact kind; an image is a structure fact whose node is img.
     expect(marqueeOn(page(`<div class="a"><img src="x.png" alt="logo"></div>`)).length).toBeGreaterThan(0);
   });
+
+  it("still fires on a partner-logo band of inline SVGs and no copy", () => {
+    // The canonical case, and the one an img-only check missed: a logo marquee is
+    // a row of inline <svg> with not a word of text in it.
+    const logos = `<svg viewBox="0 0 10 10"><rect/></svg>`.repeat(4);
+    expect(marqueeOn(page(`<div class="a">${logos}</div>`)).length).toBeGreaterThan(0);
+  });
+
+  it("still fires on a looping video or canvas", () => {
+    expect(marqueeOn(page(`<div class="a"><video src="x.mp4"></video></div>`)).length).toBeGreaterThan(0);
+    expect(marqueeOn(page(`<div class="a"><canvas></canvas></div>`)).length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
Three findings from the independent review (**H4**, **M1**, **M4**, plus **M5**), all about a comment or a type claiming more than the code did.

## H4 — the `needs` justification was false

I wrote that keeping `needs: ["motion"]` protected findings on `css-only`, `swiftui` and `flutter`. Checked at the source rather than reasoned about:

```ts
// sfc-extractor.ts (serves BOTH sfc and css-only) — no durationMs, ever
c.add({ kind: "motion", motionKind: ..., easing: ..., repeatsForever: /infinite/i.test(value), at });

// flutter-extractor.ts — easing, duration and repeat are THREE DISJOINT facts
c.add({ ... easing: `Curves.${...}` ... });
c.add({ ... durationMs: num(...) ... });
c.add({ ... repeatsForever: true ... });
```

`marquee` needs `repeatsForever && durationMs >= SLOW_LOOP_MIN_MS` **on one fact**. On all three that cannot be true — **none of them can fire this rule at all.** In practice `marquee` is html-cascade-only.

The conclusion happened to be right (`needs` states what a rule REQUIRES; structure and text are refutation *evidence*), but the reason was not — and a false reason is what the next author builds on. Corrected in place, including what it used to say.

## M1 — content was only text and img

A **partner-logo marquee** is a band of inline `<svg>` with not a word of copy — the canonical thing this rule exists to catch. Now also `video`, `canvas`, `picture`, `iframe`, `object`, `embed`.

**Re-measured across the same 747 pages: still exactly 1 finding.** So this brings nothing back on this data; it closes a class the field set does not happen to contain, and is guarded by fixtures instead. Saying otherwise would be overselling it.

## M4 — a latent trap that would have silenced the rule everywhere

An extractor that names nodes but not their parents produces a tree with **no edges**. Every walk then reaches exactly one node and reports "empty" for every element on the page — blindness printed as a verdict, with nothing going red. Today only html-cascade supplies `parentRef`; the refutation now refuses to run when no fact carries one.

## M5 — a type that asserted instead of checking

`TypeAccum` declared `align?: never` / `transform?: never` and wrote through `as never` — that type-checks by asserting the values *do not exist*, so a resolver typo would have compiled. Now `Partial<Pick<TypographyFact, …>>`.

## Gates

typecheck, lint, bundler clean; **249 files / 4319 passed / 0 failed**; field corpus 49/49.

Review report: `plans/reports/code-reviewer-260831-1550-tell-closeout-round2.md`