### PR TITLE
test(corpus): replace two stale root causes on the last three open rows

### DIFF
--- a/tests/field-corpus/showcase-d03-orchestrated-r2/verdicts.json
+++ b/tests/field-corpus/showcase-d03-orchestrated-r2/verdicts.json
@@ -43,7 +43,7 @@
     {
       "key": "cramped-padding@html > body > main > div.wrap[0] > div.product[1] > div.canvas[1] > div.impact > span.state#7px on 2 side(s)",
       "verdict": "fp-open",
-      "reason": "The surface has a 99px radius — it is a PILL state badge, and 7px vertical padding is correct for one. This is the exact near-miss named in the fixture contract; cramped-padding has no pill exclusion yet.",
+      "reason": "The element is `.impact .state` — a status pill (`font: 10px DM Mono; padding: 7px 9px; border-radius: 99px`, page line 23). Only the 7px top/bottom sides fall under the 8px CRAMPED_PADDING_MAX_PX floor; the 9px sides pass. 7px of vertical padding on a 10px-font pill badge is balanced, not cramped, and the rule's own comment concedes the case ('a pill legitimately has 4px'). REASON REPLACED 2026-08-31: the previous text said no pill exclusion existed yet. It does — tell-rules-surface.ts:171-172 — and it misses this page by ONE PIXEL, because the guard is `r.px < PILL_RADIUS` with PILL_RADIUS = 100 and this page's fully-rounded idiom is 99px. Root cause is shared with the nested-cards row: the repo holds three disagreeing notions of 'fully rounded' and none of them is a shared fact — a raw literal 100 here, another raw literal 100 in audit-detect.ts:93, and PILL_RADIUS_PX = 999 in tell-thresholds.ts. Stays fp-open rather than fp because the finding still fires; fp means MUST NOT FIRE.",
       "message": "7px padding (bottom, top) on a 99px-radius surface"
     },
     {
@@ -67,7 +67,7 @@
     {
       "key": "hero-eyebrow-chip@line:39#chip \"Get a demo\"",
       "verdict": "fp-open",
-      "reason": "Line 39 is <nav class=\"navlinks\"> and the element is <button class=\"btn dark demo-open\">Get a demo</button> — a navigation CTA, not an eyebrow chip above the headline. The rule matches a pill near the hero without checking that it sits above the h1 or that it is non-interactive.",
+      "reason": "Line 39 is the NAV, and the matched text is `<button class=\"btn dark demo-open\">Get a demo</button>` — an interactive call to action at 14px/700 with a 99px radius, not a decorative eyebrow. The page's real eyebrow is `div.eyebrow` ('Decision context, intact', line 44), it carries no radius of its own, and it correctly does not match. The predicate (tell-rules-labels.ts:89-97) accepts any non-heading text within EYEBROW_MAX_LINE_GAP = 6 SOURCE LINES above the h1 — the h1 is line 45, so the gap is exactly 6 — at 40 characters or fewer, with a >=12px same-owner radius and <=14px type. It never excludes interactive elements. Two root causes: no button/anchor exclusion, and source-line distance used as a proxy for 'visually above the headline', which reaches out of the hero and into the nav. Stays fp-open because the finding still fires.",
       "message": "pill-shaped eyebrow chip above the hero headline — a launch-announcement device with nothing to announce"
     },
     {
@@ -79,7 +79,7 @@
     {
       "key": "nested-cards@html > body > main > div.wrap[0] > div.product[1] > div.appbar[0] > div.avatars > div.avatar[0]#card at depth 7 inside div.product[1]",
       "verdict": "fp-open",
-      "reason": ".avatar is 24x24 with border-radius:50% and a 2px border — it satisfies looksLikeCard (border AND radius) but is a 24px ornament, not a surface holding content. role-synthesis.ts documents the reference implementation's size window; we did not implement it. This is the predicted property-based-detection edge case.",
+      "reason": "`.avatar` is a 24x24 circle (`border: 2px solid #141c17; border-radius: 50%; background: var(--mint)`, page line 20). `looksLikeCard` passes on a border plus an own opaque background alone, `hasDistinctSurface` passes on the opaque background, and `div.product` (dark background, 24px radius, drop shadow) is a card ancestor — so a stacked avatar in the depicted app bar registers as a card nested inside a card. A 24px circular avatar is an ornament, not a content-holding surface: the same class as this rule's documented card-title history, surfacing again through role generosity. REASON REPLACED 2026-08-31: the previous text cited a 'size window' documented in role-synthesis.ts. No such text exists at HEAD (grep across src/: zero hits), and the Surface model carries no width or height, so a size window is not currently expressible at this fact fidelity. Root cause: `looksLikeCard` has no notion of fully-rounded/ornament geometry — a bordered 50% circle with a background counts as a card. Stays fp-open because the finding still fires.",
       "message": "card nested inside another card (div.product[1]) — 2 elements, first at html > body > main > div.wrap[0] > div.product[1] > div.appbar[0] > div.avatars > div.avatar[0]"
     },
     {

--- a/vitest.mutation.config.ts
+++ b/vitest.mutation.config.ts
@@ -25,10 +25,14 @@
  * the sources have changed since it was taken. It was re-measured rather than reused.
  *
  * CAVEAT, because the number is otherwise easy to over-read: three `fp-open` rows remain
- * on `showcase-d03-orchestrated-r2`. Those kills defend behavior nobody has yet agreed is
- * correct, so 74.16% is slightly generous and will move when they are adjudicated. Never
- * quote the fixtures-only figure as rule coverage either — it answers a different
- * question, which is the whole reason both are printed.
+ * on `showcase-d03-orchestrated-r2`. An `fp-open` row is a MUST-FIRE row, so it kills
+ * mutants exactly as a `tp` row does — the kills are real, and what they defend is a
+ * finding already judged wrong. A mutant that would have removed one of those false
+ * positives is therefore counted as caught. So 74.16% is slightly generous, and it moves
+ * when the CODE is fixed, not when the rows are adjudicated: all three were adjudicated on
+ * 2026-08-31 and each names its root cause. Never quote the fixtures-only figure as rule
+ * coverage either — it answers a different question, which is the whole reason both are
+ * printed.
  */
 import { defineConfig } from "vitest/config";
 


### PR DESCRIPTION
All three remaining `fp-open` rows adjudicated. All three findings are wrong, **none can become `fp` yet**, and two of the recorded reasons cited code that no longer matches the repo.

## Two stale records

| row | the reason said | measured at HEAD |
|---|---|---|
| `cramped-padding` | "no pill exclusion yet" | It exists — `tell-rules-surface.ts:171-172` — and misses this page by **one pixel**: the guard is `r.px < PILL_RADIUS` with `PILL_RADIUS = 100`, and the page uses `border-radius: 99px` |
| `nested-cards` | cites a "size window documented in `role-synthesis.ts`" | `grep -rn "size window" src/` → **0 hits**. The Surface model carries no width or height, so a size window is not expressible at this fact fidelity |

## Why none of them flips to `fp`

`fp` means **MUST NOT FIRE**. The suite is green at HEAD, which is proof all three still fire. Flipping any of them now would turn the suite red — a must-not-fire row against code that fires. They stay `fp-open` with their real causes named.

## The hypothesis this started from is refuted

I framed these as "the tells judging a MOCK of app chrome". Wrong: the eyebrow row is in the page`'`s **real nav** (`<button class="btn dark demo-open">Get a demo</button>`), and the other two would misfire identically on a real application page — status pills and avatar stacks are ordinary patterns.

A showcase carve-out would have been the guard-widening mistake this repo has paid for twice.

## Root causes filed

- **#270** — three disagreeing notions of "fully rounded", none of them a shared fact: `PILL_RADIUS = 100` (raw literal), `PILL_RADIUS_MIN = 100` (raw literal, again, in `audit-detect.ts`), `PILL_RADIUS_PX = 999` (in the threshold table with its rationale), and `looksLikeCard` has no notion at all. Covers the `cramped-padding` and `nested-cards` rows.
- **#271** — `hero-eyebrow-chip` never excludes interactive elements, and measures "above the headline" in **source lines** (gap exactly 6, limit 6), which reaches out of the hero into the nav.

Each issue names its corpus row as the red/green probe: the row flips `fp-open` → `fp` in the same commit as its fix.

## Also corrected

A claim I wrote into `vitest.mutation.config.ts`: an `fp-open` row is **must-fire**, so it kills mutants exactly as a `tp` row does. The kills are real; what they defend is a finding already judged wrong. The score moves when the **code** is fixed, not when the rows are adjudicated — they are adjudicated now.

## Gates

typecheck, lint clean; **250 files / 4325 passed / 0 failed**, twice.

One run in three reported a single failure whose name I did not capture, while two disk-heavy agents were running concurrently (328s vs the usual 275-297s). Unreproduced across the two runs since. Recorded rather than called a flake, because I cannot name it.

Adjudication report: `plans/reports/kongming-260831-2002-corpus-open-rows-adjudication.md`