### PR TITLE
fix(gate): emit low-contrast, report a partial contrast pass, and guard the class

### DIFF
--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -147,6 +147,9 @@ export const gateCommand = {
       }
     }
     for (const s of result.skipped) lines.push(`  skipped ${s}`);
+    // A family that RAN but read only part of the artifact. Printed beside the
+    // skips because a partial verdict and an absent one are both "not a clean bill".
+    for (const s of result.partial) lines.push(`  PARTIAL ${s}`);
 
     const data = { file, ...result };
     const out = useJson ? okJsonWithExit(CMD, data, exitCode) : { exitCode, stdout: lines.join("\n") + "\n" };

--- a/src/core/gate.ts
+++ b/src/core/gate.ts
@@ -44,6 +44,14 @@ export interface GateResult {
   advisoryCount: number;
   /** Declared partial gating: "<family>: <reason>" per skipped family. */
   skipped: string[];
+  /**
+   * Families that RAN but could not see the whole artifact — "<family>: <reason>".
+   *
+   * Distinct from `skipped`, which is a family nobody ran. A pass that read half its
+   * input and found nothing is not a clean verdict, and saying so is the difference
+   * between a floor and a claim.
+   */
+  partial: string[];
   errorCount: number;
   warningCount: number;
   /** true iff no error-severity finding in any run family. */
@@ -67,6 +75,8 @@ export function runGate(html: string, opts: GateOptions = {}): GateResult {
   const skip = opts.skip ?? {};
   const families: GateResult["families"] = {};
   const skipped: string[] = [];
+  /** Checks that RAN but could not see everything — a partial verdict, not a clean one. */
+  const partial: string[] = [];
 
   // One extraction, two families. `tell` and `content` both read facts, and running
   // the cascade twice would be both slower and a place for them to disagree.
@@ -91,7 +101,23 @@ export function runGate(html: string, opts: GateOptions = {}): GateResult {
       const r = lintLayout(html);
       families.layout = familyResult(r.findings);
     } else if (fam === "a11y") {
-      families.a11y = familyResult(lintA11y(html).findings);
+      // Two producers, not one. `lintA11y` reads the document; `low-contrast` is
+      // COMPUTED — it needs a resolved background, so it comes off the same fact pass
+      // the tell and content families use. It had a catalog row and `gate coverage`
+      // called it active while `runGate` could never emit it.
+      //
+      // Measured before wiring it, across 747 real pages: 52 pass the gate today and
+      // exactly ONE of them newly fails — white on Airbnb's brand pink at 3.52:1,
+      // under the 4.5:1 AA floor. A true positive, which is the point.
+      const pass = factPass();
+      families.a11y = familyResult([...lintA11y(html).findings, ...(pass?.contrast ?? [])]);
+      // A background nobody could resolve makes that pass PARTIAL. 342 of those 747
+      // pages have one. Printing a clean a11y verdict over them would be the
+      // zero-from-a-half-read-run this repo refuses everywhere else.
+      const nc = pass?.contrastNotComputable.length ?? 0;
+      if (nc > 0) {
+        partial.push(`a11y: ${nc} contrast pair(s) NOT COMPUTABLE — a background could not be resolved, so this verdict is a floor`);
+      }
     } else if (fam === "taste") {
       families.taste = familyResult(lintTaste(html, { knownHexes: opts.knownHexes }).findings);
     } else if (fam === "tell") {
@@ -136,7 +162,7 @@ export function runGate(html: string, opts: GateOptions = {}): GateResult {
     advisoryCount += r.advisoryCount;
   }
   // pass keys on errors alone: an advisory finding prints and never fails.
-  return { families, skipped, errorCount, warningCount, advisoryCount, pass: errorCount === 0 };
+  return { families, skipped, partial, errorCount, warningCount, advisoryCount, pass: errorCount === 0 };
 }
 
 // ─── Coverage — the registry triage routes on ─────────────────────────────────

--- a/tests/gate-emits-what-coverage-claims.test.ts
+++ b/tests/gate-emits-what-coverage-claims.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `gate coverage` says a check is active. `ui gate` must be able to emit it.
+ *
+ * Those are two different code paths and they drifted apart in silence. Coverage
+ * counts CATALOG ROWS; `runGate` composes each family from whichever producers it
+ * happens to call. Where a producer is never called, its rows are reported active
+ * forever and can never appear in a verdict.
+ *
+ * Six rows were in that state: `low-contrast`, the four voice tells, and
+ * `prompt-leak-metadata` — which was added to the blind spot as the first
+ * error-severity row in it, by an author (me) who then wrote a comment asserting the
+ * gate attributed them correctly.
+ *
+ * The existing catalog pairing (`check-catalog.test.ts`) does not catch this. It
+ * pairs rows against IDS IN THE SOURCES, so a check that exists, is registered, and
+ * is never reached passes it cleanly. Reachability is a different claim and needs a
+ * different probe: run the gate on artifacts built to trip each ride-along producer,
+ * and demand the finding come back out under the right family.
+ *
+ * Deliberately fixture-driven rather than static. A structural version would have to
+ * enumerate "ids this composer can draw from", which is a grep over the same sources
+ * the catalog was built from — green by construction, and blind to exactly the
+ * question being asked.
+ *
+ * Red probe: revert either wiring in `gate.ts` — drop `factPass()?.contrast` from the
+ * a11y family, or the fact-based half from the content family — and the matching case
+ * here fails. Verified both.
+ */
+import { describe, expect, it } from "vitest";
+import { runGate, gateCoverage } from "../src/core/gate.js";
+
+/** A page whose title is a leaked brief, whose copy is a buzzword stack, and whose
+ *  brand pink cannot carry white text. One artifact, three ride-along producers. */
+const RIDE_ALONG_PAGE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>${"[var-9] Leaked Generation Brief - Web - Landing page - AI design - reference the codebase and keep the chrome. ".repeat(4)}</title>
+<style>
+  .cta { color: #ffffff; background: #ff385c; font-size: 16px; }
+</style>
+</head><body>
+<h1>Plantbox</h1>
+<p class="cta">A world-class enterprise-grade solution that will supercharge your workflow.</p>
+</body></html>`;
+
+const idsIn = (family: "a11y" | "content"): string[] => {
+  const r = runGate(RIDE_ALONG_PAGE, {});
+  return (r.families[family]?.findings ?? []).map((f) => f.checkId);
+};
+
+describe("a check the coverage report calls active is a check the gate can emit", () => {
+  it("emits low-contrast, which is computed and not read off the document", () => {
+    // `lintA11y` cannot produce this one: it needs a resolved background, so it comes
+    // off the fact pass. White on #ff385c is 3.52:1 against a 4.5:1 floor.
+    expect(idsIn("a11y")).toContain("low-contrast");
+  });
+
+  it("emits the fact-based half of the content family", () => {
+    const ids = idsIn("content");
+    expect(ids).toContain("marketing-buzzword");
+    expect(ids).toContain("prompt-leak-metadata");
+  });
+
+  it("still emits the regex half of the content family", () => {
+    // The control. Wiring the fact-based half in must not displace the twelve checks
+    // that were already there.
+    const ids = runGate(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>T</title></head>
+      <body><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></body></html>`, {}).families.content?.findings.map((f) => f.checkId) ?? [];
+    expect(ids).toContain("lorem-ipsum");
+  });
+
+  it("reports a contrast pass that could not see every background as PARTIAL", () => {
+    // A verdict from a half-read artifact is a floor, not a clean bill. 342 of 747
+    // real pages have at least one background the cascade cannot resolve.
+    const r = runGate(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>T</title>
+      <style>.x { color: #333; background: var(--nope); }</style></head>
+      <body><p class="x">Copy on a background nobody can resolve.</p></body></html>`, {});
+    expect(r.partial.join(" ")).toMatch(/NOT COMPUTABLE/);
+  });
+
+  it("leaves a clean page clean", () => {
+    // The control that stops this from becoming a page that always fails.
+    const r = runGate(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Plantbox</title>
+      <style>.c { color: #111827; background: #ffffff; font-size: 16px; }</style></head>
+      <body><h1>Plantbox</h1><p class="c">Vegan meal prep, delivered weekly.</p></body></html>`, {});
+    expect((r.families.a11y?.findings ?? []).map((f) => f.checkId)).not.toContain("low-contrast");
+    expect(r.partial).toEqual([]);
+  });
+
+  it("has no family the coverage report counts and the gate never composes", () => {
+    // The generalisation. Every family with active rows must be one `runGate`
+    // actually builds — the shape of the original defect, one level up.
+    const cov = gateCoverage({ tokensPresent: true, dsPresent: true, renderAvailable: false });
+    const r = runGate(RIDE_ALONG_PAGE, {});
+    for (const [family, counts] of Object.entries(cov.families)) {
+      if (counts.active === 0) continue;
+      expect(
+        Object.prototype.hasOwnProperty.call(r.families, family),
+        `gate coverage reports ${counts.active} active checks in "${family}" and runGate never composes that family`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #274 — the last of six catalog rows `gate coverage` called active and `ui gate` could never emit.

## The row

`low-contrast` is **computed** — it needs a resolved background — so it comes off the fact pass. The a11y family was composed from `lintA11y` alone, which cannot produce it.

## Measured before wiring it — 747 real pages

```
pages PASSING the gate today:                    52
of those, would NEWLY FAIL:                       1
pages with an unresolvable background:          342
```

The one page: white on Airbnb brand pink `#ff385c` at **3.52:1** against the 4.5:1 AA floor. A true positive, which is the point.

### That measurement was wrong the first time, and the number was the tell

The harness read `runGate(...).ok`. `GateResult` has no `ok` — it has `pass` — so every page came back falsy and it reported **0 of 747 passing**. A number that extreme is a claim about the instrument, not the world.

The harness now **self-probes that the field is a boolean before measuring anything**. Third instrument lie this session; the check that catches it costs one line.

## A partial verdict is not a clean one

New `partial` channel on `GateResult`, separate from `skipped`. A family nobody ran and a family that ran **half-blind** are different things, and 342 of those pages have a background the cascade cannot resolve. Printing a clean a11y verdict over them is the zero-from-a-half-read-run this repo refuses everywhere else.

```
PARTIAL a11y: N contrast pair(s) NOT COMPUTABLE — a background could not be resolved,
              so this verdict is a floor
```

## The guard is the part worth keeping

`check-catalog.test.ts` pairs rows against **ids in the sources** — so a check that exists, is registered, and is never reached passes it cleanly. **All six dead rows did.** Reachability is a different claim and needs a different probe.

One artifact trips every ride-along producer (a leaked-brief title, a buzzword stack, white on brand pink), goes through the real gate, and each finding is demanded back **under its own family**. Plus the generalisation one level up: no family with active rows may be one `runGate` never composes.

Fixture-driven on purpose. A structural version would enumerate ids by grepping the sources the catalog was built from — green by construction, blind to the question.

## Red probes — three knobs, separately

| sabotage | reddens |
|---|---|
| drop `factPass()?.contrast` from a11y | the low-contrast case |
| drop the fact-based half from content | the content case |
| stop reporting partial | the PARTIAL case |

Both controls — a clean page stays clean, the regex half still fires — stay green through all three.

## One more thing it caught on itself

The suite was green while `tsc` was **red**: the new test called `gateCoverage` without `dsPresent`, and JavaScript does not care. Four gates, not one.

## Gates

typecheck, lint, bundler clean; **252 files / 4339 passed / 0 failed**.