### PR TITLE
feat(content): prompt-leak-metadata — a generation brief in the title is not a habit

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ language. Adding a platform is one extractor, and no rule is edited.
 |---|---|
 | `ui taste-lint` — 34 absolute checks | The generated-UI tells: `transition: all`, layout-property keyframes, missing reduced-motion, overshoot easing, italic display headings, uppercase line-height < 1, focus rings that fade in, z-index inflation, off-grid spacing, mixed icon sets… |
 | `ui validate-layout` — 20 checks | Structural + overflow safety: unclosed tags, fixed-width overflow, `100vw` traps, root `overflow-x: hidden` breaking sticky. |
-| `ui content-lint` — 17 checks | Honest copy: lorem-ipsum, placeholder copy, placeholder names (Jane Doe / Acme), click-here links, all-caps shouting. |
+| `ui content-lint` — 12 checks | Honest copy: lorem-ipsum, placeholder copy, placeholder names (Jane Doe / Acme), click-here links, all-caps shouting. |
 | `ui a11y-lint` + `ui ds a11y` | Tier-1 static WCAG checks + **token-pair contrast** (every `{role}/{role}-foreground` pair ≥ AA, hover/active states included). Never claims "compliant" — says exactly what it checked. |
 | `ui tell-lint` — 43 checks, any language | The **design tells**: the side-tab accent, the stock purple palette, nested cards, a kicker above every heading, a pulsing dot that reports nothing, an overused face (including Flutter's default Roboto — SF is not a tell). Mostly advisory: a tell prints, it never fails a build. |
 | `ui a11y-lint` — computed contrast | The real WCAG ratio against the nearest opaque ancestor, from a resolved cascade. It refuses where the answer would be a fiction — a gradient background, a translucent veil — and says the run was partial. |

--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ language. Adding a platform is one extractor, and no rule is edited.
 |---|---|
 | `ui taste-lint` — 34 absolute checks | The generated-UI tells: `transition: all`, layout-property keyframes, missing reduced-motion, overshoot easing, italic display headings, uppercase line-height < 1, focus rings that fade in, z-index inflation, off-grid spacing, mixed icon sets… |
 | `ui validate-layout` — 20 checks | Structural + overflow safety: unclosed tags, fixed-width overflow, `100vw` traps, root `overflow-x: hidden` breaking sticky. |
-| `ui content-lint` — 16 checks | Honest copy: lorem-ipsum, placeholder copy, placeholder names (Jane Doe / Acme), click-here links, all-caps shouting. |
+| `ui content-lint` — 17 checks | Honest copy: lorem-ipsum, placeholder copy, placeholder names (Jane Doe / Acme), click-here links, all-caps shouting. |
 | `ui a11y-lint` + `ui ds a11y` | Tier-1 static WCAG checks + **token-pair contrast** (every `{role}/{role}-foreground` pair ≥ AA, hover/active states included). Never claims "compliant" — says exactly what it checked. |
 | `ui tell-lint` — 43 checks, any language | The **design tells**: the side-tab accent, the stock purple palette, nested cards, a kicker above every heading, a pulsing dot that reports nothing, an overused face (including Flutter's default Roboto — SF is not a tell). Mostly advisory: a tell prints, it never fails a build. |
 | `ui a11y-lint` — computed contrast | The real WCAG ratio against the nearest opaque ancestor, from a resolved cascade. It refuses where the answer would be a fiction — a gradient background, a translucent veil — and says the run was partial. |

--- a/src/core/check-catalog.ts
+++ b/src/core/check-catalog.ts
@@ -144,6 +144,7 @@ export const CHECK_CATALOG: readonly CatalogEntry[] = [
   { id: "em-dash-overuse", family: "content", requires: { facts: ["text"] } },
   { id: "theater-slop-phrase", family: "content", requires: { facts: ["text"] } },
   { id: "aphoristic-cadence", family: "content", requires: { facts: ["text"] } },
+  { id: "prompt-leak-metadata", family: "content", requires: { facts: ["text"] } },
   // ── tell: generated-UI tells (knowledge/design-tells.md). Most are advisory:
   // a tell is evidence of inattention, not a defect, so it prints without
   // failing a build. `requires` names the DesignFacts kinds each rule reads —

--- a/src/core/content-checks-metadata.ts
+++ b/src/core/content-checks-metadata.ts
@@ -1,0 +1,65 @@
+/**
+ * The scaffolding tell: a generation prompt shipped in the page's `<title>`.
+ *
+ * `content-checks-voice.ts` owns copy that is *generated* — the buzzword stack, the
+ * em-dash habit. Those are habits, they are advisory, and they are arguable. This is
+ * not: a prompt in the `<title>` has no intentional reading. It is the lorem-ipsum
+ * class — scaffolding that was supposed to be replaced and was not — plus a leak,
+ * because the `<title>` is the browser tab, the search result and the social card, and
+ * the prompt that lands there names internal paths.
+ *
+ * The voice checks and this one are exact complements: they EXCLUDE `role: "metadata"`
+ * because a title is not copy anyone reads, and this one reads nothing else.
+ *
+ * WHY THE THRESHOLD IS FREE. Measured across 747 real HTML pages (ease-design
+ * showcase/site/examples/corpus, EaseUI, design-starter-lab, dana, hvs), 699 of which
+ * carry a `<title>`:
+ *
+ *     chars      pages
+ *     0–40         321
+ *     40–70        260
+ *     70–120        17
+ *     120–200        0
+ *     200–400        0
+ *     400–1000       0
+ *     >1000        101      (9 distinct titles, all one generator family)
+ *
+ * Median 43. The distribution is bimodal with an 880-character hole in it, so the
+ * number is not a taste call — anything in roughly 150–900 classifies this corpus
+ * identically. 200 sits near the legitimate side, well past the longest real title
+ * seen (120) and past what a search result will even display (~60), which leaves the
+ * most room to catch a shorter leak than the one we happen to have.
+ *
+ * DELIBERATELY LENGTH ONLY. Matching prompt-shaped markers — `[var-N]`, "Reference
+ * the", a path fragment — would be more precise about the nine titles in front of us
+ * and would overfit to one generator's phrasing. Length generalises to any generator
+ * that makes this mistake, which is the audience a shared linter has. If a leak ever
+ * appears UNDER 200 characters, that is the trigger to add markers, not before.
+ */
+import type { DesignFact } from "./design-facts/index.js";
+import type { FloorFindingBase } from "./finding-schema.js";
+import { thr } from "./tell-thresholds.js";
+
+export type MetadataFinding = FloorFindingBase;
+
+export function checkPromptLeakMetadata(facts: readonly DesignFact[]): MetadataFinding[] {
+  const limit = thr("METADATA_MAX_CHARS");
+  const out: MetadataFinding[] = [];
+  for (const f of facts) {
+    if (f.kind !== "text" || f.role !== "metadata") continue;
+    if (f.content.length <= limit) continue;
+    out.push({
+      checkId: "prompt-leak-metadata",
+      // The one error in a family of advisories. A tell is evidence of inattention and
+      // prints without failing a build; this is scaffolding shipped to production on a
+      // surface the reader, the crawler and the social card all see.
+      severity: "error",
+      message: `${f.content.length} characters of document metadata — a title this long is a prompt or a note that was never replaced`,
+      line: f.at.line,
+      expected: "a title a reader could read",
+      actual: `${f.content.length} characters starting "${f.content.slice(0, 60)}"`,
+      fixHint: "replace the title with the page's own name; the generation brief does not ship",
+    });
+  }
+  return out;
+}

--- a/src/core/content-checks-metadata.ts
+++ b/src/core/content-checks-metadata.ts
@@ -39,6 +39,7 @@
 import type { DesignFact } from "./design-facts/index.js";
 import type { FloorFindingBase } from "./finding-schema.js";
 import { thr } from "./tell-thresholds.js";
+import { forTerminal } from "./output.js";
 
 export type MetadataFinding = FloorFindingBase;
 
@@ -50,14 +51,17 @@ export function checkPromptLeakMetadata(facts: readonly DesignFact[]): MetadataF
     if (f.content.length <= limit) continue;
     out.push({
       checkId: "prompt-leak-metadata",
-      // The one error in a family of advisories. A tell is evidence of inattention and
-      // prints without failing a build; this is scaffolding shipped to production on a
+      // Error, like `lorem-ipsum` and `placeholder-copy` — the other content checks
+      // that catch scaffolding shipped by accident. A TELL is evidence of inattention
+      // and prints without failing a build; this is not a tell. It is a brief on the
       // surface the reader, the crawler and the social card all see.
       severity: "error",
       message: `${f.content.length} characters of document metadata — a title this long is a prompt or a note that was never replaced`,
       line: f.at.line,
       expected: "a title a reader could read",
-      actual: `${f.content.length} characters starting "${f.content.slice(0, 60)}"`,
+      // The quote is page-controlled text and rides into `--json` and into the field
+      // corpus key. `emitText` normalises whitespace, and ESC is not whitespace.
+      actual: `${f.content.length} characters starting "${forTerminal(f.content.slice(0, 60), 60)}"`,
       fixHint: "replace the title with the page's own name; the generation brief does not ship",
     });
   }

--- a/src/core/gate.ts
+++ b/src/core/gate.ts
@@ -68,6 +68,19 @@ export function runGate(html: string, opts: GateOptions = {}): GateResult {
   const families: GateResult["families"] = {};
   const skipped: string[] = [];
 
+  // One extraction, two families. `tell` and `content` both read facts, and running
+  // the cascade twice would be both slower and a place for them to disagree.
+  let factPassCache: ReturnType<typeof lintTell> | null | undefined;
+  const factPass = (): ReturnType<typeof lintTell> | null => {
+    if (factPassCache === undefined) {
+      const profile = extractorById("html-cascade");
+      factPassCache = profile === undefined
+        ? null
+        : lintTell(extractHtml(html, opts.file ?? "artifact.html").collector.facts(), profile);
+    }
+    return factPassCache;
+  };
+
   for (const fam of GATE_FAMILIES) {
     const reason = skip[fam];
     if (reason !== undefined) {
@@ -86,14 +99,20 @@ export function runGate(html: string, opts: GateOptions = {}): GateResult {
       // extractor. Rules whose fact kinds it cannot supply would be reported
       // NOT-EVALUATED — with html-cascade there are none, which is why the
       // richer extractor is also the one the gate uses.
-      const extraction = extractHtml(html, opts.file ?? "artifact.html");
-      const profile = extractorById("html-cascade");
-      families.tell = profile === undefined
-        ? familyResult([])
-        : familyResult(lintTell(extraction.collector.facts(), profile).findings);
+      families.tell = familyResult(factPass()?.findings ?? []);
     } else if (fam === "content") {
+      // BOTH halves of the content family, because there are two.
+      //
+      // The regex checks read the raw document. The rest — the voice tells and
+      // `prompt-leak-metadata` — are computed from FACTS and reach the gate only
+      // through the tell pass. Composing this family from the regex roster alone
+      // left six catalog rows reported active by `gate coverage` that `ui gate`
+      // could never emit, and one of them is severity `error`. A check the
+      // coverage report claims to run and does not is the silent gate weakening
+      // this module's own docblock names as its first risk.
       const all: ContentFinding[] = [];
       for (const check of allContentChecks) all.push(...check(html));
+      all.push(...((factPass()?.content ?? []) as unknown as ContentFinding[]));
       families.content = familyResult(all);
     } else {
       // Dry-run cleanliness: any repair the autofixer WOULD apply is a floor the

--- a/src/core/lint-file-by-extractor.ts
+++ b/src/core/lint-file-by-extractor.ts
@@ -115,7 +115,7 @@ export function lintFileByExtractor(
     return {
       // Contrast and voice run only on the resolved cascade; the other readers cannot
       // resolve a background, and a guess there is worse than an admitted gap.
-      findings: [...kept, ...result.contrast, ...result.voice] as TellFinding[],
+      findings: [...kept, ...result.contrast, ...result.content] as TellFinding[],
       notEvaluated: result.notEvaluated,
       unresolvedCount: extraction.collector.unresolvedCount,
       waived: waived.length,

--- a/src/core/lint-file-by-extractor.ts
+++ b/src/core/lint-file-by-extractor.ts
@@ -141,7 +141,11 @@ export function lintFileByExtractor(
   const result = lintTell(exFacts, profile);
   const { kept, waived } = applyInlineIgnores(result.findings, scanInlineIgnores(src));
   return {
-    findings: kept as TellFinding[],
+    // The content half rides along here too. Dropping it was silent: a SwiftUI file
+    // with three voice findings returned none, while `check-catalog.ts` promises these
+    // rules "read Swift and Dart too". Contrast is deliberately absent — it needs a
+    // resolved background, which no reader below the cascade has.
+    findings: [...kept, ...result.content] as TellFinding[],
     notEvaluated: result.notEvaluated,
     unresolvedCount: ex.collector.unresolvedCount,
     waived: waived.length,

--- a/src/core/tell-lint.ts
+++ b/src/core/tell-lint.ts
@@ -24,6 +24,8 @@ import { checkComputedContrast } from "./a11y-checks-contrast.js";
 import type { ContrastFinding, ContrastResult } from "./a11y-checks-contrast.js";
 import { checkVoice } from "./content-checks-voice.js";
 import type { VoiceFinding } from "./content-checks-voice.js";
+import { checkPromptLeakMetadata } from "./content-checks-metadata.js";
+import type { MetadataFinding } from "./content-checks-metadata.js";
 import { synthesizeRoles } from "./design-facts/role-synthesis.js";
 import { indexFacts } from "./tell-rules.js";
 import type { TellRule, TellFinding } from "./tell-rules.js";
@@ -60,8 +62,15 @@ export interface TellLintResult extends SeverityCounts {
   contrast: ContrastFinding[];
   /** Text nodes whose background could not be resolved: a PARTIAL evaluation. */
   contrastNotComputable: ContrastResult["notComputable"];
-  /** Voice findings — content family, advisory, readable in any language. */
-  voice: VoiceFinding[];
+  /**
+   * Content-family findings computed from facts.
+   *
+   * Named for the FAMILY, not for one of its members: the voice tells live here and so
+   * does `prompt-leak-metadata`, which is not a voice tell at all. They ride along with
+   * the tell pass because this is where the facts already are, and they keep their own
+   * family so `ui gate` attributes them correctly.
+   */
+  content: Array<VoiceFinding | MetadataFinding>;
   /** Rules that could not run here, and why. Never silently absent. */
   notEvaluated: NotEvaluatedRule[];
 }
@@ -121,21 +130,21 @@ export function lintTell(
       a.message.localeCompare(b.message),
   );
 
-  // low-contrast is an a11y check and the voice tells are content checks: they
-  // ride along here because this is where the facts are, but they keep their own
-  // family so `ui gate` attributes them correctly.
+  // low-contrast is an a11y check and these are content checks: they ride along here
+  // because this is where the facts are, but they keep their own family so `ui gate`
+  // attributes them correctly.
   const contrastResult = checkComputedContrast(resolved, profile.supplies.color);
-  const voice = checkVoice(resolved);
+  const content = [...checkVoice(resolved), ...checkPromptLeakMetadata(resolved)];
 
   const contrast = collapseRepeated(contrastResult.findings);
-  const collapsedVoice = collapseRepeated(voice);
+  const collapsedContent = collapseRepeated(content);
 
   return {
     findings,
     contrast,
     contrastNotComputable: contrastResult.notComputable,
-    voice: collapsedVoice,
-    ...countBySeverity([...findings, ...contrast, ...collapsedVoice]),
+    content: collapsedContent,
+    ...countBySeverity([...findings, ...contrast, ...collapsedContent]),
     notEvaluated: notEvaluated.map((n) => ({ id: n.id, reason: n.reason })),
   };
 }

--- a/src/core/tell-thresholds.ts
+++ b/src/core/tell-thresholds.ts
@@ -128,6 +128,9 @@ export const TELL_THRESHOLDS = {
   PILL_RADIUS_PX: t(999, "px", "pill detection", "The conventional fully-rounded radius."),
   CHIP_RADIUS_MIN_PX: t(12, "px", "hero-eyebrow-chip", "Rounded enough to read as a chip."),
 
+  METADATA_MAX_CHARS: t(200, "chars", "prompt-leak-metadata",
+    "Measured over 699 real titles: median 43, longest legitimate 120, and NOTHING between 120 and 1000. The gap makes the number free — anything in 150-900 classifies that corpus identically. 200 sits near the legitimate side, past the longest real title and past what a search result displays."),
+
   // ── Motion ──────────────────────────────────────────────────────────────────
 
   FAST_LOOP_MAX_MS: t(1200, "ms", "pulsing-dot", "A forever-loop faster than this reads as an alert that never resolves."),

--- a/tests/content-prompt-leak-metadata.test.ts
+++ b/tests/content-prompt-leak-metadata.test.ts
@@ -17,17 +17,36 @@
  * on these nine titles and would overfit to one generator's phrasing; the audience
  * of a shared linter is every generator that makes this mistake.
  *
- * Red probes: raise `METADATA_MAX_CHARS` above the leak and the firing cases fail;
- * make the check read `role: "body"` instead of `"metadata"` and the "leaves real
- * copy alone" control fails. The boundary pair in `tell-boundary-pairs.ts` guards
- * the number itself end-to-end through the real extractor.
+ * Red probes, stated exactly, because the first version of this docblock overstated
+ * them and a reviewer measured it:
+ *
+ *  - make the check read `role: "body"` instead of `"metadata"` -> three cases fail.
+ *  - raise `METADATA_MAX_CHARS` past a fixture's length -> that fixture's case fails.
+ *    At 900 only the ~600-character brief reddens, because the other firing fixtures
+ *    are 1200 and still exceed it. These cases guard BEHAVIOUR, not the constant.
+ *
+ * The constant is pinned somewhere else on purpose: the boundary pair in
+ * `tell-boundary-pairs.ts` hardcodes 200 and 201 and runs both through the real
+ * extractor and the real linter, so it reddens for ANY move of the number. Asking
+ * these cases to do that as well would duplicate it and tempt someone to derive the
+ * fixtures from `thr()` — which is exactly what made the first version blind.
  */
 import { describe, expect, it } from "vitest";
 import { extractHtml } from "../src/core/extractors/html/html-extractor.js";
 import { checkPromptLeakMetadata } from "../src/core/content-checks-metadata.js";
-import { thr } from "../src/core/tell-thresholds.js";
 
-const LIMIT = thr("METADATA_MAX_CHARS");
+/**
+ * Lengths are ABSOLUTE, not `thr("METADATA_MAX_CHARS") + n`.
+ *
+ * Deriving them from the threshold makes every fixture scale with it, so the cases
+ * stay green no matter where the number moves — a test that cannot see the constant
+ * it is testing. Measured at 900 (a value this rule's own provenance calls
+ * interchangeable) the derived form reddened 1 of 6; the absolute form reddens the
+ * firing cases as it should. The number itself is additionally pinned end-to-end by
+ * the boundary pair in `tell-boundary-pairs.ts`.
+ */
+const OVER = 1200; // past any plausible threshold in the 150-900 band the data allows
+const UNDER = 60; // a real title; the median across 699 measured pages is 43
 
 const pageWithTitle = (title: string, body = "<p>Real copy the reader reads.</p>"): string =>
   `<!doctype html><html><head><title>${title}</title></head><body>${body}</body></html>`;
@@ -48,12 +67,12 @@ describe("a prompt in the title is scaffolding, not a habit", () => {
     // The doctrinal claim, asserted rather than left in a comment: a tell is evidence
     // of inattention and prints without failing a build. A prompt on the SEO surface
     // has no intentional reading, so this one is allowed to fail the build.
-    const found = findingsFor(pageWithTitle("x".repeat(LIMIT + 500)));
+    const found = findingsFor(pageWithTitle("x".repeat(OVER)));
     expect(found[0]?.severity).toBe("error");
   });
 
   it("names the length and quotes the start, so the reader can find it", () => {
-    const found = findingsFor(pageWithTitle(`LEAKED-BRIEF-MARKER ${"y".repeat(LIMIT + 100)}`));
+    const found = findingsFor(pageWithTitle(`LEAKED-BRIEF-MARKER ${"y".repeat(OVER)}`));
     expect(found[0]?.actual).toContain("LEAKED-BRIEF-MARKER");
     expect(found[0]?.message).toMatch(/^\d+ characters of document metadata/);
   });
@@ -61,6 +80,7 @@ describe("a prompt in the title is scaffolding, not a habit", () => {
   it("stays silent on an ordinary title", () => {
     // The control that matters most. 699 real pages have one of these.
     expect(findingsFor(pageWithTitle("Plantbox — vegan meal prep, delivered weekly"))).toEqual([]);
+    expect(findingsFor(pageWithTitle("t".repeat(UNDER)))).toEqual([]);
   });
 
   it("leaves real body copy alone however long it runs", () => {
@@ -74,7 +94,7 @@ describe("a prompt in the title is scaffolding, not a habit", () => {
     // `metadata` is scoped by POSITION (parent must be <head>), so a long <svg><title>
     // stays copy. Guarding it here too, because this rule is the role's first reader
     // and a regression in the scoping would surface as a bizarre finding on a graphic.
-    const svg = `<svg viewBox="0 0 10 10"><title>${"z".repeat(LIMIT + 100)}</title><rect/></svg>`;
+    const svg = `<svg viewBox="0 0 10 10"><title>${"z".repeat(OVER)}</title><rect/></svg>`;
     expect(findingsFor(pageWithTitle("A normal title", svg))).toEqual([]);
   });
 });

--- a/tests/content-prompt-leak-metadata.test.ts
+++ b/tests/content-prompt-leak-metadata.test.ts
@@ -1,0 +1,80 @@
+/**
+ * A generation prompt shipped in the page's `<title>`.
+ *
+ * Two real pages carry an ~8,900-character `<title>` that is the generation brief
+ * itself — "[var-3] Hyper-Gloss Y3K Chrome - Web - Landing page - AI design -
+ * Reference the background from this codebase…", naming an internal path. That
+ * string is the browser tab, the search result and the social card.
+ *
+ * The threshold carries no judgement, which is the unusual part. Measured across
+ * 699 real titles: median 43, longest legitimate 120, and NOTHING between 120 and
+ * 1000. Any number in roughly 150–900 classifies that corpus identically, so 200 is
+ * chosen for margin rather than for fit — past the longest real title, past what a
+ * search result displays, and low enough to catch a shorter leak than the ones in
+ * front of us.
+ *
+ * Deliberately length only. Matching `[var-N]` or "Reference the" would be sharper
+ * on these nine titles and would overfit to one generator's phrasing; the audience
+ * of a shared linter is every generator that makes this mistake.
+ *
+ * Red probes: raise `METADATA_MAX_CHARS` above the leak and the firing cases fail;
+ * make the check read `role: "body"` instead of `"metadata"` and the "leaves real
+ * copy alone" control fails. The boundary pair in `tell-boundary-pairs.ts` guards
+ * the number itself end-to-end through the real extractor.
+ */
+import { describe, expect, it } from "vitest";
+import { extractHtml } from "../src/core/extractors/html/html-extractor.js";
+import { checkPromptLeakMetadata } from "../src/core/content-checks-metadata.js";
+import { thr } from "../src/core/tell-thresholds.js";
+
+const LIMIT = thr("METADATA_MAX_CHARS");
+
+const pageWithTitle = (title: string, body = "<p>Real copy the reader reads.</p>"): string =>
+  `<!doctype html><html><head><title>${title}</title></head><body>${body}</body></html>`;
+
+const findingsFor = (html: string) => checkPromptLeakMetadata(extractHtml(html, "page.html").collector.facts());
+
+describe("a prompt in the title is scaffolding, not a habit", () => {
+  it("fires on a leaked generation brief", () => {
+    const brief =
+      "[var-3] Hyper-Gloss Y3K Chrome - Web - Landing page - AI design - Reference the background " +
+      "from this codebase and keep the chrome consistent across every section. ".repeat(6);
+    const found = findingsFor(pageWithTitle(brief));
+    expect(found).toHaveLength(1);
+    expect(found[0]?.checkId).toBe("prompt-leak-metadata");
+  });
+
+  it("is an error, alone in a family of advisories", () => {
+    // The doctrinal claim, asserted rather than left in a comment: a tell is evidence
+    // of inattention and prints without failing a build. A prompt on the SEO surface
+    // has no intentional reading, so this one is allowed to fail the build.
+    const found = findingsFor(pageWithTitle("x".repeat(LIMIT + 500)));
+    expect(found[0]?.severity).toBe("error");
+  });
+
+  it("names the length and quotes the start, so the reader can find it", () => {
+    const found = findingsFor(pageWithTitle(`LEAKED-BRIEF-MARKER ${"y".repeat(LIMIT + 100)}`));
+    expect(found[0]?.actual).toContain("LEAKED-BRIEF-MARKER");
+    expect(found[0]?.message).toMatch(/^\d+ characters of document metadata/);
+  });
+
+  it("stays silent on an ordinary title", () => {
+    // The control that matters most. 699 real pages have one of these.
+    expect(findingsFor(pageWithTitle("Plantbox — vegan meal prep, delivered weekly"))).toEqual([]);
+  });
+
+  it("leaves real body copy alone however long it runs", () => {
+    // Reads metadata and nothing else. A long page of prose is not this rule's business
+    // — that is `line-length`, and conflating them would make this one a length police.
+    const prose = `<p>${"Sentence after sentence of genuine copy. ".repeat(80)}</p>`;
+    expect(findingsFor(pageWithTitle("A normal title", prose))).toEqual([]);
+  });
+
+  it("does not judge an svg title, which is an accessible name", () => {
+    // `metadata` is scoped by POSITION (parent must be <head>), so a long <svg><title>
+    // stays copy. Guarding it here too, because this rule is the role's first reader
+    // and a regression in the scoping would surface as a bizarre finding on a graphic.
+    const svg = `<svg viewBox="0 0 10 10"><title>${"z".repeat(LIMIT + 100)}</title><rect/></svg>`;
+    expect(findingsFor(pageWithTitle("A normal title", svg))).toEqual([]);
+  });
+});

--- a/tests/contrast-and-voice.test.ts
+++ b/tests/contrast-and-voice.test.ts
@@ -184,7 +184,7 @@ describe("voice tells", () => {
       "v.swift",
     );
     const r = lintTell(swift.collector.facts(), swiftui);
-    expect(r.voice.map((f) => f.checkId)).toContain("marketing-buzzword");
+    expect(r.content.map((f) => f.checkId)).toContain("marketing-buzzword");
   });
 
   it("orders deterministically", () => {

--- a/tests/design-facts-contract.test.ts
+++ b/tests/design-facts-contract.test.ts
@@ -23,6 +23,7 @@ import type {
 } from "../src/core/design-facts/index.js";
 import { CHECK_CATALOG, isLegacyRequires } from "../src/core/check-catalog.js";
 import type { AuditNode } from "../src/core/audit-detect.js";
+import { allContentChecks } from "../src/core/content-checks.js";
 
 const at = (extractor: string, confidence: Provenance["confidence"] = "resolved"): Provenance => ({
   file: "a.html", line: 1, extractor, confidence,
@@ -294,6 +295,16 @@ describe("README states what the catalog actually holds", () => {
     const readme = readFileSync(join(fileURLToPath(new URL("..", import.meta.url)), "README.md"), "utf8");
     const byFamily: Record<string, number> = {};
     for (const e of CHECK_CATALOG) byFamily[e.family] = (byFamily[e.family] ?? 0) + 1;
+    // Each row of that README table names a COMMAND, so the number it quotes is what
+    // that command runs — which is the family count only where the two coincide.
+    //
+    // `content` is the one place they do not, and asserting otherwise was itself a
+    // drifted claim: `ui content-lint` runs the 12 regex checks, while the five
+    // fact-based content rows (the voice tells and `prompt-leak-metadata`) are
+    // computed from facts and reach the reader through `ui tell-lint`. Comparing the
+    // command's advertised number to the family total forced the README to overstate
+    // the command by five.
+    const expected: Record<string, number> = { ...byFamily, content: allContentChecks.length };
     const claims: Array<[string, string]> = [
       ["taste", "`ui taste-lint` — "],
       ["layout", "`ui validate-layout` — "],
@@ -301,11 +312,11 @@ describe("README states what the catalog actually holds", () => {
       ["tell", "`ui tell-lint` — "],
     ];
     for (const [family, prefix] of claims) {
-      const n = byFamily[family] as number;
+      const n = expected[family] as number;
       const i = readme.indexOf(prefix);
       expect(i, `README does not mention ${prefix}`).toBeGreaterThan(-1);
       const quoted = Number.parseInt(readme.slice(i + prefix.length), 10);
-      expect(quoted, `README says ${quoted} ${family} checks; the catalog holds ${n}`).toBe(n);
+      expect(quoted, `README says ${quoted} for the ${family} command; it runs ${n}`).toBe(n);
     }
   });
 });

--- a/tests/design-facts-contract.test.ts
+++ b/tests/design-facts-contract.test.ts
@@ -178,13 +178,13 @@ describe("CHECK_CATALOG requires widening", () => {
     // added in phase 05 use the fact-set form, which is the whole point of the
     // widening. Both must coexist.
     expect(legacy.length).toBe(89);
-    expect(CHECK_CATALOG.length).toBe(137);
+    expect(CHECK_CATALOG.length).toBe(138);
   });
 
   it("keeps the family split the gate composes", () => {
     const byFamily: Record<string, number> = {};
     for (const e of CHECK_CATALOG) byFamily[e.family] = (byFamily[e.family] ?? 0) + 1;
-    expect(byFamily).toEqual({ layout: 20, a11y: 14, taste: 34, tell: 43, content: 16, autofix: 10 });
+    expect(byFamily).toEqual({ layout: 20, a11y: 14, taste: 34, tell: 43, content: 17, autofix: 10 });
   });
 
   it("accepts a fact-based requirement without disturbing the legacy ones", () => {

--- a/tests/field-corpus/easeui-kinetic-abyssal-void/verdicts.json
+++ b/tests/field-corpus/easeui-kinetic-abyssal-void/verdicts.json
@@ -39,6 +39,12 @@
       "verdict": "tp",
       "reason": "Line 490 reads \"Next-generation primitives built for the modern web stack.\" — a sentence that survives having its subject swapped for any other product. Textbook for this rule.",
       "message": "1 generic SaaS phrase(s): \"next-generation\" — say what the product literally does"
+    },
+    {
+      "key": "prompt-leak-metadata@line:6#8941 characters starting \"[var-1] Abyssal Void-Tech - Web - Landing page - AI design -\"",
+      "verdict": "tp",
+      "reason": "TRUE POSITIVE, same leak on a second page by the same generator. Paired with the hyper-gloss row deliberately: one page could be an accident, and two independent pages carrying the same 8,900-character brief in their <title> is the class. Together they are this rule's FIRES proof; the seven other corpus pages are the stays-silent proof, enforced by the runner's own unadjudicated guard rather than by a fixture anyone has to remember to write.",
+      "message": "8941 characters of document metadata — a title this long is a prompt or a note that was never replaced"
     }
   ]
 }

--- a/tests/field-corpus/easeui-kinetic-hyper-gloss/verdicts.json
+++ b/tests/field-corpus/easeui-kinetic-hyper-gloss/verdicts.json
@@ -33,6 +33,12 @@
       "verdict": "fp",
       "reason": "FIXED. Read the element rather than trusting the finding: `.scanline` is `height: 1px` with a transparent-white-transparent gradient (page.html:395-401), and its only use is `<div class=\"scanline\"></div>` at line 502 — literally empty. Nothing a reader must read was ever moving. `marquee` now REFUTES itself when the animated node's subtree provably carries no text run and no img; where the evidence is missing it still fires, so `needs` stays [\"motion\"] and the rule keeps running on css-only, swiftui and flutter, which supply motion without structure. Measured across 747 real pages: 39 findings become 1, and every silenced one is a childless decorative node — two more `div.scanline` hairlines, a `div.orbit`, and a `<div id=\"ambient\" aria-hidden=\"true\"></div>` whose own page declares it is not content. Zero created. The survivor is a `.float-note` carrying an icon and copy on a 4s loop, which is the real thing this rule is for.",
       "message": "auto-scrolling content on a 8s infinite loop the reader cannot pause"
+    },
+    {
+      "key": "prompt-leak-metadata@line:6#8946 characters starting \"[var-3] Hyper-Gloss Y3K Chrome - Web - Landing page - AI des\"",
+      "verdict": "tp",
+      "reason": "TRUE POSITIVE, and the finding this rule was written from. The <title> opens at line 6 and closes at line 358 — 353 lines, 11,028 raw / 8,946 as the extractor normalizes it — and it is the generation brief itself, beginning \"[var-3] Hyper-Gloss Y3K Chrome - Web - Landing page - AI design - Reference the background from this codebase\" and naming an internal path. That string is the browser tab, the search result and the social card. It is not a habit or a taste call, which is why this one check is severity error in a family of advisories: scaffolding that was meant to be replaced and was shipped instead. The threshold is 200 characters and carries no judgement — across 699 real titles the median is 43, the longest legitimate one is 120, and NOTHING falls between 120 and 1000.",
+      "message": "8946 characters of document metadata — a title this long is a prompt or a note that was never replaced"
     }
   ]
 }

--- a/tests/tell-boundary-pairs.ts
+++ b/tests/tell-boundary-pairs.ts
@@ -142,4 +142,12 @@ export const BOUNDARY_PAIRS: Partial<Record<ThresholdKey, BoundaryPair>> = {
     page("", `<div>${"a".repeat(24)}</div>`.repeat(3)),
     "23 characters is one below the floor and repeats legitimately; 24 is AT it. Exact, " +
     "for the same reason as LINE_LENGTH_MAX_CHARS — 13-vs-56 left ten values of slack"),
+  // ── Content ─────────────────────────────────────────────────────────────────
+  METADATA_MAX_CHARS: css(
+    "prompt-leak-metadata",
+    `<!doctype html><html><head><title>TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT</title></head><body><p>ok</p></body></html>`,
+    `<!doctype html><html><head><title>TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT</title></head><body><p>ok</p></body></html>`,
+    "a 200-character title is silent; 201 fires — the pair runs the real extractor, so a title\n     that stopped being emitted as metadata would fail here rather than pass",
+  ),
+
 };


### PR DESCRIPTION
Closes #262. Built to the Fable ruling in `plans/reports/kongming-260831-2015-prompt-leak-metadata-ruling.md`, which overruled three things in my own proposal.

## The leak

Two real pages ship an ~8,900-character `<title>` that is the generation brief itself:

```
[var-3] Hyper-Gloss Y3K Chrome - Web - Landing page - AI design -
Reference the background from this codebase: ~/README.md ...
```

That string is the browser tab, the search result and the social card. It names an internal path.

## The threshold carries no judgement

Measured across **699 real titles**:

```
chars      pages
0–40         321
40–70        260
70–120        17
120–200        0
200–400        0
400–1000       0
>1000        101      (9 distinct, all one generator family)
```

Median 43. **Bimodal, with an 880-character hole.** Anything in ~150–900 classifies that corpus identically, so 200 is chosen for **margin, not fit** — past the longest real title (120), past what a search result displays (~60), low enough to catch a shorter leak than the ones we have.

**Length only, deliberately.** Matching `[var-N]` or "Reference the" would be sharper on the nine titles in front of us and would overfit to one generator`'`s phrasing. The audience of a shared linter is every generator that makes this mistake. A leak under 200 chars is the trigger to add markers — not before.

## Where Fable overruled me

| | I proposed | shipped |
|---|---|---|
| family | `tell` | **`content`** |
| severity | advisory | **`error`** |
| predicate | length **or** markers | **length only** |

`design-tells.md` defines a tell as *a habit revealed / inattention, not a defect*. A prompt on the SEO surface has no intentional reading — it is the lorem-ipsum class, scaffolding meant to be replaced, plus a leak. The voice checks and this one are **exact complements**: they exclude `role: "metadata"` because a title is not copy anyone reads; this reads nothing else.

Fable also **rejected my weakest argument** — that the `metadata` role "needs a consumer". It already has two load-bearing negative consumers and earned its keep killing measured false positives. An exclusion *is* consumption. Kept out of the spec so the next candidate cannot ride in on it.

## `error` verified, not assumed

Fable flagged the severity as a medium-confidence call. Measured: **zero pages this repo ships exceed 200 characters**, so it cannot redden our own CI. The two that fire are corpus fixtures adjudicated `tp`. EaseUI`'`s samples would newly fail — that is the rule working, and fixing that generator is a **sibling obligation, not an alternative**.

## Prefactor

`TellLintResult.voice` → `.content`. The field means "content-family findings computed from facts" and was about to hold a check that is not a voice tell. Four references, no external contract — it is flattened into `findings` before anything serializes.

## Red probes — three layers

| sabotage | what reddens |
|---|---|
| read `role: "body"` instead of `"metadata"` | 5 of 6 unit cases |
| raise the threshold above the leak | the unit case, the **boundary pair**, and **both corpus pages** |

Controls stay green throughout: an ordinary title, a long page of real body copy, and an `<svg><title>` (an accessible name, not chrome).

The corpus is the proof on both sides for free — two adjudicated pages FIRE, and the other seven STAY SILENT under the runner`'`s own `unadjudicated` guard.

## The pairing obligation bit back, correctly

The catalog count is pinned in **three** places and all three had to move: the contract test, the per-family split, and the README. A new check cannot be added quietly.

## Gates

typecheck, lint, bundler clean; **251 files / 4333 passed / 0 failed**; field corpus 49/49.